### PR TITLE
Ensure offsets are whole dots

### DIFF
--- a/src/Documents/Commands.ts
+++ b/src/Documents/Commands.ts
@@ -252,8 +252,8 @@ export class Offset implements IPrinterCommand {
     }
 
     constructor(horizontal: number, vertical?: number, absolute = false) {
-        this.horizontal = horizontal;
-        this.vertical = vertical;
+        this.horizontal = Math.floor(horizontal);
+        this.vertical = Math.floor(vertical);
         this.absolute = absolute;
     }
 


### PR DESCRIPTION
Wondered why my test prints were missing elements. The printer will drop offset commands that don't have a whole number haha