### PR TITLE
Introduce percent instead of raw numeric range

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -37,6 +37,7 @@
     <!-- Here's some actual demo code. Note that it is typescript, not javascript. -->
     <script type="text/typescript">
         import {
+            DarknessPercent,
             IDocument,
             ILabelDocumentBuilder,
             PrinterUsbManager,
@@ -414,7 +415,7 @@
                 form.modalCancel.setAttribute("disabled", "");
 
                 // Pull the values out of the form.
-                const darkness = parseInt(form.modalDarkness.value) as NumericRange<1, 100>;
+                const darkness = parseInt(form.modalDarkness.value) as DarknessPercent;
                 const rawSpeed = parseInt(form.modalSpeed.value) as PrintSpeed;
                 const labelWidthInches = parseFloat(form.modalLabelWidth.value);
                 const autosense = form.modalWithAutosense.checked;

--- a/src/Documents/Commands.ts
+++ b/src/Documents/Commands.ts
@@ -1,8 +1,8 @@
-import { NumericRange } from '../NumericRange';
 import {
     PrintSpeed,
     PrinterOptions,
-    PrinterCommandLanguage
+    PrinterCommandLanguage,
+    DarknessPercent
 } from '../Printers/Configuration/PrinterOptions';
 
 /** A prepared document, ready to be compiled and sent. */
@@ -267,13 +267,13 @@ export class SetDarknessCommand implements IPrinterCommand {
         return `Set darkness to ${this.darknessPercent}%`;
     }
 
-    constructor(darknessPercent: NumericRange<0, 100>, darknessMax: number) {
+    constructor(darknessPercent: DarknessPercent, darknessMax: number) {
         this.darknessPercent = darknessPercent;
         this.darknessMax = darknessMax;
         this.darknessSetting = Math.ceil((darknessPercent * darknessMax) / 100);
     }
 
-    darknessPercent: NumericRange<0, 100>;
+    darknessPercent: DarknessPercent;
     darknessMax: number;
     darknessSetting: number;
 

--- a/src/Documents/ConfigDocument.ts
+++ b/src/Documents/ConfigDocument.ts
@@ -1,6 +1,9 @@
-import { NumericRange } from '../NumericRange';
 import * as Commands from './Commands';
-import { PrinterOptions, PrintSpeed } from '../Printers/Configuration/PrinterOptions';
+import {
+    DarknessPercent,
+    PrinterOptions,
+    PrintSpeed
+} from '../Printers/Configuration/PrinterOptions';
 import { WebZlpError } from '../WebZlpError';
 
 /** A series of printer commands that results in configuration changes. */
@@ -46,7 +49,7 @@ export class ConfigDocumentBuilder
 
     ///////////////////// ALTER PRINTER CONFIG
 
-    setDarknessConfig(darknessPercent: NumericRange<1, 100>) {
+    setDarknessConfig(darknessPercent: DarknessPercent) {
         return this.then(
             new Commands.SetDarknessCommand(darknessPercent, this._config.model.maxDarkness)
         );
@@ -124,7 +127,7 @@ export interface IPrinterConfigBuilder {
 
 export interface IPrinterLabelConfigBuilder {
     /** Set the darkness of the printer in the stored configuration. */
-    setDarknessConfig(darknessPercent: NumericRange<1, 100>): IConfigDocumentBuilder;
+    setDarknessConfig(darknessPercent: DarknessPercent): IConfigDocumentBuilder;
 
     /** Set the direction labels print out of the printer. */
     setPrintDirection(upsideDown?: boolean): IConfigDocumentBuilder;

--- a/src/NumericRange.ts
+++ b/src/NumericRange.ts
@@ -3,3 +3,5 @@ type Enumerate<N extends number, Acc extends number[] = []> = Acc['length'] exte
     : Enumerate<N, [...Acc, Acc['length']]>;
 
 export type NumericRange<F extends number, T extends number> = Exclude<Enumerate<T>, Enumerate<F>>;
+
+export type Percent = NumericRange<0, 101>;

--- a/src/Printers/Configuration/PrinterOptions.ts
+++ b/src/Printers/Configuration/PrinterOptions.ts
@@ -1,10 +1,12 @@
 import { IPrinterModelInfo, PrinterModel, PrinterModelDb } from '../Models/PrinterModel';
-import { NumericRange } from '../../NumericRange';
+import { Percent } from '../../NumericRange';
+
+export type DarknessPercent = Percent;
 
 /** Printer options related to the label media being printed */
 export interface IPrinterLabelMediaOptions {
     /** How dark to print. 0 is blank, 99 is max darkness */
-    darknessPercent: NumericRange<0, 100>;
+    darknessPercent: DarknessPercent;
     /** Mode the printer uses to detect separate labels when printing. */
     labelGapDetectMode: LabelMediaGapDetectionMode;
     /**
@@ -83,7 +85,7 @@ export class PrinterOptions implements IPrinterFactoryInformation, IPrinterLabel
 
     speed: PrintSpeedSettings;
 
-    darknessPercent: NumericRange<0, 100>;
+    darknessPercent: DarknessPercent;
     thermalPrintMode: ThermalPrintMode;
     mediaPrintMode: MediaPrintMode;
     printOrientation: PrintOrientation;

--- a/src/Printers/Languages/EplPrinterCommandSet.ts
+++ b/src/Printers/Languages/EplPrinterCommandSet.ts
@@ -1,5 +1,6 @@
 import { WebZlpError } from '../../WebZlpError';
 import {
+    DarknessPercent,
     MediaPrintMode,
     PrinterCommandLanguage,
     PrintOrientation,
@@ -11,7 +12,6 @@ import { PrinterModel, PrinterModelDb } from '../Models/PrinterModel';
 import { DocumentValidationError, PrinterCommandSet } from './PrinterCommandSet';
 import * as Commands from '../../Documents/Commands';
 import { match, P } from 'ts-pattern';
-import { NumericRange } from '../../NumericRange';
 import { PrinterCommunicationOptions } from '../Communication/PrinterCommunication';
 
 /** Command set for communicating with an EPL II printer. */
@@ -279,7 +279,7 @@ export class EplPrinterCommandSet extends PrinterCommandSet {
         const options = new PrinterOptions(printerInfo.serial, expectedModel, printerInfo.firmware);
 
         const rawDarkness = Math.ceil(labelInfo.density * (100 / expectedModel.maxDarkness));
-        options.darknessPercent = Math.max(0, Math.min(rawDarkness, 99)) as NumericRange<0, 99>;
+        options.darknessPercent = Math.max(0, Math.min(rawDarkness, 100)) as DarknessPercent;
 
         options.speed = new PrintSpeedSettings(options.model.fromRawSpeed(printerInfo.speed));
 

--- a/src/Printers/Printer.ts
+++ b/src/Printers/Printer.ts
@@ -5,7 +5,6 @@ import {
     LabelDocumentBuilder,
     LabelDocumentType
 } from '../Documents/LabelDocument';
-import { NumericRange } from '../NumericRange';
 import { WebZlpError } from '../WebZlpError';
 import {
     IPrinterDeviceChannel,
@@ -13,7 +12,12 @@ import {
     PrinterCommunicationOptions
 } from './Communication/PrinterCommunication';
 import { UsbPrinterDeviceChannel } from './Communication/UsbPrinterDeviceChannel';
-import { PrinterCommandLanguage, PrinterOptions, PrintSpeed } from './Configuration/PrinterOptions';
+import {
+    DarknessPercent,
+    PrinterCommandLanguage,
+    PrinterOptions,
+    PrintSpeed
+} from './Configuration/PrinterOptions';
 import { EplPrinterCommandSet } from './Languages/EplPrinterCommandSet';
 import { PrinterCommandSet } from './Languages/PrinterCommandSet';
 import { ZplPrinterCommandSet } from './Languages/ZplPrinterCommandSet';
@@ -361,7 +365,7 @@ export class ReadyToPrintDocuments {
     static configLabelSettings(
         printer: Printer,
         labelWidthInches: number,
-        darknessPercent: NumericRange<1, 100>
+        darknessPercent: DarknessPercent
     ) {
         return printer
             .getConfigDocument()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 export * from './PrinterUsbManager';
 export * from './Color';
-export * from './NumericRange';
 export * from './WebZlpError';
 export * from './Printers/Printer';
 export * from './Printers/Communication/LineBreakTransformer';


### PR DESCRIPTION
I was already typo'ing the values in the NumericRange I was using for percents, so this avoids that issue by introducing explicit types for 0-100 for percent values.