### PR TITLE
Bring ZPL up to EPL parity

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -37,6 +37,7 @@
     <!-- Here's some actual demo code. Note that it is typescript, not javascript. -->
     <script type="text/typescript">
         import {
+            DarknessPercent,
             IDocument,
             ILabelDocumentBuilder,
             PrinterUsbManager,
@@ -414,7 +415,7 @@
                 form.modalCancel.setAttribute("disabled", "");
 
                 // Pull the values out of the form.
-                const darkness = parseInt(form.modalDarkness.value) as NumericRange<1, 100>;
+                const darkness = parseInt(form.modalDarkness.value) as DarknessPercent;
                 const rawSpeed = parseInt(form.modalSpeed.value) as PrintSpeed;
                 const labelWidthInches = parseFloat(form.modalLabelWidth.value);
                 const autosense = form.modalWithAutosense.checked;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webzlp",
-  "version": "1.0.0-rc1",
+  "version": "1.0.0-rc2",
   "description": "Zebra LP-series WebUSB driver",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/src/Documents/Commands.ts
+++ b/src/Documents/Commands.ts
@@ -1,4 +1,4 @@
-import { NumericRange } from '../NumericRange';
+import { DarknessPercent } from '../NumericRange';
 import {
     PrintSpeed,
     PrinterOptions,
@@ -267,13 +267,13 @@ export class SetDarknessCommand implements IPrinterCommand {
         return `Set darkness to ${this.darknessPercent}%`;
     }
 
-    constructor(darknessPercent: NumericRange<0, 100>, darknessMax: number) {
+    constructor(darknessPercent: DarknessPercent, darknessMax: number) {
         this.darknessPercent = darknessPercent;
         this.darknessMax = darknessMax;
         this.darknessSetting = Math.ceil((darknessPercent * darknessMax) / 100);
     }
 
-    darknessPercent: NumericRange<0, 100>;
+    darknessPercent: DarknessPercent;
     darknessMax: number;
     darknessSetting: number;
 

--- a/src/Documents/ConfigDocument.ts
+++ b/src/Documents/ConfigDocument.ts
@@ -1,4 +1,4 @@
-import { NumericRange } from '../NumericRange';
+import { DarknessPercent } from '../NumericRange';
 import * as Commands from './Commands';
 import { PrinterOptions, PrintSpeed } from '../Printers/Configuration/PrinterOptions';
 import { WebZlpError } from '../WebZlpError';
@@ -46,7 +46,7 @@ export class ConfigDocumentBuilder
 
     ///////////////////// ALTER PRINTER CONFIG
 
-    setDarknessConfig(darknessPercent: NumericRange<1, 100>) {
+    setDarknessConfig(darknessPercent: DarknessPercent) {
         return this.then(
             new Commands.SetDarknessCommand(darknessPercent, this._config.model.maxDarkness)
         );
@@ -124,7 +124,7 @@ export interface IPrinterConfigBuilder {
 
 export interface IPrinterLabelConfigBuilder {
     /** Set the darkness of the printer in the stored configuration. */
-    setDarknessConfig(darknessPercent: NumericRange<1, 100>): IConfigDocumentBuilder;
+    setDarknessConfig(darknessPercent: DarknessPercent): IConfigDocumentBuilder;
 
     /** Set the direction labels print out of the printer. */
     setPrintDirection(upsideDown?: boolean): IConfigDocumentBuilder;

--- a/src/NumericRange.ts
+++ b/src/NumericRange.ts
@@ -3,3 +3,5 @@ type Enumerate<N extends number, Acc extends number[] = []> = Acc['length'] exte
     : Enumerate<N, [...Acc, Acc['length']]>;
 
 export type NumericRange<F extends number, T extends number> = Exclude<Enumerate<T>, Enumerate<F>>;
+
+export type DarknessPercent = NumericRange<0, 100>;

--- a/src/Printers/Configuration/PrinterOptions.ts
+++ b/src/Printers/Configuration/PrinterOptions.ts
@@ -1,10 +1,10 @@
 import { IPrinterModelInfo, PrinterModel, PrinterModelDb } from '../Models/PrinterModel';
-import { NumericRange } from '../../NumericRange';
+import { DarknessPercent } from '../../NumericRange';
 
 /** Printer options related to the label media being printed */
 export interface IPrinterLabelMediaOptions {
     /** How dark to print. 0 is blank, 99 is max darkness */
-    darknessPercent: NumericRange<0, 100>;
+    darknessPercent: DarknessPercent;
     /** Mode the printer uses to detect separate labels when printing. */
     labelGapDetectMode: LabelMediaGapDetectionMode;
     /**
@@ -83,7 +83,7 @@ export class PrinterOptions implements IPrinterFactoryInformation, IPrinterLabel
 
     speed: PrintSpeedSettings;
 
-    darknessPercent: NumericRange<0, 100>;
+    darknessPercent: DarknessPercent;
     thermalPrintMode: ThermalPrintMode;
     mediaPrintMode: MediaPrintMode;
     printOrientation: PrintOrientation;
@@ -258,6 +258,7 @@ export class PrintSpeedSettings {
 
 /** Printer speed values in inches per second (IPS). */
 export enum PrintSpeed {
+    unknown = -1,
     /** Mobile printers can't be configured otherwise. */
     auto = 0,
     /** The lowest speed a given printer supports. */

--- a/src/Printers/Languages/EplPrinterCommandSet.ts
+++ b/src/Printers/Languages/EplPrinterCommandSet.ts
@@ -11,7 +11,7 @@ import { PrinterModel, PrinterModelDb } from '../Models/PrinterModel';
 import { DocumentValidationError, PrinterCommandSet } from './PrinterCommandSet';
 import * as Commands from '../../Documents/Commands';
 import { match, P } from 'ts-pattern';
-import { NumericRange } from '../../NumericRange';
+import { DarknessPercent } from '../../NumericRange';
 import { PrinterCommunicationOptions } from '../Communication/PrinterCommunication';
 
 /** Command set for communicating with an EPL II printer. */
@@ -279,7 +279,7 @@ export class EplPrinterCommandSet extends PrinterCommandSet {
         const options = new PrinterOptions(printerInfo.serial, expectedModel, printerInfo.firmware);
 
         const rawDarkness = Math.ceil(labelInfo.density * (100 / expectedModel.maxDarkness));
-        options.darknessPercent = Math.max(0, Math.min(rawDarkness, 99)) as NumericRange<0, 99>;
+        options.darknessPercent = Math.max(0, Math.min(rawDarkness, 99)) as DarknessPercent;
 
         options.speed = new PrintSpeedSettings(options.model.fromRawSpeed(printerInfo.speed));
 
@@ -333,16 +333,17 @@ export class EplPrinterCommandSet extends PrinterCommandSet {
             options.mediaPrintMode = MediaPrintMode.peelWithButtonTap;
         }
 
-        // TODO: morehardware options:
+        // TODO: more hardware options:
         // - Form feed button mode (Ff, Fr, Fi)
         // - Figure out what reverse gap sensor mode S means
         // - Figure out how to encode C{num} for cut-after-label-count
 
         // TODO other options:
         // Autosense settings?
-        // Print orientation?
         // Character set?
         // Error handling?
+        // Continuous media?
+        // Black mark printing?
 
         return options;
     }

--- a/src/Printers/Models/PrinterModel.ts
+++ b/src/Printers/Models/PrinterModel.ts
@@ -38,6 +38,7 @@ export class PrinterModelDb {
                 return PrinterModel.lp2844ups;
             })
             .with('LP2844-Z-200dpi', () => PrinterModel.lp2844z)
+            .with('LP2844-Z', () => PrinterModel.lp2824z)
             .otherwise(() => PrinterModel.unknown);
     }
 
@@ -51,6 +52,44 @@ export class PrinterModelDb {
             .otherwise(() => new UnknownPrinter());
         // TODO: Switch to this once I have a better way of handling switches..
         // .exhaustive();
+    }
+
+    /** Look up a speed enum from a given whole number */
+    public static getSpeedFromWholeNumber(speed: number): PrintSpeed {
+        switch (speed) {
+            case 0:
+                return PrintSpeed.auto;
+            case 1:
+                return PrintSpeed.ips1;
+            case 2:
+                return PrintSpeed.ips2;
+            case 3:
+                return PrintSpeed.ips3;
+            case 4:
+                return PrintSpeed.ips4;
+            case 5:
+                return PrintSpeed.ips5;
+            case 6:
+                return PrintSpeed.ips6;
+            case 7:
+                return PrintSpeed.ips7;
+            case 8:
+                return PrintSpeed.ips8;
+            case 9:
+                return PrintSpeed.ips9;
+            case 10:
+                return PrintSpeed.ips10;
+            case 11:
+                return PrintSpeed.ips11;
+            case 12:
+                return PrintSpeed.ips12;
+            case 13:
+                return PrintSpeed.ips13;
+            case 14:
+                return PrintSpeed.ips14;
+            default:
+                return PrintSpeed.unknown;
+        }
     }
 
     public static guessLanguageFromModelHint(modelHint?: string): PrinterCommandLanguage {
@@ -160,6 +199,45 @@ export abstract class BasicPrinterInfo implements IPrinterModelInfo {
             }
         }
         return PrintSpeed.auto;
+    }
+}
+
+/** A printer model object that was autodetected from the printer itself. */
+export class AutodetectedPrinter extends BasicPrinterInfo {
+    private _commandLanugage: PrinterCommandLanguage;
+    get commandLanguage(): PrinterCommandLanguage {
+        return this._commandLanugage;
+    }
+    private _dpi: number;
+    get dpi(): number {
+        return this._dpi;
+    }
+    private _model: PrinterModel;
+    get model(): PrinterModel {
+        return this._model;
+    }
+    private _speedTable: ReadonlyMap<PrintSpeed, number>;
+    get speedTable(): ReadonlyMap<PrintSpeed, number> {
+        return this._speedTable;
+    }
+    private _maxDarkness: number;
+    get maxDarkness(): number {
+        return this._maxDarkness;
+    }
+
+    constructor(
+        commandLanugage: PrinterCommandLanguage,
+        dpi: number,
+        model: PrinterModel,
+        speedTable: ReadonlyMap<PrintSpeed, number>,
+        maxDarkness: number
+    ) {
+        super();
+        this._commandLanugage = commandLanugage;
+        this._dpi = dpi;
+        this._model = model;
+        this._maxDarkness = maxDarkness;
+        this._speedTable = speedTable;
     }
 }
 

--- a/src/Printers/Printer.ts
+++ b/src/Printers/Printer.ts
@@ -5,7 +5,7 @@ import {
     LabelDocumentBuilder,
     LabelDocumentType
 } from '../Documents/LabelDocument';
-import { NumericRange } from '../NumericRange';
+import { DarknessPercent } from '../NumericRange';
 import { WebZlpError } from '../WebZlpError';
 import {
     IPrinterDeviceChannel,
@@ -139,6 +139,7 @@ export class Printer {
         }
 
         if (!this._printerConfig?.valid) {
+            this.dispose();
             throw new WebZlpError(
                 'Failed to detect the printer information, either the printer is unknown or the config can not be parsed. This printer can not be used.'
             );
@@ -361,7 +362,7 @@ export class ReadyToPrintDocuments {
     static configLabelSettings(
         printer: Printer,
         labelWidthInches: number,
-        darknessPercent: NumericRange<1, 100>
+        darknessPercent: DarknessPercent
     ) {
         return printer
             .getConfigDocument()


### PR DESCRIPTION
Right now EPL support is sufficient to print graphic images to labels, a feature the primary consumer of this repo needs. They have an EPL printer to work with and can test, however I have several ZPL printers that I would also like to be able to use.

This PR adds the missing functionality for ZPL to read configs, configure a printer, and print graphic data to ZPL printers.