### PR TITLE
Fix module type references

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webzlp",
-  "version": "1.0.0-rc3",
+  "version": "1.0.0-rc4",
   "description": "Zebra LP-series WebUSB driver",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/src/Documents/BitmapGRF.ts
+++ b/src/Documents/BitmapGRF.ts
@@ -104,7 +104,8 @@ export class BitmapGRF {
             this.width,
             this.height,
             this.bytesPerRow,
-            structuredClone(this.boundingBox));
+            structuredClone(this.boundingBox)
+        );
     }
 
     /** Get a compressed representation of this GRF. This is not compatible with EPL.
@@ -175,7 +176,7 @@ export class BitmapGRF {
      * Create a GRF bitmap from a raw RGBA array-like object.
      */
     public static fromRGBA(
-        data: Uint8Array | Uint8ClampedArray | Buffer | Array<number>,
+        data: Uint8Array | Uint8ClampedArray | Array<number>,
         width: number,
         { grayThreshold = 75, trimWhitespace = true }: ImageConversionOptions = {}
     ): BitmapGRF {
@@ -196,7 +197,11 @@ export class BitmapGRF {
             { grayThreshold, trimWhitespace }
         );
 
-        const { grfData, bytesPerRow } = this.monochromeToGRF(monochromeData, imageWidth, imageHeight);
+        const { grfData, bytesPerRow } = this.monochromeToGRF(
+            monochromeData,
+            imageWidth,
+            imageHeight
+        );
 
         return new BitmapGRF(grfData, imageWidth, imageHeight, bytesPerRow, boundingBox);
     }
@@ -262,7 +267,7 @@ export class BitmapGRF {
      * bounding box information for the bitmap.
      */
     private static toMonochrome(
-        rgba: Uint8Array | Uint8ClampedArray | Buffer | Array<number>,
+        rgba: Uint8Array | Uint8ClampedArray | Array<number>,
         width: number,
         height: number,
         { grayThreshold = 75, trimWhitespace = true }: ImageConversionOptions

--- a/src/PrinterUsbManager.ts
+++ b/src/PrinterUsbManager.ts
@@ -1,3 +1,4 @@
+/// <reference types="w3c-web-usb" />
 import { Printer } from './Printers/Printer';
 import { PrinterCommunicationOptions } from './Printers/PrinterCommunicationOptions';
 

--- a/test/Documents/BitmapGRF.test.ts
+++ b/test/Documents/BitmapGRF.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="jest" />
 import { BitmapGRF } from '../../src/Documents/BitmapGRF';
 
 // Class pulled from jest-mock-canvas which I can't seem to actually import.
@@ -90,7 +91,11 @@ describe('rgbaImageConversion', () => {
       imageData.height,
       { grayThreshold: 75, trimWhitespace: false }
     );
-    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](monochromeData, imageWidth, imageHeight);
+    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](
+      monochromeData,
+      imageWidth,
+      imageHeight
+    );
 
     expect(imageWidth).toBe(8);
     expect(imageHeight).toBe(1);
@@ -107,7 +112,11 @@ describe('rgbaImageConversion', () => {
       imageData.height,
       { grayThreshold: 75, trimWhitespace: false }
     );
-    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](monochromeData, imageWidth, imageHeight);
+    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](
+      monochromeData,
+      imageWidth,
+      imageHeight
+    );
 
     expect(imageWidth).toBe(8);
     expect(imageHeight).toBe(1);
@@ -124,7 +133,11 @@ describe('rgbaImageConversion', () => {
       imageData.height,
       { grayThreshold: 75, trimWhitespace: false }
     );
-    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](monochromeData, imageWidth, imageHeight);
+    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](
+      monochromeData,
+      imageWidth,
+      imageHeight
+    );
 
     expect(imageWidth).toBe(8);
     expect(imageHeight).toBe(1);
@@ -141,7 +154,11 @@ describe('rgbaImageConversion', () => {
       imageData.height,
       { grayThreshold: 75, trimWhitespace: false }
     );
-    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](monochromeData, imageWidth, imageHeight);
+    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](
+      monochromeData,
+      imageWidth,
+      imageHeight
+    );
 
     expect(imageWidth).toBe(5);
     expect(imageHeight).toBe(1);
@@ -159,7 +176,11 @@ describe('rgbaImageConversion', () => {
       imageData.height,
       { grayThreshold: 75, trimWhitespace: false }
     );
-    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](monochromeData, imageWidth, imageHeight);
+    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](
+      monochromeData,
+      imageWidth,
+      imageHeight
+    );
 
     expect(imageWidth).toBe(4);
     expect(imageHeight).toBe(1);
@@ -177,7 +198,11 @@ describe('rgbaImageConversion', () => {
       imageData.height,
       { grayThreshold: 75, trimWhitespace: false }
     );
-    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](monochromeData, imageWidth, imageHeight);
+    const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](
+      monochromeData,
+      imageWidth,
+      imageHeight
+    );
 
     expect(imageWidth).toBe(4);
     expect(imageHeight).toBe(1);

--- a/test/Printers/Languages/EplPrinterCommandSet.test.ts
+++ b/test/Printers/Languages/EplPrinterCommandSet.test.ts
@@ -1,4 +1,10 @@
-import { AddImageCommand, DitheringMethod, EplPrinterCommandSet, TranspilationFormMetadata } from '../../../src';
+/// <reference types="jest" />
+import {
+  AddImageCommand,
+  DitheringMethod,
+  EplPrinterCommandSet,
+  TranspilationFormMetadata
+} from '../../../src';
 import { BitmapGRF } from '../../../src/Documents/BitmapGRF';
 
 // Class pulled from jest-mock-canvas which I can't seem to actually import.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "es6",
+    "types": ["w3c-web-usb", "jest"],
     "lib": ["dom", "esnext"],
     "outDir": "./dist/",
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "es6",
-    "types": ["w3c-web-usb", "jest"],
+    "types": [],
     "lib": ["dom", "esnext"],
     "outDir": "./dist/",
     "sourceMap": true,


### PR DESCRIPTION
Apparently TypeScript will implicitly reference all types found in node_modules, and some transitive dev dependency pulled in the `node` types, which includes conflicting types compared to browser types.

This switches to explicit type references to hopefully avoid this kind of surprise in the future. This also drops references to 'Buffer' objects which apparently don't exist in the browser at all and I pulled in via copy/pasta.