### PR TITLE
Bring ZPL to parity with EPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ To facilitate local dev you can spin up a local static webserver that will end u
 Much of the technical documenation and information comes from Zebra Technologies Corporation's public documentation and an amount of trial-and-error from working with an array of LP2844 printers with assembly dates between 2000 and 2008.
 
 Zebra have graciously made this information public through reference documentation available on their website. When in doubt please seek their information! The company makes robust printers that continue to be well supported. The latest available printers they manufacture are compatible with EPL command sets dating back to the 90s. I can't recommend them highly enough for any integrator concerned with making sure their systems continue to work into the future.
+
+## Additional Credits
+
+* [Binaryfox](https://github.com/binaryf0x) for significant help with WebUSB.
+* Metafloor for the very handy [zpl-image](https://github.com/metafloor/zpl-image) library.

--- a/demo/index.html
+++ b/demo/index.html
@@ -424,6 +424,7 @@
                 const configDoc = printer
                     .getConfigDocument()
                     .setPrintDirection()
+                    .setLabelHomeOffsetDots(0, 0)
                     .setPrintSpeed(rawSpeed)
                     .setDarknessConfig(darkness)
                     .setLabelDimensions(labelWidthInches);

--- a/demo/index.html
+++ b/demo/index.html
@@ -393,7 +393,7 @@
                 // and sending that canvas directly to a label. This allows your webpage to generate complex
                 // images and fonts (like emoji!) that EPL/ZPL can't support.
                 return builder
-                    .addImage(imgData)
+                    .addImageFromImageData(imgData)
                     .addPrintCmd()
                     .finalize();
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webzlp",
-  "version": "1.0.0-rc2",
+  "version": "1.0.0-rc3",
   "description": "Zebra LP-series WebUSB driver",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webzlp",
-  "version": "1.0.0-rc1",
+  "version": "1.0.0-rc2",
   "description": "Zebra LP-series WebUSB driver",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/src/Documents/BitmapGRF.ts
+++ b/src/Documents/BitmapGRF.ts
@@ -1,0 +1,345 @@
+import { Percent } from '../NumericRange';
+import { WebZlpError } from '../WebZlpError';
+
+/** Padding information for a trimmed image. */
+export interface ImageBoundingBox {
+    /** The total original width of the image, including padding. */
+    width: number;
+    /** The total original height of the image, including padding. */
+    height: number;
+
+    /** The number of pixels between the top of the box and the actual image. */
+    paddingTop: number;
+    /** The number of pixels between the right side of the box and the actual image. */
+    paddingRight: number;
+    /** The number of pixels between the bottom of the box and the actual image. */
+    paddingBottom: number;
+    /** The number of pixels between the left side of the box and the actual image. */
+    paddingLeft: number;
+}
+
+/** Settings for converting an image to a GRF. */
+export interface ImageConversionOptions {
+    /** The threshold brightness below which to consider a pixel black. Defaults to 75. */
+    grayThreshold?: Percent;
+    /** Whether to trim whitespace around the image to reduce file size. Trimmed pixels will become padding in the bounding box. */
+    trimWhitespace?: boolean;
+}
+
+/** Represents a GRF bitmap file. */
+export class BitmapGRF {
+    private _bitmap: Uint8Array;
+
+    private _width: number;
+    /** Gets the actual width of the image file, not including any padding. */
+    public get width() {
+        return this._width;
+    }
+
+    private _height: number;
+    /** Gets the actual height of the image file, not inlcuding any padding. */
+    public get height() {
+        return this._height;
+    }
+
+    private _bytesPerRow: number;
+    /** Gets the number of bytes per row (width) of the image file. */
+    public get bytesPerRow() {
+        return this._bytesPerRow;
+    }
+    /** Gets the total number of uncompressed bytes of the image file. Usually used in printer commands. */
+    public get bytesUncompressed() {
+        return this._bitmap.length;
+    }
+
+    private _boundingBox: ImageBoundingBox;
+    /** Gets the bounding box information for this image, for proper alignment of trimmed images. */
+    public get boundingBox() {
+        return this._boundingBox;
+    }
+
+    constructor(
+        bitmapGRF: Uint8Array,
+        imageWidth: number,
+        imageHeight: number,
+        bytesPerRow: number,
+        boundingBox: ImageBoundingBox
+    ) {
+        this._bitmap = bitmapGRF;
+        this._width = imageWidth;
+        this._height = imageHeight;
+        this._bytesPerRow = bytesPerRow;
+        this._boundingBox = Object.freeze(boundingBox);
+    }
+
+    /** Get a raw binary representation of this GRF. This is raw binary with no compression, compatible with EPL and ZPL.
+     *
+     * The image may need to be offset according to the bounding box padding. Use the bytesPerRow for data length calculations.
+     *
+     * Example use:
+     * ```
+     * const grf = new BitmapGRF();
+     * const zplCmd = `^GFC,${grf.bytesUncompressed},${grf.bytesUncompressed},${grf.bytesPerRow},${grf.toBinaryGRF()}`;
+     *
+     * const eplCmd = `GW${grf.boundingBox.paddingLeft},${grf.boundingBox.paddingTop},${grf.bytesPerRow},${grf.height},${grf.toBitmapGRF}`;
+     * ```
+     */
+    public toBinaryGRF(): Uint8Array {
+        // Previous conversions have gotten the data into the right format. Send as-is.
+        return this._bitmap;
+    }
+
+    /** Get a compressed representation of this GRF. This is not compatible with EPL.
+     * This is also referred to as the "Alternate Compression Scheme" or "Zebra Compression".
+     *
+     * The image may need to be offset according to the bounding box.
+     *
+     * Example use:
+     * ```
+     * const grf = new BitmapGRF();
+     * const cmd = `^GFA,${grf.bytesUncompressed},${grf.bytesUncompressed},${grf.bytesPerRow},${grf.toZebraCompressedGrf()}`;
+     * ```
+     */
+    public toZebraCompressedGRF(): string {
+        // Method (c) 2022 metafloor
+        // https://github.com/metafloor/zpl-image/blob/491f4d6887294d71dcfa859957d43b3be28ce1e5/zpl-image.js
+
+        // The Zebra ACS compression scheme is a form of run-length encoding. Sequential runs of values
+        // are replaced with a marker for the length of the run.
+        // ZACS / ACS uses this encoding table:
+        //
+        // G   H   I   J   K   L   M   N   O   P   Q   R   S   T   U   V   W   X   Y
+        // 1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19
+        //
+        // g   h   i   j   k   l   m   n   o   p   q   r   s   t   u   v   w   x   y   z
+        // 20  40  60  80 100 120 140 160 180 200 220 240 260 280 300 320 340 360 380 400
+        //
+        const buf = this._bitmap;
+
+        let hex = '';
+        for (let i = 0, l = buf.length; i < l; i++) {
+            hex += BitmapGRF.hexmap[buf[i]];
+        }
+        const re = /([0-9a-fA-F])\1{2,}/g;
+        let acs = '';
+        let match = re.exec(hex);
+        let offset = 0;
+        while (match) {
+            acs += hex.substring(offset, match.index);
+            let l = match[0].length;
+            while (l >= 400) {
+                acs += 'z';
+                l -= 400;
+            }
+            if (l >= 20) {
+                acs += '_ghijklmnopqrstuvwxy'[(l / 20) | 0];
+                l = l % 20;
+            }
+            if (l) {
+                acs += '_GHIJKLMNOPQRSTUVWXY'[l];
+            }
+            acs += match[1];
+            offset = re.lastIndex;
+            match = re.exec(hex);
+        }
+        acs += hex.substr(offset);
+        return acs;
+    }
+
+    // TODO: ASCII-compressed formats are only supported on newer firmwares.
+    // Implement feature detection into the transpiler operation to choose the most
+    // appropriate compression format such as LZ77/DEFLATE compression for Z64.
+    // public toAsciiB64(): string { }
+    // public toAsciiZ64(): string { }
+
+    /**
+     * Create a GRF bitmap from a raw RGBA array-like object.
+     */
+    public static fromRGBA(
+        data: Uint8Array | Uint8ClampedArray | Buffer | Array<number>,
+        width: number,
+        { grayThreshold = 75, trimWhitespace = true }: ImageConversionOptions = {}
+    ): BitmapGRF {
+        width = width | 0;
+        if (!width || width < 0) {
+            throw new BitmapFormatError('Image width must be provided for RGBA data.');
+        }
+        if (data.length % 4 !== 0) {
+            throw new BitmapFormatError(`Array data is not a multiple of 4, is it RGBA data?`);
+        }
+
+        const height = ~~(data.length / width / 4);
+
+        const { monochromeData, imageWidth, imageHeight, boundingBox } = this.toMonochrome(
+            data,
+            width,
+            height,
+            { grayThreshold, trimWhitespace }
+        );
+
+        const { grfData, bytesPerRow } = this.toGRF(monochromeData, imageWidth, imageHeight);
+
+        return new BitmapGRF(grfData, imageWidth, imageHeight, bytesPerRow, boundingBox);
+    }
+
+    /**
+     * Create a GRF bitmap from a canvas ImageData object.
+     * @param imageData The canvas ImageData object to convert.
+     * @param grayThreshold The cutoff percentage below which values are considered black. Defaults to 75% of white.
+     * @param trimWhitespace Trim image to save space, storing trim amounts in the bounding box.
+     * @returns The bitmap GRF file.
+     */
+    public static fromCanvasImageData(
+        imageData: ImageData,
+        { grayThreshold = 75, trimWhitespace = true }: ImageConversionOptions = {}
+    ): BitmapGRF {
+        // This property isn't supported in Firefox, so it isn't supported
+        // in the lib types, and I don't feel like dealing with it right now
+        // so TODO: fix this eventually
+        //
+        // Only supports sRGB as RGBA data.
+        // if (imageData.colorSpace !== 'srgb') {
+        //     throw new DocumentValidationError(
+        //         'Unknown color space for given imageData. Expected srgb but got ' +
+        //             imageData.colorSpace
+        //     );
+        // }
+        //
+        // Proceed on assuming it's an RGBA bitmap of sRGB data.
+        return this.fromRGBA(imageData.data, imageData.width, { grayThreshold, trimWhitespace });
+    }
+
+    /** Converts monochrome data to GRF format. */
+    private static toGRF(monochromeData: Uint8Array, width: number, height: number) {
+        // Method (c) 2022 metafloor
+        // https://github.com/metafloor/zpl-image/blob/491f4d6887294d71dcfa859957d43b3be28ce1e5/zpl-image.js
+
+        const bytesPerRow = ~~((width + 7) / 8);
+        const paddingToAdd = (8 - (width % 8)) % 8;
+        const buffer = new Uint8Array(bytesPerRow * height);
+        let idx = 0; // index into buf
+        let byte = 0; // current byte of image data, default to white.
+        let bitx = 0; // bit index
+        for (let i = 0, n = monochromeData.length; i < n; i++) {
+            byte |= monochromeData[i] << (7 - (bitx++ & 7));
+
+            if (bitx == width || !(bitx & 7)) {
+                if (bitx == width) {
+                    bitx = 0;
+                    byte |= (1 << paddingToAdd) - 1;
+                }
+                buffer[idx++] = byte;
+                byte = 0;
+            }
+        }
+
+        return { grfData: buffer, bytesPerRow };
+    }
+
+    /**
+     * Converts an RGBA array to monochrome, 1-bit-per-byte.
+     * This supports trimming the image to save space, and will remove whitespace
+     * to an internal bounding box. The results of this padding are stored as the
+     * bounding box information for the bitmap.
+     */
+    private static toMonochrome(
+        rgba: Uint8Array | Uint8ClampedArray | Buffer | Array<number>,
+        width: number,
+        height: number,
+        { grayThreshold = 75, trimWhitespace = true }: ImageConversionOptions
+    ) {
+        // Method (c) 2022 metafloor
+        // https://github.com/metafloor/zpl-image/blob/491f4d6887294d71dcfa859957d43b3be28ce1e5/zpl-image.js
+
+        // Convert black from percent to 0..255 value
+        const threshold = (255 * grayThreshold) / 100;
+
+        let minx: number, maxx: number, miny: number, maxy: number;
+        if (!trimWhitespace) {
+            minx = miny = 0;
+            maxx = width - 1;
+            maxy = height - 1;
+        } else {
+            // Run through the image and determine bounding box
+            maxx = maxy = 0;
+            minx = width;
+            miny = height;
+            let x = 0,
+                y = 0;
+            for (let i = 0, n = width * height * 4; i < n; i += 4) {
+                // Alpha blend with white.
+                const a = rgba[i + 3] / 255;
+                const r = rgba[i] * 0.3 * a + 255 * (1 - a);
+                const g = rgba[i + 1] * 0.59 * a + 255 * (1 - a);
+                const b = rgba[i + 2] * 0.11 * a + 255 * (1 - a);
+                const gray = r + g + b;
+
+                if (gray <= threshold) {
+                    if (minx > x) minx = x;
+                    if (miny > y) miny = y;
+                    if (maxx < x) maxx = x;
+                    if (maxy < y) maxy = y;
+                }
+                if (++x == width) {
+                    x = 0;
+                    y++;
+                }
+            }
+        }
+
+        // One more time through the data, this time we create the cropped image.
+        const cx = maxx - minx + 1;
+        const cy = maxy - miny + 1;
+        const buffer = new Uint8Array(cx * cy);
+        let idx = 0;
+        for (let y = miny; y <= maxy; y++) {
+            let i = (y * width + minx) * 4;
+            for (let x = minx; x <= maxx; x++) {
+                // Alpha blend with white.
+                const a = rgba[i + 3] / 255.0;
+                const r = rgba[i] * 0.3 * a + 255.0 * (1 - a);
+                const g = rgba[i + 1] * 0.59 * a + 255.0 * (1 - a);
+                const b = rgba[i + 2] * 0.11 * a + 255.0 * (1 - a);
+                const gray = r + g + b;
+
+                buffer[idx++] = gray <= threshold ? 0 : 1;
+                i += 4;
+            }
+        }
+
+        return {
+            monochromeData: buffer,
+            imageWidth: cx,
+            imageHeight: cy,
+            boundingBox: {
+                width: width,
+                height: height,
+                paddingLeft: minx,
+                paddingTop: miny,
+                // TODO: Are these correct offesets or does it need + 1?
+                paddingRight: width - maxx,
+                paddingBottom: height - maxy
+            }
+        };
+    }
+
+    /** Lookup table for binary to hex values. */
+    private static hexmap = (() => {
+        const arr = Array(256);
+        for (let i = 0; i < 16; i++) {
+            arr[i] = '0' + i.toString(16);
+        }
+        for (let i = 16; i < 256; i++) {
+            arr[i] = i.toString(16);
+        }
+        return arr;
+    })();
+}
+
+/** Error indicating an issue with the provided image. */
+export class BitmapFormatError extends WebZlpError {
+    constructor(message: string) {
+        super(message);
+        this.name = this.constructor.name;
+    }
+}

--- a/src/Documents/BitmapGRF.ts
+++ b/src/Documents/BitmapGRF.ts
@@ -89,6 +89,24 @@ export class BitmapGRF {
         return this._bitmap;
     }
 
+    /** Gets a bitmap GRF that has its colors inverted.
+     *
+     * EPL uses 1 as white. ZPL uses 1 as black. Use this to convert between them.
+     */
+    public toInvertedGRF(): BitmapGRF {
+        const buffer = new Uint8Array(this._bitmap.length);
+        for (let i = 0, n = this._bitmap.length; i < n; i++) {
+            buffer[i] = ~this._bitmap[i];
+        }
+
+        return new BitmapGRF(
+            buffer,
+            this.width,
+            this.height,
+            this.bytesPerRow,
+            structuredClone(this.boundingBox));
+    }
+
     /** Get a compressed representation of this GRF. This is not compatible with EPL.
      * This is also referred to as the "Alternate Compression Scheme" or "Zebra Compression".
      *
@@ -105,8 +123,9 @@ export class BitmapGRF {
         // https://github.com/metafloor/zpl-image/blob/491f4d6887294d71dcfa859957d43b3be28ce1e5/zpl-image.js
 
         // The Zebra ACS compression scheme is a form of run-length encoding. Sequential runs of values
-        // are replaced with a marker for the length of the run.
-        // ZACS / ACS uses this encoding table:
+        // are replaced with a marker for the length of the run. This is referred to in the documentation
+        // alternatively as "Zebra Compression" and "Alternative Compression Scheme".
+        // ZACS uses this encoding table:
         //
         // G   H   I   J   K   L   M   N   O   P   Q   R   S   T   U   V   W   X   Y
         // 1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19
@@ -177,7 +196,7 @@ export class BitmapGRF {
             { grayThreshold, trimWhitespace }
         );
 
-        const { grfData, bytesPerRow } = this.toGRF(monochromeData, imageWidth, imageHeight);
+        const { grfData, bytesPerRow } = this.monochromeToGRF(monochromeData, imageWidth, imageHeight);
 
         return new BitmapGRF(grfData, imageWidth, imageHeight, bytesPerRow, boundingBox);
     }
@@ -210,7 +229,7 @@ export class BitmapGRF {
     }
 
     /** Converts monochrome data to GRF format. */
-    private static toGRF(monochromeData: Uint8Array, width: number, height: number) {
+    private static monochromeToGRF(monochromeData: Uint8Array, width: number, height: number) {
         // Method (c) 2022 metafloor
         // https://github.com/metafloor/zpl-image/blob/491f4d6887294d71dcfa859957d43b3be28ce1e5/zpl-image.js
 

--- a/src/Documents/Commands.ts
+++ b/src/Documents/Commands.ts
@@ -1,4 +1,5 @@
 import * as Options from '../Printers/Configuration/PrinterOptions';
+import { BitmapGRF } from './BitmapGRF';
 
 /** Flags to indicate special operations a command might cause. */
 export enum PrinterCommandEffectFlags {
@@ -278,19 +279,13 @@ export class AddImageCommand implements IPrinterCommand {
         return 'Add image to label';
     }
     toDisplay(): string {
-        if (!this.imageData) {
-            return 'Adds a null image';
+        if (!this.bitmap) {
+            return 'Adds a blank image';
         }
-        return this.name;
+        return `Adds a {}`;
     }
 
-    constructor(imageData: ImageData, dithering: DitheringMethod) {
-        this.imageData = imageData;
-        this.dithering = dithering;
-    }
-
-    imageData: ImageData;
-    dithering: DitheringMethod;
+    constructor(public bitmap: BitmapGRF, public dithering: DitheringMethod) {}
 }
 
 /** Command class to draw a straight line. */

--- a/src/Documents/LabelDocument.ts
+++ b/src/Documents/LabelDocument.ts
@@ -18,6 +18,10 @@ export class LabelDocumentBuilder
     // Maybe different types??
     private _docType: LabelDocumentType = LabelDocumentType.instanceForm;
 
+    get commandReorderBehavior(): Commands.CommandReorderBehavior {
+        return Commands.CommandReorderBehavior.none;
+    }
+
     constructor(
         config: Options.PrinterOptions,
         docType: LabelDocumentType = LabelDocumentType.instanceForm
@@ -55,15 +59,15 @@ export class LabelDocumentBuilder
     ///////////////////// OFFSET AND SPACING
 
     setOffset(horizontal: number, vertical?: number): ILabelDocumentBuilder {
-        return this.then(new Commands.Offset(horizontal, vertical, true));
+        return this.then(new Commands.OffsetCommand(horizontal, vertical, true));
     }
 
     addOffset(horizontal: number, vertical?: number): ILabelDocumentBuilder {
-        return this.then(new Commands.Offset(horizontal, vertical));
+        return this.then(new Commands.OffsetCommand(horizontal, vertical));
     }
 
     resetOffset(): ILabelDocumentBuilder {
-        return this.then(new Commands.Offset(0, 0, true));
+        return this.then(new Commands.OffsetCommand(0, 0, true));
     }
 
     ///////////////////// LABEL IMAGE CONTENTS

--- a/src/Documents/LabelDocument.ts
+++ b/src/Documents/LabelDocument.ts
@@ -1,6 +1,7 @@
 import * as Commands from './Commands';
 import { DocumentBuilder } from './Document';
 import * as Options from '../Printers/Configuration/PrinterOptions';
+import { BitmapGRF } from './BitmapGRF';
 
 export interface ILabelDocumentBuilder
     extends DocumentBuilder<ILabelDocumentBuilder>,
@@ -67,11 +68,13 @@ export class LabelDocumentBuilder
 
     ///////////////////// LABEL IMAGE CONTENTS
 
-    addImage(
+    addImageFromImageData(
         imageData: ImageData,
         dithering = Commands.DitheringMethod.none
     ): ILabelDocumentBuilder {
-        return this.then(new Commands.AddImageCommand(imageData, dithering));
+        return this.then(
+            new Commands.AddImageCommand(BitmapGRF.fromCanvasImageData(imageData), dithering)
+        );
     }
 
     addLine(lengthInDots: number, heightInDots: number, color = Commands.DrawColor.black) {
@@ -130,7 +133,10 @@ export interface ILabelPositionCommandBuilder {
 
 export interface ILabelContentCommandBuilder {
     /** Add an ImageData object as an image to the label */
-    addImage(imageData: ImageData, dithering?: Commands.DitheringMethod): ILabelDocumentBuilder;
+    addImageFromImageData(
+        imageData: ImageData,
+        dithering?: Commands.DitheringMethod
+    ): ILabelDocumentBuilder;
 
     /** Draw a line from the current offset for the length and height. */
     addLine(

--- a/src/PrinterUsbManager.ts
+++ b/src/PrinterUsbManager.ts
@@ -1,5 +1,5 @@
 import { Printer } from './Printers/Printer';
-import { PrinterCommunicationOptions } from './Printers/Communication/PrinterCommunication';
+import { PrinterCommunicationOptions } from './Printers/PrinterCommunicationOptions';
 
 export interface PrinterManagerEventMap {
     connectedPrinter: CustomEvent<{ detail: Printer }>;

--- a/src/Printers/Communication/PrinterCommunication.ts
+++ b/src/Printers/Communication/PrinterCommunication.ts
@@ -1,5 +1,4 @@
 import { WebZlpError } from '../../WebZlpError';
-
 /** A communication channel for talking to a printer device. */
 export interface IPrinterDeviceChannel {
     /** Whether to print communications to the console. */
@@ -56,25 +55,4 @@ export enum PrinterCommMode {
     none,
     unidirectional,
     bidirectional
-}
-
-export class PrinterCommunicationOptions {
-    /**
-     * Value to use for rounding read-from-config label sizes.
-     *
-     * When reading the config from a printer the label width and height may be
-     * variable. When you set the label width to 4 inches it's translated into
-     * dots, and then the printer adds a calculated offset to that. This offset
-     * is unique per printer (so far as I have observed) and introduces noise.
-     * This value rounds the returned value to the nearest fraction of an inch.
-     *
-     * For example, with a rounding step of 0.25 (the default) if the printer
-     * returns a width 4.113 it will be rounded to 4.0
-     */
-    public labelDimensionRoundingStep = 0.25;
-
-    /**
-     * Whether to display printer communication to the dev console
-     */
-    public debug = false;
 }

--- a/src/Printers/Configuration/MediaOptions.ts
+++ b/src/Printers/Configuration/MediaOptions.ts
@@ -67,10 +67,50 @@ export class PrintSpeedSettings {
     printSpeed: PrintSpeed;
     /** Speed during feeding a blank label. ZPL only, same as media speed for EPL. */
     slewSpeed: PrintSpeed;
+
+    // My kingdom for extension methods on enums in a reasonable manner.
+    /** Look up a speed enum from a given whole number */
+    public static getSpeedFromWholeNumber(speed: number): PrintSpeed {
+        switch (speed) {
+            case 0:
+                return PrintSpeed.auto;
+            case 1:
+                return PrintSpeed.ips1;
+            case 2:
+                return PrintSpeed.ips2;
+            case 3:
+                return PrintSpeed.ips3;
+            case 4:
+                return PrintSpeed.ips4;
+            case 5:
+                return PrintSpeed.ips5;
+            case 6:
+                return PrintSpeed.ips6;
+            case 7:
+                return PrintSpeed.ips7;
+            case 8:
+                return PrintSpeed.ips8;
+            case 9:
+                return PrintSpeed.ips9;
+            case 10:
+                return PrintSpeed.ips10;
+            case 11:
+                return PrintSpeed.ips11;
+            case 12:
+                return PrintSpeed.ips12;
+            case 13:
+                return PrintSpeed.ips13;
+            case 14:
+                return PrintSpeed.ips14;
+            default:
+                return PrintSpeed.unknown;
+        }
+    }
 }
 
 /** Printer speed values in inches per second (IPS). */
 export enum PrintSpeed {
+    unknown = -1,
     /** Mobile printers can't be configured otherwise. */
     auto = 0,
     /** The lowest speed a given printer supports. */

--- a/src/Printers/Languages/EplPrinterCommandSet.ts
+++ b/src/Printers/Languages/EplPrinterCommandSet.ts
@@ -341,16 +341,17 @@ export class EplPrinterCommandSet extends PrinterCommandSet {
             options.mediaPrintMode = Options.MediaPrintMode.peelWithButtonTap;
         }
 
-        // TODO: morehardware options:
+        // TODO: more hardware options:
         // - Form feed button mode (Ff, Fr, Fi)
         // - Figure out what reverse gap sensor mode S means
         // - Figure out how to encode C{num} for cut-after-label-count
 
         // TODO other options:
         // Autosense settings?
-        // Print orientation?
         // Character set?
         // Error handling?
+        // Continuous media?
+        // Black mark printing?
 
         return options;
     }

--- a/src/Printers/Languages/ZplPrinterCommandSet.ts
+++ b/src/Printers/Languages/ZplPrinterCommandSet.ts
@@ -1,4 +1,4 @@
-import { PrinterCommandLanguage, PrinterOptions } from '../Configuration/PrinterOptions';
+import * as Options from '../Configuration/PrinterOptions';
 import {
     PrinterCommandSet,
     DocumentValidationError,
@@ -6,12 +6,15 @@ import {
 } from './PrinterCommandSet';
 import * as Commands from '../../Documents/Commands';
 import { match, P } from 'ts-pattern';
+import { AutodetectedPrinter } from '../Models/PrinterModel';
+import { PrinterCommunicationOptions } from '../Communication/PrinterCommunication';
+import { PrinterModelDb } from '../Models/PrinterModelDb';
 
 export class ZplPrinterCommandSet extends PrinterCommandSet {
     private encoder = new TextEncoder();
 
-    get commandLanugage(): PrinterCommandLanguage {
-        return PrinterCommandLanguage.zpl;
+    get commandLanugage(): Options.PrinterCommandLanguage {
+        return Options.PrinterCommandLanguage.zpl;
     }
 
     get documentStartCommand(): Uint8Array {
@@ -60,7 +63,8 @@ export class ZplPrinterCommandSet extends PrinterCommandSet {
             })
             .with(P.instanceOf(Commands.RebootPrinterCommand), () => this.encodeCommand('~JR'))
             .with(P.instanceOf(Commands.QueryConfigurationCommand), () =>
-                this.encodeCommand('^HZa')
+                // HH returns serial, HZA gets everything but the serial in XML.
+                this.encodeCommand('^HZA\r\n^HH')
             )
             .with(P.instanceOf(Commands.PrintConfigurationCommand), () => this.encodeCommand('~WC'))
             .with(P.instanceOf(Commands.SetPrintDirectionCommand), (cmd) => {
@@ -111,15 +115,208 @@ export class ZplPrinterCommandSet extends PrinterCommandSet {
             });
     }
 
-    parseConfigurationResponse(rawText: string): PrinterOptions {
+    parseConfigurationResponse(
+        rawText: string,
+        commOpts: PrinterCommunicationOptions
+    ): Options.PrinterOptions {
         if (rawText.length <= 0) {
-            return PrinterOptions.invalid();
+            return Options.PrinterOptions.invalid();
         }
 
-        // ZPL returns xml (!) which makes this far easier to do!
-        // .. if it was implemented
-        // TODO: ZPL config support.
-        return PrinterOptions.invalid();
+        // The two commands run were ^HH to get the raw two-column config label, and ^HZA to get the
+        // full XML configuration block. Unfortunately ZPL doesn't seem to put the serial number in
+        // the XML so we must pull it from the first line of the raw two-column config.
+
+        // Fascinatingly, it doesn't matter what order the two commands appear in. The XML will be
+        // presented first and the raw label afterwards.
+        const pivotText = '</ZEBRA-ELTRON-PERSONALITY>\r\n';
+        const pivot = rawText.lastIndexOf(pivotText) + pivotText.length;
+        if (pivot == pivotText.length - 1) {
+            return Options.PrinterOptions.invalid();
+        }
+
+        const rawConfig = rawText.substring(pivot);
+        // First line of the raw config should be the serial, which should be alphanumeric.
+        const serial = rawConfig.match(/[A-Z0-9]+/i)[0];
+        console.log('SERIAL', serial);
+
+        // ZPL configuration is just XML, parse it into an object and then into config.
+
+        // For reasons I do not understand printers will tend to send _one_ invalid XML line
+        // and it looks like
+        // ` ENUM='NONE, AUTO DETECT, TAG-IT, ICODE, PICO, ISO15693, EPC, UID'>`
+        // This is supposed to look like
+        // `<RFID-TYPE ENUM='NONE, AUTO DETECT, TAG-IT, ICODE, PICO, ISO15693, EPC, UID'>`
+        // I don't have the appropriate equipment to determine where the XML tag prefix is being
+        // lost. Do a basic find + replace to replace an instance of the exact text with a fixed
+        // version instead.
+        // TODO: Deeper investigation with more printers?
+        const xmlStart = rawText.indexOf("<?xml version='1.0'?>");
+        const rawXml = rawText
+            .substring(xmlStart, pivot)
+            .replace(
+                "\n ENUM='NONE, AUTO DETECT, TAG-IT, ICODE, PICO, ISO15693, EPC, UID'>",
+                "<RFID-TYPE ENUM='NONE, AUTO DETECT, TAG-IT, ICODE, PICO, ISO15693, EPC, UID'>"
+            );
+
+        // The rest is straightforward: parse it as an XML document and pull out
+        // the data. The format is standardized and semi-self-documenting.
+        const parser = new DOMParser();
+        const xmldoc = parser.parseFromString(rawXml, 'application/xml');
+        const errorNode = xmldoc.querySelector('parsererror');
+        console.log(xmldoc);
+        if (errorNode) {
+            // TODO: Log? Throw?
+            console.log('lol failed');
+            return Options.PrinterOptions.invalid();
+        }
+
+        return this.docToOptions(xmldoc, serial, commOpts);
+    }
+
+    private docToOptions(
+        doc: Document,
+        serial: string,
+        commOpts: PrinterCommunicationOptions
+    ): Options.PrinterOptions {
+        // ZPL includes enough information in the document to autodetect the printer's capabilities.
+        const model = PrinterModelDb.getModel(this.getXmlText(doc, 'MODEL'));
+        // ZPL rounds, multiplying by 25 gets us to 'inches' in their book.
+        // 8 DPM == 200 DPI, for example.
+        const dpi = parseInt(this.getXmlText(doc, 'DOTS-PER-MM')) * 25;
+        // Max darkness is an attribute on the element
+        const maxDarkness = parseInt(
+            doc.getElementsByTagName('MEDIA-DARKNESS')[0].getAttribute('MAX').valueOf()
+        );
+
+        // Speed table is specially constructed with a few rules.
+        // Each table should have at least an auto, min, and max value. We assume we can use the whole
+        // number speeds between the min and max values. If the min and max values are the same though
+        // that indicates a mobile printer.
+        const printSpeedElement = doc.getElementsByTagName('PRINT-RATE')[0];
+        const slewSpeedElement = doc.getElementsByTagName('SLEW-RATE')[0];
+        // Highest minimum wins
+        const printMin = parseInt(printSpeedElement.getAttribute('MIN').valueOf());
+        const slewMin = parseInt(slewSpeedElement.getAttribute('MIN').valueOf());
+        const speedMin = printMin >= slewMin ? printMin : slewMin;
+        const printMax = parseInt(printSpeedElement.getAttribute('MAX').valueOf());
+        const slewMax = parseInt(slewSpeedElement.getAttribute('MAX').valueOf());
+        const speedMax = printMax <= slewMax ? printMax : slewMax;
+
+        const modelInfo = new AutodetectedPrinter(
+            Options.PrinterCommandLanguage.zpl,
+            dpi,
+            model,
+            this.getSpeedTable(speedMin, speedMax),
+            maxDarkness
+        );
+
+        const options = new Options.PrinterOptions(
+            serial,
+            modelInfo,
+            this.getXmlText(doc, 'FIRMWARE-VERSION')
+        );
+
+        const currentDarkness = parseInt(this.getXmlCurrent(doc, 'MEDIA-DARKNESS'));
+        const rawDarkness = Math.ceil(currentDarkness * (100 / maxDarkness));
+        options.darknessPercent = Math.max(0, Math.min(rawDarkness, 99)) as Options.DarknessPercent;
+
+        options.speed = new Options.PrintSpeedSettings(
+            parseInt(this.getXmlText(doc, 'PRINT-RATE')),
+            parseInt(this.getXmlText(doc, 'SLEW-RATE'))
+        );
+
+        // Always in dots
+        const labelWidth = parseInt(this.getXmlCurrent(doc, 'PRINT-WIDTH'));
+        const labelLength = parseInt(this.getXmlText(doc, 'LABEL-LENGTH'));
+        const labelRoundingStep = commOpts.labelDimensionRoundingStep ?? 0;
+        if (labelRoundingStep > 0) {
+            // Label size should be rounded to the step value by round-tripping the value to an inch
+            // then rounding, then back to dots.
+            const roundedWidth = this.roundToNearestStep(
+                labelWidth / options.model.dpi,
+                labelRoundingStep
+            );
+            options.labelWidthDots = roundedWidth * options.model.dpi;
+            const roundedHeight = this.roundToNearestStep(
+                labelLength / options.model.dpi,
+                labelRoundingStep
+            );
+            options.labelHeightDots = roundedHeight * options.model.dpi;
+        } else {
+            // No rounding
+            options.labelWidthDots = labelWidth;
+            options.labelHeightDots = labelLength;
+        }
+
+        options.printOrientation =
+            this.getXmlText(doc, 'LABEL-REVERSE') === 'Y'
+                ? Options.PrintOrientation.inverted
+                : Options.PrintOrientation.normal;
+
+        options.thermalPrintMode =
+            this.getXmlCurrent(doc, 'MEDIA-TYPE') === 'DIRECT-THERMAL'
+                ? Options.ThermalPrintMode.direct
+                : Options.ThermalPrintMode.transfer;
+
+        options.mediaPrintMode = this.parsePrintMode(this.getXmlCurrent(doc, 'PRINT-MODE'));
+
+        options.mediaPrintMode =
+            this.getXmlCurrent(doc, 'PRE-PEEL') === 'Y'
+                ? Options.MediaPrintMode.peelWithPrepeel
+                : options.mediaPrintMode;
+
+        // TODO: more hardware options:
+        // - Figure out how to encode C{num} for cut-after-label-count
+
+        // TODO other options:
+        // Autosense settings?
+        // Character set?
+        // Error handling?
+        // Continuous media?
+        // Black mark printing?
+        // Media feed on powerup settings?
+        // Prepeel rewind?
+
+        return options;
+    }
+
+    private range(start: number, stop: number, step = 1) {
+        return Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step);
+    }
+
+    private getXmlText(doc: Document, tag: string) {
+        return doc.getElementsByTagName(tag)[0].textContent;
+    }
+
+    private getXmlCurrent(doc: Document, tag: string) {
+        return doc.getElementsByTagName(tag)[0].getElementsByTagName('CURRENT')[0].textContent;
+    }
+
+    private parsePrintMode(str: string) {
+        switch (str) {
+            case 'REWIND':
+                return Options.MediaPrintMode.rewind;
+            case 'PEEL OFF':
+                return Options.MediaPrintMode.peel;
+            case 'CUTTER':
+                return Options.MediaPrintMode.cutter;
+            default:
+            case 'TEAR OFF':
+                return Options.MediaPrintMode.tearoff;
+        }
+    }
+
+    private getSpeedTable(min: number, max: number) {
+        const table = new Map<Options.PrintSpeed, number>([
+            [Options.PrintSpeed.auto, 0],
+            [Options.PrintSpeed.ipsPrinterMin, min],
+            [Options.PrintSpeed.ipsPrinterMax, max]
+        ]);
+        this.range(min, max).forEach((s) =>
+            table.set(Options.PrintSpeedSettings.getSpeedFromWholeNumber(s), s)
+        );
+        return table;
     }
 
     private lineOrBoxToCmd(

--- a/src/Printers/Models/PrinterModel.ts
+++ b/src/Printers/Models/PrinterModel.ts
@@ -123,3 +123,32 @@ export class UnknownPrinter extends BasePrinterInfo {
         throw new WebZlpError('Unknown printer, cannot read metadata.');
     }
 }
+
+/** A printer model object that was autodetected from the printer itself. */
+export class AutodetectedPrinter extends BasePrinterInfo {
+    get commandLanguage(): PrinterCommandLanguage {
+        return this._commandLanugage;
+    }
+    get dpi(): number {
+        return this._dpi;
+    }
+    get model(): PrinterModel {
+        return this._model;
+    }
+    get speedTable(): ReadonlyMap<PrintSpeed, number> {
+        return this._speedTable;
+    }
+    get maxDarkness(): number {
+        return this._maxDarkness;
+    }
+
+    constructor(
+        private _commandLanugage: PrinterCommandLanguage,
+        private _dpi: number,
+        private _model: PrinterModel,
+        private _speedTable: ReadonlyMap<PrintSpeed, number>,
+        private _maxDarkness: number
+    ) {
+        super();
+    }
+}

--- a/src/Printers/Models/PrinterModel.ts
+++ b/src/Printers/Models/PrinterModel.ts
@@ -3,6 +3,7 @@ import { PrinterCommandLanguage, PrintSpeed } from '../Configuration/PrinterOpti
 
 export enum PrinterModel {
     unknown = 'unknown',
+    zplAutodetect = 'ZPL_AUTODETECT',
     lp2824 = 'LP2824',
     lp2824z = 'LP2824Z',
     lp2844 = 'LP2844',
@@ -23,7 +24,7 @@ export interface IPrinterModelInfo {
     get dpi(): number;
 
     /** Gets the model of this printer. */
-    get model(): PrinterModel;
+    get model(): PrinterModel | string;
 
     /** Gets the map of speeds this printer supports. */
     get speedTable(): ReadonlyMap<PrintSpeed, number>;
@@ -47,7 +48,7 @@ export abstract class BasePrinterInfo implements IPrinterModelInfo {
     /** Gets the DPI of this printer. */
     abstract get dpi(): number;
     /** Gets the model of this printer. */
-    abstract get model(): PrinterModel;
+    abstract get model(): PrinterModel | string;
 
     // Speed is determined by what the printer supports
     // EPL printers have a table that determines their setting and it needs to be hardcoded.
@@ -132,7 +133,7 @@ export class AutodetectedPrinter extends BasePrinterInfo {
     get dpi(): number {
         return this._dpi;
     }
-    get model(): PrinterModel {
+    get model(): PrinterModel | string {
         return this._model;
     }
     get speedTable(): ReadonlyMap<PrintSpeed, number> {
@@ -145,7 +146,7 @@ export class AutodetectedPrinter extends BasePrinterInfo {
     constructor(
         private _commandLanugage: PrinterCommandLanguage,
         private _dpi: number,
-        private _model: PrinterModel,
+        private _model: PrinterModel | string,
         private _speedTable: ReadonlyMap<PrintSpeed, number>,
         private _maxDarkness: number
     ) {

--- a/src/Printers/Models/PrinterModelDb.ts
+++ b/src/Printers/Models/PrinterModelDb.ts
@@ -18,6 +18,8 @@ export class PrinterModelDb {
         // Hard mode: Model correlation between observed values and output.
         // This is pretty much all based off of observed values, I can't find a mapping
         // of the config's model number vs the hardware model number.
+        // TODO: Make this extensible so it's possible for consumers to add their own
+        // printers to the enum, match list, etc.
         return match<string, PrinterModel>(rawModelId)
             .with('UKQ1935HLU', () => PrinterModel.lp2844)
             .with('UKQ1935HMU', () => {
@@ -26,11 +28,14 @@ export class PrinterModelDb {
                 return PrinterModel.lp2844ups;
             })
             .with('LP2844-Z-200dpi', () => PrinterModel.lp2844z)
+            .with('LP2824-Z-200dpi', () => PrinterModel.lp2824z)
             .otherwise(() => PrinterModel.unknown);
     }
 
     /** Look up the model information for a given printer model. */
     public static getModelInfo(model: PrinterModel): IPrinterModelInfo {
+        // TODO: Make this extensible so it's possible for consumers to add their own
+        // printers to the enum, match list, etc.
         return match(model)
             .with(PrinterModel.lp2824, () => new EPL.LP2824())
             .with(PrinterModel.lp2844, () => new EPL.LP2844())

--- a/src/Printers/Printer.ts
+++ b/src/Printers/Printer.ts
@@ -7,17 +7,14 @@ import {
 } from '../Documents/LabelDocument';
 import { ReadyToPrintDocuments } from '../Documents/ReadyToPrintDocuments';
 import { WebZlpError } from '../WebZlpError';
-import {
-    IPrinterDeviceChannel,
-    PrinterChannelType,
-    PrinterCommunicationOptions
-} from './Communication/PrinterCommunication';
+import { IPrinterDeviceChannel, PrinterChannelType } from './Communication/PrinterCommunication';
 import { UsbPrinterDeviceChannel } from './Communication/UsbPrinterDeviceChannel';
 import { PrinterCommandLanguage, PrinterOptions } from './Configuration/PrinterOptions';
 import { EplPrinterCommandSet } from './Languages/EplPrinterCommandSet';
 import { PrinterCommandSet } from './Languages/PrinterCommandSet';
 import { ZplPrinterCommandSet } from './Languages/ZplPrinterCommandSet';
 import { PrinterModelDb } from './Models/PrinterModelDb';
+import { PrinterCommunicationOptions } from './PrinterCommunicationOptions';
 
 /**
  * A class for working with a label printer.

--- a/src/Printers/PrinterCommunicationOptions.ts
+++ b/src/Printers/PrinterCommunicationOptions.ts
@@ -1,0 +1,35 @@
+import { PrinterCommandLanguage } from './Configuration/PrinterOptions';
+import { CommandFormInclusionMode, TranspileCommandDelegate } from './Languages/PrinterCommandSet';
+
+export class PrinterCommunicationOptions {
+    /**
+     * Value to use for rounding read-from-config label sizes.
+     *
+     * When reading the config from a printer the label width and height may be
+     * variable. When you set the label width to 4 inches it's translated into
+     * dots, and then the printer adds a calculated offset to that. This offset
+     * is unique per printer (so far as I have observed) and introduces noise.
+     * This value rounds the returned value to the nearest fraction of an inch.
+     *
+     * For example, with a rounding step of 0.25 (the default) if the printer
+     * returns a width 4.113 it will be rounded to 4.0
+     */
+    public labelDimensionRoundingStep = 0.25;
+
+    /**
+     * Whether to display printer communication to the dev console
+     */
+    public debug = false;
+
+    /**
+     * Custom printer commands added to the base set for a given language.
+     *
+     * See the documentation for more details on how to implement this.
+     */
+    public additionalCustomCommands: Array<{
+        commandType: symbol;
+        applicableLanguages: PrinterCommandLanguage;
+        transpileDelegate: TranspileCommandDelegate;
+        commandInclusionMode: CommandFormInclusionMode;
+    }> = null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export * from './Printers/Languages/PrinterCommandSet';
 export * from './Printers/Models/EplPrinterModels';
 export * from './Printers/Models/PrinterModel';
 export * from './Printers/Models/PrinterModelDb';
+export * from './Printers/PrinterCommunicationOptions';
 export * from './Printers/Printer';
 export * from './PrinterUsbManager';
 export * from './WebZlpError';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from './Color';
 export * from './Documents/Commands';
 export * from './Documents/ConfigDocument';
 export * from './Documents/Document';
+export * from './Documents/BitmapGRF';
 export * from './Documents/LabelDocument';
 export * from './Documents/ReadyToPrintDocuments';
 export * from './Printers/Communication/LineBreakTransformer';

--- a/test/Documents/BitmapGRF.test.ts
+++ b/test/Documents/BitmapGRF.test.ts
@@ -1,0 +1,187 @@
+import { BitmapGRF } from '../../src/Documents/BitmapGRF';
+
+// Class pulled from jest-mock-canvas which I can't seem to actually import.
+class ImageData {
+  _width = 0;
+  _height = 0;
+  _data: Uint8ClampedArray;
+  get width() {
+    return this._width;
+  }
+
+  get height() {
+    return this._height;
+  }
+
+  get data() {
+    return this._data;
+  }
+
+  get colorSpace() {
+    return 'srgb' as PredefinedColorSpace;
+  }
+
+  constructor(arr, w, h) {
+    if (arguments.length === 2) {
+      if (arr instanceof Uint8ClampedArray) {
+        if (arr.length === 0)
+          throw new RangeError('Source length must be a positive multiple of 4.');
+        if (arr.length % 4 !== 0)
+          throw new RangeError('Source length must be a positive multiple of 4.');
+        if (!Number.isFinite(w)) throw new RangeError('The width is zero or not a number.');
+        if (w === 0) throw new RangeError('The width is zero or not a number.');
+        this._width = w;
+        this._height = arr.length / 4 / w;
+        this._data = arr;
+      } else {
+        const width = arr;
+        const height = w;
+        if (!Number.isFinite(height)) throw new RangeError('The height is zero or not a number.');
+        if (height === 0) throw new RangeError('The height is zero or not a number.');
+        if (!Number.isFinite(width)) throw new RangeError('The width is zero or not a number.');
+        if (width === 0) throw new RangeError('The width is zero or not a number.');
+        this._width = width;
+        this._height = height;
+        this._data = new Uint8ClampedArray(width * height * 4);
+      }
+    } else if (arguments.length === 3) {
+      if (!(arr instanceof Uint8ClampedArray))
+        throw new TypeError('First argument must be a Uint8ClampedArray when using 3 arguments.');
+      if (arr.length === 0) throw new RangeError('Source length must be a positive multiple of 4.');
+      if (arr.length % 4 !== 0)
+        throw new RangeError('Source length must be a positive multiple of 4.');
+      if (!Number.isFinite(h)) throw new RangeError('The height is zero or not a number.');
+      if (h === 0) throw new RangeError('The height is zero or not a number.');
+      if (!Number.isFinite(w)) throw new RangeError('The width is zero or not a number.');
+      if (w === 0) throw new RangeError('The width is zero or not a number.');
+      if (arr.length !== w * h * 4)
+        throw new RangeError("Source doesn'n contain the exact number of pixels needed.");
+      this._width = w;
+      this._height = h;
+      this._data = arr;
+    } else {
+      throw new TypeError('Wrong number of arguments provided.');
+    }
+  }
+}
+
+function getImageDataInput(width: number, height: number, fill: number, alpha?: number) {
+  const arr = new Uint8ClampedArray(width * height * 4);
+  if (alpha != null && alpha != fill) {
+    for (let i = 0; i < arr.length; i += 4) {
+      arr[i + 0] = fill;
+      arr[i + 1] = fill;
+      arr[i + 2] = fill;
+      arr[i + 3] = alpha;
+    }
+  } else {
+    arr.fill(fill);
+  }
+  return arr;
+}
+
+describe('rgbaImageConversion', () => {
+  it('Should downconvert transparent images correctly', () => {
+    const imageData = new ImageData(getImageDataInput(8, 1, 0), 8, 1);
+    const expected = new Uint8Array([(1 << 8) - 1]);
+    const { monochromeData, imageWidth, imageHeight, boundingBox } = BitmapGRF['toMonochrome'](
+      imageData.data,
+      imageData.width,
+      imageData.height,
+      { grayThreshold: 75, trimWhitespace: false }
+    );
+    const { grfData, bytesPerRow } = BitmapGRF['toGRF'](monochromeData, imageWidth, imageHeight);
+
+    expect(imageWidth).toBe(8);
+    expect(imageHeight).toBe(1);
+    expect(bytesPerRow).toBe(1);
+    expect(grfData).toEqual(expected);
+  });
+
+  it('Should downconvert black images correctly', () => {
+    const imageData = new ImageData(getImageDataInput(8, 1, 0, 255), 8, 1);
+    const expected = new Uint8Array([0]);
+    const { monochromeData, imageWidth, imageHeight, boundingBox } = BitmapGRF['toMonochrome'](
+      imageData.data,
+      imageData.width,
+      imageData.height,
+      { grayThreshold: 75, trimWhitespace: false }
+    );
+    const { grfData, bytesPerRow } = BitmapGRF['toGRF'](monochromeData, imageWidth, imageHeight);
+
+    expect(imageWidth).toBe(8);
+    expect(imageHeight).toBe(1);
+    expect(bytesPerRow).toBe(1);
+    expect(grfData).toEqual(expected);
+  });
+
+  it('Should downconvert white images correctly', () => {
+    const imageData = new ImageData(getImageDataInput(8, 1, 255), 8, 1);
+    const expected = new Uint8Array([(1 << 8) - 1]);
+    const { monochromeData, imageWidth, imageHeight, boundingBox } = BitmapGRF['toMonochrome'](
+      imageData.data,
+      imageData.width,
+      imageData.height,
+      { grayThreshold: 75, trimWhitespace: false }
+    );
+    const { grfData, bytesPerRow } = BitmapGRF['toGRF'](monochromeData, imageWidth, imageHeight);
+
+    expect(imageWidth).toBe(8);
+    expect(imageHeight).toBe(1);
+    expect(bytesPerRow).toBe(1);
+    expect(grfData).toEqual(expected);
+  });
+
+  it('Should pad and downconvert transparent images correctly', () => {
+    const imageData = new ImageData(getImageDataInput(5, 1, 0), 5, 1);
+    const expected = new Uint8Array([(1 << 8) - 1]);
+    const { monochromeData, imageWidth, imageHeight, boundingBox } = BitmapGRF['toMonochrome'](
+      imageData.data,
+      imageData.width,
+      imageData.height,
+      { grayThreshold: 75, trimWhitespace: false }
+    );
+    const { grfData, bytesPerRow } = BitmapGRF['toGRF'](monochromeData, imageWidth, imageHeight);
+
+    expect(imageWidth).toBe(5);
+    expect(imageHeight).toBe(1);
+    expect(bytesPerRow).toBe(1);
+    expect(grfData).toEqual(expected);
+  });
+
+  it('Should pad and downconvert black images correctly', () => {
+    const imgWidth = 4;
+    const imageData = new ImageData(getImageDataInput(imgWidth, 1, 0, 255), imgWidth, 1);
+    const expected = new Uint8Array([(1 << imgWidth) - 1]);
+    const { monochromeData, imageWidth, imageHeight, boundingBox } = BitmapGRF['toMonochrome'](
+      imageData.data,
+      imageData.width,
+      imageData.height,
+      { grayThreshold: 75, trimWhitespace: false }
+    );
+    const { grfData, bytesPerRow } = BitmapGRF['toGRF'](monochromeData, imageWidth, imageHeight);
+
+    expect(imageWidth).toBe(4);
+    expect(imageHeight).toBe(1);
+    expect(bytesPerRow).toBe(1);
+    expect(grfData).toEqual(expected);
+  });
+
+  it('Should pad and downconvert white images correctly', () => {
+    const imgWidth = 4;
+    const imageData = new ImageData(getImageDataInput(imgWidth, 1, 255), imgWidth, 1);
+    const expected = new Uint8Array([(1 << 8) - 1]);
+    const { monochromeData, imageWidth, imageHeight, boundingBox } = BitmapGRF['toMonochrome'](
+      imageData.data,
+      imageData.width,
+      imageData.height,
+      { grayThreshold: 75, trimWhitespace: false }
+    );
+    const { grfData, bytesPerRow } = BitmapGRF['toGRF'](monochromeData, imageWidth, imageHeight);
+
+    expect(imageWidth).toBe(4);
+    expect(imageHeight).toBe(1);
+    expect(bytesPerRow).toBe(1);
+    expect(grfData).toEqual(expected);
+  });
+});

--- a/test/Documents/BitmapGRF.test.ts
+++ b/test/Documents/BitmapGRF.test.ts
@@ -90,7 +90,7 @@ describe('rgbaImageConversion', () => {
       imageData.height,
       { grayThreshold: 75, trimWhitespace: false }
     );
-    const { grfData, bytesPerRow } = BitmapGRF['toGRF'](monochromeData, imageWidth, imageHeight);
+    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](monochromeData, imageWidth, imageHeight);
 
     expect(imageWidth).toBe(8);
     expect(imageHeight).toBe(1);
@@ -107,7 +107,7 @@ describe('rgbaImageConversion', () => {
       imageData.height,
       { grayThreshold: 75, trimWhitespace: false }
     );
-    const { grfData, bytesPerRow } = BitmapGRF['toGRF'](monochromeData, imageWidth, imageHeight);
+    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](monochromeData, imageWidth, imageHeight);
 
     expect(imageWidth).toBe(8);
     expect(imageHeight).toBe(1);
@@ -124,7 +124,7 @@ describe('rgbaImageConversion', () => {
       imageData.height,
       { grayThreshold: 75, trimWhitespace: false }
     );
-    const { grfData, bytesPerRow } = BitmapGRF['toGRF'](monochromeData, imageWidth, imageHeight);
+    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](monochromeData, imageWidth, imageHeight);
 
     expect(imageWidth).toBe(8);
     expect(imageHeight).toBe(1);
@@ -141,7 +141,7 @@ describe('rgbaImageConversion', () => {
       imageData.height,
       { grayThreshold: 75, trimWhitespace: false }
     );
-    const { grfData, bytesPerRow } = BitmapGRF['toGRF'](monochromeData, imageWidth, imageHeight);
+    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](monochromeData, imageWidth, imageHeight);
 
     expect(imageWidth).toBe(5);
     expect(imageHeight).toBe(1);
@@ -159,7 +159,7 @@ describe('rgbaImageConversion', () => {
       imageData.height,
       { grayThreshold: 75, trimWhitespace: false }
     );
-    const { grfData, bytesPerRow } = BitmapGRF['toGRF'](monochromeData, imageWidth, imageHeight);
+    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](monochromeData, imageWidth, imageHeight);
 
     expect(imageWidth).toBe(4);
     expect(imageHeight).toBe(1);
@@ -177,7 +177,7 @@ describe('rgbaImageConversion', () => {
       imageData.height,
       { grayThreshold: 75, trimWhitespace: false }
     );
-    const { grfData, bytesPerRow } = BitmapGRF['toGRF'](monochromeData, imageWidth, imageHeight);
+    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](monochromeData, imageWidth, imageHeight);
 
     expect(imageWidth).toBe(4);
     expect(imageHeight).toBe(1);

--- a/test/Printers/Languages/EplPrinterCommandSet.test.ts
+++ b/test/Printers/Languages/EplPrinterCommandSet.test.ts
@@ -1,4 +1,5 @@
 import { EplPrinterCommandSet, TranspilationDocumentMetadata } from '../../../src';
+import { BitmapGRF } from '../../../src/Documents/BitmapGRF';
 
 // Class pulled from jest-mock-canvas which I can't seem to actually import.
 class ImageData {
@@ -82,114 +83,12 @@ function getImageDataInput(width: number, height: number, fill: number, alpha?: 
 
 const cmdSet = new EplPrinterCommandSet();
 
-describe('ConversationRgbaToMonochrome', () => {
-  it('Converts white to 1', () => {
-    const result = cmdSet['rgbaToMonochrome'](255, 255, 255, 255, 255, 200);
-    const expected = 1;
-
-    expect(result).toBe(expected);
-  });
-  it('Converts black to 0', () => {
-    const result = cmdSet['rgbaToMonochrome'](0, 0, 0, 255, 255, 200);
-    const expected = 0;
-
-    expect(result).toBe(expected);
-  });
-  it('Converts transparent black to background white', () => {
-    const result = cmdSet['rgbaToMonochrome'](0, 0, 0, 0, 255, 200);
-    const expected = 1;
-
-    expect(result).toBe(expected);
-  });
-  it('Converts transparent white to background white', () => {
-    const result = cmdSet['rgbaToMonochrome'](255, 255, 255, 0, 255, 200);
-    const expected = 1;
-
-    expect(result).toBe(expected);
-  });
-  it('Converts transparent black to background black', () => {
-    const result = cmdSet['rgbaToMonochrome'](0, 0, 0, 0, 0, 200);
-    const expected = 0;
-
-    expect(result).toBe(expected);
-  });
-  it('Converts transparent white to background black', () => {
-    const result = cmdSet['rgbaToMonochrome'](255, 255, 255, 0, 0, 200);
-    const expected = 0;
-
-    expect(result).toBe(expected);
-  });
-});
-
-describe('EplImageConversion', () => {
-  it('Should downconvert transparent images correctly', () => {
-    const imageData = new ImageData(getImageDataInput(8, 1, 0), 8, 1);
-    const expected = new Uint8Array([(1 << 8) - 1]);
-    const [bitmap, bitmapWidth, bitmapHeight] = cmdSet['imageDataToEplBitmap'](imageData);
-
-    expect(bitmapWidth).toBe(8);
-    expect(bitmapHeight).toBe(1);
-    expect(bitmap).toEqual(expected);
-  });
-
-  it('Should downconvert black images correctly', () => {
-    const imageData = new ImageData(getImageDataInput(8, 1, 0, 255), 8, 1);
-    const expected = new Uint8Array([0]);
-    const [bitmap, bitmapWidth, bitmapHeight] = cmdSet['imageDataToEplBitmap'](imageData);
-
-    expect(bitmapWidth).toBe(8);
-    expect(bitmapHeight).toBe(1);
-    expect(bitmap).toEqual(expected);
-  });
-
-  it('Should downconvert white images correctly', () => {
-    const imageData = new ImageData(getImageDataInput(8, 1, 255), 8, 1);
-    const expected = new Uint8Array([(1 << 8) - 1]);
-    const [bitmap, bitmapWidth, bitmapHeight] = cmdSet['imageDataToEplBitmap'](imageData);
-
-    expect(bitmapWidth).toBe(8);
-    expect(bitmapHeight).toBe(1);
-    expect(bitmap).toEqual(expected);
-  });
-
-  it('Should pad and downconvert transparent images correctly', () => {
-    const imageData = new ImageData(getImageDataInput(5, 1, 0), 5, 1);
-    const expected = new Uint8Array([(1 << 8) - 1]);
-    const [bitmap, bitmapWidth, bitmapHeight] = cmdSet['imageDataToEplBitmap'](imageData);
-
-    expect(bitmapWidth).toBe(8);
-    expect(bitmapHeight).toBe(1);
-    expect(bitmap).toEqual(expected);
-  });
-
-  it('Should pad and downconvert black images correctly', () => {
-    const imgWidth = 4;
-    const imageData = new ImageData(getImageDataInput(imgWidth, 1, 0, 255), imgWidth, 1);
-    const expected = new Uint8Array([(1 << imgWidth) - 1]);
-    const [bitmap, bitmapWidth, bitmapHeight] = cmdSet['imageDataToEplBitmap'](imageData);
-
-    expect(bitmapWidth).toBe(8);
-    expect(bitmapHeight).toBe(1);
-    expect(bitmap).toEqual(expected);
-  });
-
-  it('Should pad and downconvert white images correctly', () => {
-    const imgWidth = 4;
-    const imageData = new ImageData(getImageDataInput(imgWidth, 1, 255), imgWidth, 1);
-    const expected = new Uint8Array([(1 << 8) - 1]);
-    const [bitmap, bitmapWidth, bitmapHeight] = cmdSet['imageDataToEplBitmap'](imageData);
-
-    expect(bitmapWidth).toBe(8);
-    expect(bitmapHeight).toBe(1);
-    expect(bitmap).toEqual(expected);
-  });
-});
-
 describe('EplImageConversionToFullCommand', () => {
   it('Should convert blank images to valid command', () => {
     const imageData = new ImageData(getImageDataInput(8, 1, 0), 8, 1);
+    const bitmap = BitmapGRF.fromCanvasImageData(imageData, { trimWhitespace: false });
     const doc = new TranspilationDocumentMetadata();
-    const resultCmd = cmdSet['imageBufferToCmd'](imageData, doc);
+    const resultCmd = cmdSet['imageBufferToCmd'](bitmap, doc);
 
     const expectedCmd = Uint8Array.from([
       ...new TextEncoder().encode('GW0,0,1,1,'),
@@ -202,11 +101,12 @@ describe('EplImageConversionToFullCommand', () => {
 
   it('Should apply offsets in command', () => {
     const imageData = new ImageData(getImageDataInput(8, 1, 0), 8, 1);
+    const bitmap = BitmapGRF.fromCanvasImageData(imageData, { trimWhitespace: false });
     const appliedOffset = 10;
     const doc = new TranspilationDocumentMetadata();
     doc.horizontalOffset = appliedOffset;
     doc.verticalOffset = appliedOffset * 2;
-    const resultCmd = cmdSet['imageBufferToCmd'](imageData, doc);
+    const resultCmd = cmdSet['imageBufferToCmd'](bitmap, doc);
 
     const expectedCmd = Uint8Array.from([
       ...new TextEncoder().encode(`GW${appliedOffset},${appliedOffset * 2},1,1,`),

--- a/test/Printers/Languages/EplPrinterCommandSet.test.ts
+++ b/test/Printers/Languages/EplPrinterCommandSet.test.ts
@@ -1,4 +1,4 @@
-import { EplPrinterCommandSet, TranspilationDocumentMetadata } from '../../../src';
+import { AddImageCommand, DitheringMethod, EplPrinterCommandSet, TranspilationFormMetadata } from '../../../src';
 import { BitmapGRF } from '../../../src/Documents/BitmapGRF';
 
 // Class pulled from jest-mock-canvas which I can't seem to actually import.
@@ -87,8 +87,9 @@ describe('EplImageConversionToFullCommand', () => {
   it('Should convert blank images to valid command', () => {
     const imageData = new ImageData(getImageDataInput(8, 1, 0), 8, 1);
     const bitmap = BitmapGRF.fromCanvasImageData(imageData, { trimWhitespace: false });
-    const doc = new TranspilationDocumentMetadata();
-    const resultCmd = cmdSet['imageBufferToCmd'](bitmap, doc);
+    const cmd = new AddImageCommand(bitmap, DitheringMethod.none);
+    const doc = new TranspilationFormMetadata();
+    const resultCmd = cmdSet['addImageCommand'](cmd, doc, cmdSet);
 
     const expectedCmd = Uint8Array.from([
       ...new TextEncoder().encode('GW0,0,1,1,'),
@@ -102,11 +103,12 @@ describe('EplImageConversionToFullCommand', () => {
   it('Should apply offsets in command', () => {
     const imageData = new ImageData(getImageDataInput(8, 1, 0), 8, 1);
     const bitmap = BitmapGRF.fromCanvasImageData(imageData, { trimWhitespace: false });
+    const cmd = new AddImageCommand(bitmap, DitheringMethod.none);
     const appliedOffset = 10;
-    const doc = new TranspilationDocumentMetadata();
+    const doc = new TranspilationFormMetadata();
     doc.horizontalOffset = appliedOffset;
     doc.verticalOffset = appliedOffset * 2;
-    const resultCmd = cmdSet['imageBufferToCmd'](bitmap, doc);
+    const resultCmd = cmdSet['addImageCommand'](cmd, doc, cmdSet);
 
     const expectedCmd = Uint8Array.from([
       ...new TextEncoder().encode(`GW${appliedOffset},${appliedOffset * 2},1,1,`),
@@ -118,8 +120,8 @@ describe('EplImageConversionToFullCommand', () => {
   });
 
   it('Should return noop for blank imageData', () => {
-    const doc = new TranspilationDocumentMetadata();
-    const resultCmd = cmdSet['imageBufferToCmd'](null, doc);
+    const doc = new TranspilationFormMetadata();
+    const resultCmd = cmdSet['addImageCommand'](null, doc, cmdSet);
 
     expect(resultCmd).toEqual(new Uint8Array());
   });


### PR DESCRIPTION
Right now EPL support is sufficient to print graphic images to labels, a feature the primary consumer of this repo needs. They have an EPL printer to work with and can test, however I have several ZPL printers that I would also like to be able to use.

This PR adds the missing functionality for ZPL to read configs, configure a printer, and print graphic data to ZPL printers.

Continuation of #16 after the other fixes went in.