### PR TITLE
Explicit class for transpile metadata tracking

### DIFF
--- a/src/Documents/Document.ts
+++ b/src/Documents/Document.ts
@@ -22,62 +22,24 @@ export class Document implements IDocument {
 
     /** Display the commands that will be performed in a human-readable format. */
     public showCommands(): string {
-        let result = '';
-        this._commands.forEach((c) => (result += `${c.toDisplay()}\n`));
-        return result;
+        return this._commands.map((c) => c.toDisplay()).join('\n');
     }
 }
 
 /** A document of raw commands, ready to be sent to a printer. */
 export class CompiledDocument {
-    private rawCmdBuffer: Array<Uint8Array> = [];
-    private _commandLanugage: Options.PrinterCommandLanguage;
-    get commandLanguage() {
-        return this._commandLanugage;
-    }
-
-    horizontalOffset = 0;
-    verticalOffset = 0;
-    lineSpacingDots = 5;
-
-    commandEffectFlags = Commands.PrinterCommandEffectFlags.none;
-
-    constructor(commandLang: Options.PrinterCommandLanguage) {
-        this._commandLanugage = commandLang;
-    }
-
-    /**
-     * Gets a single buffer of the internal command set.
-     */
-    get commandBufferRaw(): Uint8Array {
-        const bufferLen = this.rawCmdBuffer.reduce((sum, arr) => sum + arr.byteLength, 0);
-        const buffer = new Uint8Array(bufferLen);
-        this.rawCmdBuffer.reduce((offset, arr) => {
-            buffer.set(arr, offset);
-            return arr.byteLength + offset;
-        }, 0);
-
-        return buffer;
-    }
+    constructor(
+        public commandLanguage: Options.PrinterCommandLanguage,
+        public effectFlags: Commands.PrinterCommandEffectFlags,
+        public commandBuffer: Uint8Array
+    ) {}
 
     /**
      * Gets the text view of the command buffer. Do not send this to the printer, the encoding
      * will break and commands will fail.
      */
     get commandBufferString(): string {
-        return new TextDecoder('ascii').decode(this.commandBufferRaw);
-    }
-
-    /** Add a raw command to the internal buffer. */
-    addRawCmd(array: Uint8Array): CompiledDocument {
-        this.rawCmdBuffer.push(array);
-        return this;
-    }
-
-    /** Clear the internal buffer. */
-    clearCommandBuffer(): CompiledDocument {
-        this.rawCmdBuffer = [];
-        return this;
+        return new TextDecoder('ascii').decode(this.commandBuffer);
     }
 }
 
@@ -119,9 +81,7 @@ export abstract class DocumentBuilder implements IDocumentBuilder {
     }
 
     showCommands(): string {
-        let result = '';
-        this._commands.forEach((c) => (result += `${c.name} - ${c.toDisplay()}\n`));
-        return result;
+        return this._commands.map((c) => c.toDisplay()).join('\n');
     }
 
     finalize(): IDocument {

--- a/src/Printers/Languages/EplPrinterCommandSet.ts
+++ b/src/Printers/Languages/EplPrinterCommandSet.ts
@@ -1,10 +1,13 @@
 import { WebZlpError } from '../../WebZlpError';
 import * as Options from '../Configuration/PrinterOptions';
-import { CompiledDocument } from '../../Documents/Document';
 import { PrinterOptions } from '../Configuration/PrinterOptions';
 import { PrinterModelDb } from '../Models/PrinterModelDb';
 import { PrinterModel } from '../Models/PrinterModel';
-import { DocumentValidationError, PrinterCommandSet } from './PrinterCommandSet';
+import {
+    DocumentValidationError,
+    PrinterCommandSet,
+    TranspilationDocumentMetadata
+} from './PrinterCommandSet';
 import * as Commands from '../../Documents/Commands';
 import { match, P } from 'ts-pattern';
 import { PrinterCommunicationOptions } from '../Communication/PrinterCommunication';
@@ -34,7 +37,10 @@ export class EplPrinterCommandSet extends PrinterCommandSet {
         return this.encoder.encode(str + (withNewline ? '\r\n' : ''));
     }
 
-    transpileCommand(cmd: Commands.IPrinterCommand, outDoc: CompiledDocument): Uint8Array {
+    transpileCommand(
+        cmd: Commands.IPrinterCommand,
+        outDoc: TranspilationDocumentMetadata
+    ): Uint8Array {
         return match<Commands.IPrinterCommand, Uint8Array>(cmd)
             .with(P.instanceOf(Commands.NewLabelCommand), () => this.startNewDocument())
             .with(P.instanceOf(Commands.Offset), (cmd) => this.modifyOffset(cmd, outDoc))
@@ -349,7 +355,7 @@ export class EplPrinterCommandSet extends PrinterCommandSet {
         return options;
     }
 
-    private imageBufferToCmd(imageData: ImageData, outDoc: CompiledDocument) {
+    private imageBufferToCmd(imageData: ImageData, outDoc: TranspilationDocumentMetadata) {
         if (imageData == null) {
             return this.noop;
         }
@@ -453,7 +459,7 @@ export class EplPrinterCommandSet extends PrinterCommandSet {
         height: number,
         length: number,
         color: Commands.DrawColor,
-        outDoc: CompiledDocument
+        outDoc: TranspilationDocumentMetadata
     ) {
         length = Math.trunc(length) || 0;
         height = Math.trunc(height) || 0;
@@ -472,7 +478,12 @@ export class EplPrinterCommandSet extends PrinterCommandSet {
         );
     }
 
-    private boxToCmd(height: number, length: number, thickness: number, outDoc: CompiledDocument) {
+    private boxToCmd(
+        height: number,
+        length: number,
+        thickness: number,
+        outDoc: TranspilationDocumentMetadata
+    ) {
         length = Math.trunc(length) || 0;
         height = Math.trunc(height) || 0;
         thickness = Math.trunc(thickness) || 0;

--- a/src/Printers/Languages/ZplPrinterCommandSet.ts
+++ b/src/Printers/Languages/ZplPrinterCommandSet.ts
@@ -1,8 +1,11 @@
 import { PrinterCommandLanguage, PrinterOptions } from '../Configuration/PrinterOptions';
-import { PrinterCommandSet, DocumentValidationError } from './PrinterCommandSet';
+import {
+    PrinterCommandSet,
+    DocumentValidationError,
+    TranspilationDocumentMetadata
+} from './PrinterCommandSet';
 import * as Commands from '../../Documents/Commands';
 import { match, P } from 'ts-pattern';
-import { CompiledDocument } from '../../Documents/Document';
 
 export class ZplPrinterCommandSet extends PrinterCommandSet {
     private encoder = new TextEncoder();
@@ -27,7 +30,10 @@ export class ZplPrinterCommandSet extends PrinterCommandSet {
         return this.encoder.encode(str + '\n');
     }
 
-    transpileCommand(cmd: Commands.IPrinterCommand, outDoc: CompiledDocument): Uint8Array {
+    transpileCommand(
+        cmd: Commands.IPrinterCommand,
+        outDoc: TranspilationDocumentMetadata
+    ): Uint8Array {
         return match<Commands.IPrinterCommand, Uint8Array>(cmd)
             .with(P.instanceOf(Commands.NewLabelCommand), () => this.startNewDocument())
             .with(P.instanceOf(Commands.Offset), (cmd) => this.modifyOffset(cmd, outDoc))

--- a/src/Printers/Printer.ts
+++ b/src/Printers/Printer.ts
@@ -121,7 +121,7 @@ export class Printer {
             console.debug(compiled.commandBufferString);
         }
 
-        await this.printerChannel.sendCommands(compiled.commandBufferRaw);
+        await this.printerChannel.sendCommands(compiled.commandBuffer);
     }
 
     /** Close the connection to this printer, preventing future communication from working. */
@@ -204,7 +204,7 @@ export class Printer {
             const listenEpl = this.listenForData();
 
             // Config isn't set up yet, send command directly without the send command.
-            await this.printerChannel.sendCommands(compiled.commandBufferRaw);
+            await this.printerChannel.sendCommands(compiled.commandBuffer);
             const rawResult = await listenEpl;
             config = cmdSet.parseConfigurationResponse(
                 rawResult,

--- a/test/Printers/Languages/EplPrinterCommandSet.test.ts
+++ b/test/Printers/Languages/EplPrinterCommandSet.test.ts
@@ -1,5 +1,4 @@
-import { EplPrinterCommandSet, PrinterCommandLanguage } from '../../../src';
-import { CompiledDocument } from '../../../src/Documents/Document';
+import { EplPrinterCommandSet, TranspilationDocumentMetadata } from '../../../src';
 
 // Class pulled from jest-mock-canvas which I can't seem to actually import.
 class ImageData {
@@ -189,7 +188,7 @@ describe('EplImageConversion', () => {
 describe('EplImageConversionToFullCommand', () => {
   it('Should convert blank images to valid command', () => {
     const imageData = new ImageData(getImageDataInput(8, 1, 0), 8, 1);
-    const doc = new CompiledDocument(PrinterCommandLanguage.epl);
+    const doc = new TranspilationDocumentMetadata();
     const resultCmd = cmdSet['imageBufferToCmd'](imageData, doc);
 
     const expectedCmd = Uint8Array.from([
@@ -204,7 +203,7 @@ describe('EplImageConversionToFullCommand', () => {
   it('Should apply offsets in command', () => {
     const imageData = new ImageData(getImageDataInput(8, 1, 0), 8, 1);
     const appliedOffset = 10;
-    const doc = new CompiledDocument(PrinterCommandLanguage.epl);
+    const doc = new TranspilationDocumentMetadata();
     doc.horizontalOffset = appliedOffset;
     doc.verticalOffset = appliedOffset * 2;
     const resultCmd = cmdSet['imageBufferToCmd'](imageData, doc);
@@ -219,7 +218,7 @@ describe('EplImageConversionToFullCommand', () => {
   });
 
   it('Should return noop for blank imageData', () => {
-    const doc = new CompiledDocument(PrinterCommandLanguage.epl);
+    const doc = new TranspilationDocumentMetadata();
     const resultCmd = cmdSet['imageBufferToCmd'](null, doc);
 
     expect(resultCmd).toEqual(new Uint8Array());


### PR DESCRIPTION
When starting to explore CPCL support it became more clear that the library is going to need to understand the actual boundaries of individual documents within a full document. The boundary of a document is more meaningful to CPCL as there's additional state details that can be modified on a per-document basis than ZPL. 

To facilitate this and other analysis this PR adds explicit tracking of individual document elements within the transpile operation. This also makes the compiled document class much simpler.

Added a few other cleanup notes from @kobaj and @nican, thanks!