### PR TITLE
Properly expose image conversion options

### DIFF
--- a/src/Documents/BitmapGRF.ts
+++ b/src/Documents/BitmapGRF.ts
@@ -20,7 +20,7 @@ export interface ImageBoundingBox {
 
 /** Settings for converting an image to a GRF. */
 export interface ImageConversionOptions {
-    /** The threshold brightness below which to consider a pixel black. Defaults to 25. */
+    /** The threshold brightness below which to consider a pixel black. Defaults to 90. */
     grayThreshold?: Percent;
     /** Whether to trim whitespace around the image to reduce file size. Trimmed pixels will become padding in the bounding box. */
     trimWhitespace?: boolean;
@@ -186,12 +186,14 @@ export class BitmapGRF {
     public static fromRGBA(
         data: Uint8Array | Uint8ClampedArray | Array<number>,
         width: number,
-        {
-            grayThreshold = 25,
+        imageOptions?: ImageConversionOptions
+    ): BitmapGRF {
+        const {
+            grayThreshold = 90,
             trimWhitespace = true,
             ditheringMethod = DitheringMethod.none
-        }: ImageConversionOptions = {}
-    ): BitmapGRF {
+        } = imageOptions;
+
         width = width | 0;
         if (!width || width < 0) {
             throw new BitmapFormatError('Image width must be provided for RGBA data.');
@@ -227,12 +229,13 @@ export class BitmapGRF {
      */
     public static fromCanvasImageData(
         imageData: ImageData,
-        {
-            grayThreshold = 25,
+        imageOptions?: ImageConversionOptions
+    ): BitmapGRF {
+        const {
+            grayThreshold = 90,
             trimWhitespace = true,
             ditheringMethod = DitheringMethod.none
-        }: ImageConversionOptions = {}
-    ): BitmapGRF {
+        } = imageOptions;
         // This property isn't supported in Firefox, so it isn't supported
         // in the lib types, and I don't feel like dealing with it right now
         // so TODO: fix this eventually

--- a/src/Documents/Commands.ts
+++ b/src/Documents/Commands.ts
@@ -1,5 +1,5 @@
 import * as Options from '../Printers/Configuration/PrinterOptions.js';
-import { BitmapGRF } from './BitmapGRF.js';
+import { BitmapGRF, ImageConversionOptions } from './BitmapGRF.js';
 
 /** Flags to indicate special operations a command might cause. */
 export enum PrinterCommandEffectFlags {
@@ -38,12 +38,6 @@ export interface IPrinterExtendedCommand extends IPrinterCommand {
 
     /** Gets the command languages this extended command can apply to. */
     get commandLanguageApplicability(): Options.PrinterCommandLanguage;
-}
-
-/** List of available dithering methods for converting images to black/white. */
-export enum DitheringMethod {
-    /** No dithering, cutoff with  used. */
-    none
 }
 
 /** List of colors to draw elements with */
@@ -436,7 +430,7 @@ export class AddImageCommand implements IPrinterCommand {
         return `Adds a ${this.bitmap.width} wide x ${this.bitmap.height} high image.`;
     }
 
-    constructor(public bitmap: BitmapGRF, public dithering: DitheringMethod) {}
+    constructor(public bitmap: BitmapGRF, public imageConversionOptions: ImageConversionOptions) {}
 }
 
 /** Command class to draw a straight line. */

--- a/src/Documents/LabelDocument.ts
+++ b/src/Documents/LabelDocument.ts
@@ -1,7 +1,7 @@
 import * as Commands from './Commands.js';
 import { DocumentBuilder } from './Document.js';
 import * as Options from '../Printers/Configuration/PrinterOptions.js';
-import { BitmapGRF } from './BitmapGRF.js';
+import { BitmapGRF, ImageConversionOptions } from './BitmapGRF.js';
 
 export interface ILabelDocumentBuilder
     extends DocumentBuilder<ILabelDocumentBuilder>,
@@ -74,11 +74,18 @@ export class LabelDocumentBuilder
 
     addImageFromImageData(
         imageData: ImageData,
-        dithering = Commands.DitheringMethod.none
+        imageConversionOptions: ImageConversionOptions = {}
     ): ILabelDocumentBuilder {
         return this.then(
-            new Commands.AddImageCommand(BitmapGRF.fromCanvasImageData(imageData), dithering)
+            new Commands.AddImageCommand(
+                BitmapGRF.fromCanvasImageData(imageData),
+                imageConversionOptions
+            )
         );
+    }
+
+    addImageFromGRF(image: BitmapGRF): ILabelDocumentBuilder {
+        return this.then(new Commands.AddImageCommand(image, {}));
     }
 
     addLine(lengthInDots: number, heightInDots: number, color = Commands.DrawColor.black) {
@@ -139,8 +146,11 @@ export interface ILabelContentCommandBuilder {
     /** Add an ImageData object as an image to the label */
     addImageFromImageData(
         imageData: ImageData,
-        dithering?: Commands.DitheringMethod
+        imageConversionOptions?: ImageConversionOptions
     ): ILabelDocumentBuilder;
+
+    /** Add a bitmap GRF image to the label */
+    addImageFromGRF(image: BitmapGRF): ILabelDocumentBuilder;
 
     /** Draw a line from the current offset for the length and height. */
     addLine(

--- a/src/Printers/PrinterCommunicationOptions.ts
+++ b/src/Printers/PrinterCommunicationOptions.ts
@@ -1,5 +1,8 @@
 import { PrinterCommandLanguage } from './Configuration/PrinterOptions.js';
-import { CommandFormInclusionMode, TranspileCommandDelegate } from './Languages/PrinterCommandSet.js';
+import {
+    CommandFormInclusionMode,
+    TranspileCommandDelegate
+} from './Languages/PrinterCommandSet.js';
 
 export class PrinterCommunicationOptions {
     /**

--- a/test/Documents/BitmapGRF.test.ts
+++ b/test/Documents/BitmapGRF.test.ts
@@ -1,5 +1,9 @@
 /// <reference types="jest" />
-import { BitmapGRF } from '../../src/Documents/BitmapGRF.js';
+import {
+  BitmapGRF,
+  DitheringMethod,
+  ImageConversionOptions
+} from '../../src/Documents/BitmapGRF.js';
 
 // Class pulled from jest-mock-canvas which I can't seem to actually import.
 class ImageData {
@@ -81,6 +85,12 @@ function getImageDataInput(width: number, height: number, fill: number, alpha?: 
   return arr;
 }
 
+const imageConversionOptions: ImageConversionOptions = {
+  ditheringMethod: DitheringMethod.none,
+  grayThreshold: 99,
+  trimWhitespace: false
+};
+
 describe('rgbaImageConversion', () => {
   it('Should downconvert transparent images correctly', () => {
     const imageData = new ImageData(getImageDataInput(8, 1, 0), 8, 1);
@@ -89,7 +99,7 @@ describe('rgbaImageConversion', () => {
       imageData.data,
       imageData.width,
       imageData.height,
-      { grayThreshold: 75, trimWhitespace: false }
+      imageConversionOptions
     );
     const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](
       monochromeData,
@@ -110,7 +120,7 @@ describe('rgbaImageConversion', () => {
       imageData.data,
       imageData.width,
       imageData.height,
-      { grayThreshold: 75, trimWhitespace: false }
+      imageConversionOptions
     );
     const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](
       monochromeData,
@@ -131,7 +141,7 @@ describe('rgbaImageConversion', () => {
       imageData.data,
       imageData.width,
       imageData.height,
-      { grayThreshold: 75, trimWhitespace: false }
+      imageConversionOptions
     );
     const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](
       monochromeData,
@@ -152,7 +162,7 @@ describe('rgbaImageConversion', () => {
       imageData.data,
       imageData.width,
       imageData.height,
-      { grayThreshold: 75, trimWhitespace: false }
+      imageConversionOptions
     );
     const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](
       monochromeData,
@@ -174,7 +184,7 @@ describe('rgbaImageConversion', () => {
       imageData.data,
       imageData.width,
       imageData.height,
-      { grayThreshold: 75, trimWhitespace: false }
+      imageConversionOptions
     );
     const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](
       monochromeData,
@@ -196,7 +206,7 @@ describe('rgbaImageConversion', () => {
       imageData.data,
       imageData.width,
       imageData.height,
-      { grayThreshold: 75, trimWhitespace: false }
+      imageConversionOptions
     );
     const { grfData, bytesPerRow } = BitmapGRF['monochromeToGRF'](
       monochromeData,

--- a/test/Printers/Languages/EplPrinterCommandSet.test.ts
+++ b/test/Printers/Languages/EplPrinterCommandSet.test.ts
@@ -1,7 +1,6 @@
 /// <reference types="jest" />
 import {
   AddImageCommand,
-  DitheringMethod,
   EplPrinterCommandSet,
   TranspilationFormMetadata
 } from '../../../src/index.js';
@@ -93,7 +92,7 @@ describe('EplImageConversionToFullCommand', () => {
   it('Should convert blank images to valid command', () => {
     const imageData = new ImageData(getImageDataInput(8, 1, 0), 8, 1);
     const bitmap = BitmapGRF.fromCanvasImageData(imageData, { trimWhitespace: false });
-    const cmd = new AddImageCommand(bitmap, DitheringMethod.none);
+    const cmd = new AddImageCommand(bitmap, {});
     const doc = new TranspilationFormMetadata();
     const resultCmd = cmdSet['addImageCommand'](cmd, doc, cmdSet);
 
@@ -109,7 +108,7 @@ describe('EplImageConversionToFullCommand', () => {
   it('Should apply offsets in command', () => {
     const imageData = new ImageData(getImageDataInput(8, 1, 0), 8, 1);
     const bitmap = BitmapGRF.fromCanvasImageData(imageData, { trimWhitespace: false });
-    const cmd = new AddImageCommand(bitmap, DitheringMethod.none);
+    const cmd = new AddImageCommand(bitmap, {});
     const appliedOffset = 10;
     const doc = new TranspilationFormMetadata();
     doc.horizontalOffset = appliedOffset;


### PR DESCRIPTION
Turns out I forgot to do this. This is a breaking change.

This moves the image dithering options directly into the image options object that can be passed to `addImageFromImageData`, the idea being the consumer of the library can alter the conversion options to suit their needs depending on their printer's shenanigans. 

This also alters the default gray cutoff down to 25% instead of 75%, mostly to see if that improves things.