### PR TITLE
Bugfix/service worker safety

### DIFF
--- a/demo-sw.js
+++ b/demo-sw.js
@@ -63,13 +63,14 @@ self.addEventListener('message', async ({data: [sourceUrl, sourceCode]}) => {
 
 const maybeFetchJs = async (requestUrl) => {
     const maybeJs = await fetch(requestUrl);
-    if (maybeJs.status === 404) {
-        // Try it again with a TS extension
-        const tsUrl = requestUrl.substr(0, requestUrl.lastIndexOf('.')) + '.ts';
-        log('Rewrote JS URL to', tsUrl, 'and fetching as typescript');
-        return transpileTypeScript(tsUrl);
+    if (maybeJs.status !== 404) {
+        return maybeJs;
     }
-    return maybeJs.body;
+
+    // Try it again with a TS extension
+    const tsUrl = requestUrl.substr(0, requestUrl.lastIndexOf('.')) + '.ts';
+    log('Rewrote JS URL to', tsUrl, 'and fetching as typescript');
+    return transpileTypeScript(tsUrl);
 }
 
 const runTranspile = async (src, code) => {

--- a/demo/index.html
+++ b/demo/index.html
@@ -32,9 +32,37 @@
         }
     </script>
     <script type="module" src="./ts-browser.js"></script>
+    <script type="text/javascript" id="emergency_shenanigans_reboot_script">
+
+        window.addEventListener('DOMContentLoaded', async () => {
+            // Just in case our shenanigans explode, provide an easier way to clear state.
+            document.getElementById('emergencyRefreshBtn').addEventListener('click', () => {
+                navigator.serviceWorker.getRegistration('../demo-sw.js')
+                    .then(r => r.unregister())
+                    .finally(result => window.location.reload());
+            });
+        });
+
+    </script>
+    <script type="text/typescript" id="just_shenanigans_to_make_the_page_work">
+
+        // Since we got this far it's safe to hide the loading indicator.
+        document.getElementById('loadingIndicator').classList.add('d-none');
+
+        // This bit detects if the browser supports WebUSB, displaying a warning if not.
+        if (navigator.usb == null) {
+            document.getElementById('browserNoWebUsb').classList.remove('d-none');
+        }
+
+        // Display a warning if the OS is windows, which needs some configuration.
+        if (navigator.appVersion.indexOf('Win') != -1) {
+            document.getElementById('windowsDriverWarning').classList.remove('d-none');
+        }
+
+    </script>
 
     <!-- Here's some actual demo code. Note that it is typescript, not javascript. -->
-    <script type="text/typescript">
+    <script type="text/typescript" id="cool_demo_code_to_show_off_the_lib">
         import {
             DarknessPercent,
             IDocument,
@@ -457,16 +485,7 @@
         // Now we'll fire the reconnect since our UI is wired up.
         await printerMgr.reconnectAllPrinters();
 
-        // A couple of last minute things.
-        // This bit detects if the operating system is Windows and shows a little warning about the
-        // Windows print driver conflicting with WebUSB.
-        if (navigator.appVersion.indexOf('Win') != -1) {
-            document.getElementById('windowsDriverWarning').classList.remove('d-none');
-        }
-        // This bit detects if the browser supports WebUSB, displaying a warning if not.
-        if (navigator.usb == null) {
-            document.getElementById('browserNoWebUsb').classList.remove('d-none');
-        }
+        // We're done here. Bring in the dancing lobsters.
     </script>
     <row>
         <div class="container-fluid">
@@ -480,6 +499,10 @@
                 <div class="alert alert-warning d-none" role="alert" id="browserNoWebUsb">
                     <h4>Your browser doesn't support WebUSB</h4>
                     <p>This demo uses WebUSB to function and your browser doesn't seem to have that available.</p>
+                </div>
+                <div class="alert alert-info" role="alert" id="loadingIndicator">
+                    <h4>Loading....</h4>
+                    <p>If you see this for a long time check the dev console for errors and try the <button id="emergencyRefreshBtn">emergency reset button.</button></p>
                 </div>
             </div>
         </div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -59,6 +59,10 @@
             document.getElementById('windowsDriverWarning').classList.remove('d-none');
         }
 
+        if (location.protocol !== 'https:') {
+            document.getElementById('urlNotSecure').classList.remove('d-none');
+        }
+
     </script>
 
     <!-- Here's some actual demo code. Note that it is typescript, not javascript. -->
@@ -503,6 +507,10 @@
                 <div class="alert alert-info" role="alert" id="loadingIndicator">
                     <h4>Loading....</h4>
                     <p>If you see this for a long time check the dev console for errors and try the <button id="emergencyRefreshBtn">emergency reset button.</button></p>
+                </div>
+                <div class="alert alert-warning d-none" role="alert" id="urlNotSecure">
+                    <h4>WebUSB requires HTTPS</h4>
+                    <p>It looks like this URL is not using HTTPS, and WebUSB <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebUSB_API">only works in a secure context.</a> You'll need to load this page over HTTPS instead.</p>
                 </div>
             </div>
         </div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -59,6 +59,14 @@
             document.getElementById('windowsDriverWarning').classList.remove('d-none');
         }
 
+        // Display a warning if the OS is linux, which may need some configuration.
+        if (navigator.appVersion.indexOf('Linux') != -1) {
+            document.getElementById('linuxDriverWarning').classList.remove('d-none');
+        }
+
+        // ChromeOS works out of the box!
+
+        // WebUSB requires HTTPS, show an error if the page wasn't loaded securely.
         if (location.protocol !== 'https:') {
             document.getElementById('urlNotSecure').classList.remove('d-none');
         }
@@ -500,17 +508,24 @@
                     <p>It looks like your operating system is Windows. The <a href="https://web.dev/build-for-webusb/#windows">windows driver model conflicts with WebUSB</a> and might prevent this page from working with a printer.</p>
                     <p>To make this demo work you'll need to <a href="https://cellivar.github.io/WebZLP/docs/windows_driver">set up your driver correctly</a>. You'll see errors in the developer console if it isn't configured correctly.</p>
                 </div>
+                <div class="alert alert-warning alert-dismissible d-none" role="alert" id="linuxDriverWarning">
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    <h4>Linux may need extra configuration</h4>
+                    <p>It looks like your operating system is Linux. The <a href="https://web.dev/build-for-webusb/#linux">linux default driver conflicts with WebUSB</a> and might prevent this page from working with a printer.</p>
+                    <p>If a printer doesn't connect successfully you'll need to <a href="https://github.com/anthroarts/artshow-jockey/tree/73a794bcaa0f0a10625c94d4b2876eba5b638287/udev">set up udev rules</a> to load a different driver. You'll see errors in the developer console if it isn't configured correctly.</p>
+                    <p>You may be able to find the correct USB IDs for your device by visiting either opening <pre>chrome://usb-internals</pre> in a new tab and clicking on the 'Devices' tab, or visiting the <a href="http://www.linux-usb.org/usb-ids.html">the USB ID Repository</a>.</p>
+                </div>
                 <div class="alert alert-warning d-none" role="alert" id="browserNoWebUsb">
                     <h4>Your browser doesn't support WebUSB</h4>
                     <p>This demo uses WebUSB to function and your browser doesn't seem to have that available.</p>
                 </div>
-                <div class="alert alert-info" role="alert" id="loadingIndicator">
-                    <h4>Loading....</h4>
-                    <p>If you see this for a long time check the dev console for errors and try the <button id="emergencyRefreshBtn">emergency reset button.</button></p>
-                </div>
                 <div class="alert alert-warning d-none" role="alert" id="urlNotSecure">
                     <h4>WebUSB requires HTTPS</h4>
                     <p>It looks like this URL is not using HTTPS, and WebUSB <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebUSB_API">only works in a secure context.</a> You'll need to load this page over HTTPS instead.</p>
+                </div>
+                <div class="alert alert-info" role="alert" id="loadingIndicator">
+                    <h4>Loading....</h4>
+                    <p>If you see this for a long time check the dev console for errors and try the <button id="emergencyRefreshBtn">emergency reset button.</button></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The actual bug here was the service worker wasn't sending a valid fetch response for the raw js files, and when it tried to interpret the CDN requests those failed. Didn't test having a cache haha.

To facilitate recovering from service worker shenanigans I've added a loading indicator and an explicit 'nuke the service worker' button.

Also added an HTTPS-only warning while I was in there. 

Also added a Linux udev rule warning while I was in there, it's got a similar issue with the OS providing a conflicting driver by default.