### PR TITLE
0.2.0: Clean up npm, es6 exports.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.github/
+test/
+coverage/
+jest.config.jest

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "webzlp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Zebra LP-series WebUSB driver",
   "type": "module",
   "exports": {
-    ".": "./lib/*.js",
-    "./labelepl": "./lib/LabelEpl.js",
-    "./lp2844": "./lib/LP2844.js"
+    ".": "./src/*.js",
+    "./labelepl": "./src/LabelEpl.js",
+    "./lp2844": "./src/LP2844.js",
+    "./PrinterCommunicationMode": "./src/PrinterCommunicationMode.js",
+    "./LineBreakTransformer": "./src/LineBreakTransformer.js",
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"

--- a/src/LP2844.js
+++ b/src/LP2844.js
@@ -1,10 +1,6 @@
-import { LabelEpl } from "./LabelEpl";
-import { LineBreakTransformer } from "./LineBreakTransformer";
-import { PrinterCommunicationMode } from "./PrinterCommunicationMode";
-
-export { LabelEpl };
-export { PrinterCommunicationMode };
-export { LineBreakTransformer };
+import { LabelEpl } from "./LabelEpl.js";
+import { LineBreakTransformer } from "./LineBreakTransformer.js";
+import { PrinterCommunicationMode } from "./PrinterCommunicationMode.js";
 
 export class LP2844 {
     #inputStream;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,4 @@
+export { LabelEpl } from './LabelEpl.js';
+export { LineBreakTransformer } from './LineBreakTransformer.js';
+export { LP2844 } from './LP2844.js';
+export { PrinterCommunicationMode } from './PrinterCommunicationMode.js';


### PR DESCRIPTION
My understanding of ES6 exports from NPM was incomplete, this fixes those issues.

It also adds an npmignore file as shipping the entire contents of the repo seems silly.