### PR TITLE
Revert grayscale algorithm changes

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -76,6 +76,7 @@
     <!-- Here's some actual demo code. Note that it is typescript, not javascript. -->
     <script type="text/typescript" id="cool_demo_code_to_show_off_the_lib">
         import {
+            BitmapGRF,
             DarknessPercent,
             IDocument,
             ILabelDocumentBuilder,
@@ -408,19 +409,30 @@
 
                 const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
                 const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-                const c = canvas.getContext('2d');
+                const pageContext = canvas.getContext('2d');
+                pageContext.clearRect(0, 0, canvas.width, canvas.height);
 
-                // We're doing this the quick and dirty way, clearing the rectangle each time and
-                // redrawing all of the text. A more complex app could do this more gracefully!
-                c.clearRect(0, 0, canvas.width, canvas.height);
-                c.font = `30pt ${this.fontName}`;
-                c.imageSmoothingEnabled = false;
-                c.fillStyle = "#000000";
+                // We'd like the preview image to be as close as possible to what the printer will
+                // actually print. To do this we don't draw text to the page's canvas directly,
+                // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
+                // then render *that* back to the page's canvas. This is a more accurate picture of
+                // what the label will end up looking like.
+
+                // A more complex app could do this more gracefully!
+                const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d');
+                offscreenContext.font = `30pt ${this.fontName}`;
+                offscreenContext.fillStyle = "#000000";
 
                 // fillText doesn't do newlines, do that manually
                 textarea.value.split('\n').forEach((l, i) => {
-                    c.fillText(l, 5, (i * 31) + 30);
+                    offscreenContext.fillText(l, 5, (i * 31) + 30);
                 })
+
+                // Now into the monochrome bitmap.
+                const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
+                const monoImg = BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
+                // And finally back onto the page.
+                pageContext.putImageData(monoImg.toImageData(), 0, 0);
             }
 
             /** Render the canvas to a document for printing */

--- a/src/Documents/BitmapGRF.ts
+++ b/src/Documents/BitmapGRF.ts
@@ -97,6 +97,24 @@ export class BitmapGRF {
         return this._bitmap;
     }
 
+    /** Gets an ImageData representation of this GRF. Can be used to draw into Canvas elements. */
+    public toImageData() {
+        const buffer = new Uint8ClampedArray(this._bitmap.length * 4 * 8);
+        for (let i = 0, n = this._bitmap.length; i < n; i++) {
+            // High bit to low bit (left to right) in the bitmap byte.
+            for (let offset = 7; offset >= 0; offset--) {
+                const outOffset = (i * 8 * 4) + ((7 - offset) * 4);
+                const pixel = ((this._bitmap[i] >> offset) & 1) === 1 ? 255 : 0;
+                buffer[outOffset + 0] = pixel;
+                buffer[outOffset + 1] = pixel;
+                buffer[outOffset + 2] = pixel;
+                buffer[outOffset + 3] = 255; // Always opaque alpha.
+            }
+        }
+
+        return new ImageData(buffer, this.width, this.height);
+    }
+
     /** Gets a bitmap GRF that has its colors inverted.
      *
      * EPL uses 1 as white. ZPL uses 1 as black. Use this to convert between them.
@@ -189,7 +207,7 @@ export class BitmapGRF {
         imageOptions?: ImageConversionOptions
     ): BitmapGRF {
         const {
-            grayThreshold = 90,
+            grayThreshold = 70,
             trimWhitespace = true,
             ditheringMethod = DitheringMethod.none
         } = imageOptions ?? {};
@@ -217,7 +235,7 @@ export class BitmapGRF {
             imageHeight
         );
 
-        return new BitmapGRF(grfData, imageWidth, imageHeight, bytesPerRow, boundingBox);
+        return new BitmapGRF(grfData, bytesPerRow * 8, imageHeight, bytesPerRow, boundingBox);
     }
 
     /**
@@ -232,7 +250,7 @@ export class BitmapGRF {
         imageOptions?: ImageConversionOptions
     ): BitmapGRF {
         const {
-            grayThreshold = 90,
+            grayThreshold = 70,
             trimWhitespace = true,
             ditheringMethod = DitheringMethod.none
         } = imageOptions ?? {};


### PR DESCRIPTION
As part of #22 I introduced the BitmapGRF class that was heavily based on another nodejs library. As it turns out the grayscale conversion method that library uses is far less tolerant of anti-aliasing or other effects that drawing to a canvas can generate.

The side-effect here was a hard to nail down issue with printed text looking awful. After lots of debugging I decided to revert the image conversion logic back to the color theory based version I wrote last year and this cleared up the issue. The threshold values now work much more effectively and have been returned back to the default 70% they used to be. Prints look much sharper and the font looks much crisper.

To facilitate the debugging I had modified the demo app to show the preview _as rendered by the BitmapGRF class_, which generates a much more "this is what the badge will actually print like" preview. I've decided to keep this as a good example of how the library ends up rendering text and images. The demo app is starting to get longer than I think is appropriate for a  'basic example code demo' and I'm considering forking it into an 'advanced test app' demo showing more features. This might include more sliders for text control, adding in full image files, and advanced controls like resetting a printer to default values and altering cut controls.

As part of this I identified a couple of other bugs with the bounding box calculations that have been fixed.