### PR TITLE
Support addImageFromSVG

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webzlp",
-  "version": "1.0.0-rc5",
+  "version": "1.0.0-rc6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webzlp",
-      "version": "1.0.0-rc5",
+      "version": "1.0.0-rc6",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@swc/core": "^1.3.24",
@@ -24,7 +24,7 @@
         "prettier": "^2.7.1",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
-        "typescript": "^4.8.4"
+        "typescript": "^4.9.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5900,9 +5900,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10528,9 +10528,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "prettier": "^2.7.1",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
-    "typescript": "^4.8.4"
+    "typescript": "^4.9.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webzlp",
-  "version": "1.0.0-rc6",
+  "version": "1.0.0-rc7",
   "description": "Zebra LP-series WebUSB driver",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/src/Documents/ConfigDocument.ts
+++ b/src/Documents/ConfigDocument.ts
@@ -28,40 +28,40 @@ export class ConfigDocumentBuilder
     // so to bring them closer to parity this is automatically implied.
     // TODO: Consider whether this should move to a ZPL extended command.
     finalize() {
-        this.then(new Commands.SaveCurrentConfigurationCommand());
+        this.andThen(new Commands.SaveCurrentConfigurationCommand());
         return super.finalize();
     }
 
     ///////////////////// GENERAL LABEL HANDLING
 
     clearImageBuffer(): IConfigDocumentBuilder {
-        return this.then(new Commands.ClearImageBufferCommand());
+        return this.andThen(new Commands.ClearImageBufferCommand());
     }
 
     rebootPrinter(): IDocument {
-        return this.then(new Commands.RebootPrinterCommand()).finalize();
+        return this.andThen(new Commands.RebootPrinterCommand()).finalize();
     }
 
     ///////////////////// CONFIG READING
 
     queryConfiguration(): IConfigDocumentBuilder {
-        return this.then(new Commands.QueryConfigurationCommand());
+        return this.andThen(new Commands.QueryConfigurationCommand());
     }
 
     printConfiguration(): IDocument {
-        return this.then(new Commands.PrintConfigurationCommand()).finalize();
+        return this.andThen(new Commands.PrintConfigurationCommand()).finalize();
     }
 
     ///////////////////// ALTER PRINTER CONFIG
 
     setDarknessConfig(darknessPercent: Options.DarknessPercent) {
-        return this.then(
+        return this.andThen(
             new Commands.SetDarknessCommand(darknessPercent, this._config.model.maxDarkness)
         );
     }
 
     setPrintDirection(upsideDown = false) {
-        return this.then(new Commands.SetPrintDirectionCommand(upsideDown));
+        return this.andThen(new Commands.SetPrintDirectionCommand(upsideDown));
     }
 
     setPrintSpeed(speed: Options.PrintSpeed, mediaSlewSpeed = Options.PrintSpeed.auto) {
@@ -82,7 +82,7 @@ export class ConfigDocumentBuilder
         if (mediaSlewSpeed === Options.PrintSpeed.auto) {
             mediaSlewSpeed = speed;
         }
-        return this.then(
+        return this.andThen(
             new Commands.SetPrintSpeedCommand(
                 speed,
                 this._config.model.getSpeedValue(speed),
@@ -95,7 +95,7 @@ export class ConfigDocumentBuilder
     ///////////////////// ALTER LABEL CONFIG
 
     autosenseLabelLength() {
-        return this.then(new Commands.AutosenseLabelDimensionsCommand()).finalize();
+        return this.andThen(new Commands.AutosenseLabelDimensionsCommand()).finalize();
     }
 
     setLabelDimensions(widthInInches: number, heightInInches?: number, gapLengthInInches?: number) {
@@ -108,13 +108,13 @@ export class ConfigDocumentBuilder
     }
 
     setLabelDimensionsDots(widthInDots: number, heightInDots?: number, gapLengthInDots?: number) {
-        return this.then(
+        return this.andThen(
             new Commands.SetLabelDimensionsCommand(widthInDots, heightInDots, gapLengthInDots)
         );
     }
 
     setLabelHomeOffsetDots(horizontalOffsetInDots: number, verticalOffsetInDots: number) {
-        return this.then(
+        return this.andThen(
             new Commands.SetLabelHomeCommand(horizontalOffsetInDots, verticalOffsetInDots)
         );
     }

--- a/src/Documents/Document.ts
+++ b/src/Documents/Document.ts
@@ -75,7 +75,7 @@ export abstract class DocumentBuilder<TBuilder extends DocumentBuilder<TBuilder>
         return new Document(this._commands, this.commandReorderBehavior);
     }
 
-    protected then(command: Commands.IPrinterCommand): TBuilder {
+    protected andThen(command: Commands.IPrinterCommand): TBuilder {
         this._commands.push(command);
         return this as unknown as TBuilder;
     }

--- a/src/Documents/LabelDocument.ts
+++ b/src/Documents/LabelDocument.ts
@@ -84,8 +84,22 @@ export class LabelDocumentBuilder
         );
     }
 
-    addImageFromGRF(image: BitmapGRF): ILabelDocumentBuilder {
-        return this.then(new Commands.AddImageCommand(image, {}));
+    addImageFromGRF(
+        image: BitmapGRF,
+        imageConversionOptions: ImageConversionOptions = {}
+    ): ILabelDocumentBuilder {
+        return this.andThen(new Commands.AddImageCommand(image, imageConversionOptions));
+    }
+
+    async addImageFromSVG(
+        svg: string,
+        widthInDots: number,
+        heightInDots: number,
+        imageConversionOptions: ImageConversionOptions = {}
+    ): Promise<ILabelDocumentBuilder> {
+        const img = await BitmapGRF.fromSVG(svg, widthInDots, heightInDots, imageConversionOptions);
+        const result = this.addImageFromGRF(img, imageConversionOptions);
+        return result;
     }
 
     addLine(lengthInDots: number, heightInDots: number, color = Commands.DrawColor.black) {
@@ -153,6 +167,14 @@ export interface ILabelContentCommandBuilder {
 
     /** Add a bitmap GRF image to the label */
     addImageFromGRF(image: BitmapGRF): ILabelDocumentBuilder;
+
+    /** Add an SVG image to the label, rendered to the given width and height. */
+    addImageFromSVG(
+        svg: string,
+        widthInDots: number,
+        heightInDots: number,
+        imageConversionOptions?: ImageConversionOptions
+    ): Promise<ILabelDocumentBuilder>;
 
     /** Draw a line from the current offset for the length and height. */
     addLine(

--- a/src/Documents/LabelDocument.ts
+++ b/src/Documents/LabelDocument.ts
@@ -33,41 +33,41 @@ export class LabelDocumentBuilder
     ///////////////////// GENERAL LABEL HANDLING
 
     clearImageBuffer(): ILabelDocumentBuilder {
-        return this.then(new Commands.ClearImageBufferCommand());
+        return this.andThen(new Commands.ClearImageBufferCommand());
     }
 
     addPrintCmd(count?: number, additionalDuplicateOfEach?: number): ILabelDocumentBuilder {
-        return this.then(new Commands.PrintCommand(count ?? 1, additionalDuplicateOfEach ?? 0));
+        return this.andThen(new Commands.PrintCommand(count ?? 1, additionalDuplicateOfEach ?? 0));
     }
 
     addCutNowCommand(): ILabelDocumentBuilder {
-        return this.then(new Commands.CutNowCommand());
+        return this.andThen(new Commands.CutNowCommand());
     }
 
     startNewLabel(): ILabelDocumentBuilder {
-        return this.then(new Commands.NewLabelCommand());
+        return this.andThen(new Commands.NewLabelCommand());
     }
 
     suppressFeedBackupForLabel(): ILabelDocumentBuilder {
-        return this.then(new Commands.SuppressFeedBackupCommand());
+        return this.andThen(new Commands.SuppressFeedBackupCommand());
     }
 
     reenableFeedBackup(): ILabelDocumentBuilder {
-        return this.then(new Commands.EnableFeedBackupCommand());
+        return this.andThen(new Commands.EnableFeedBackupCommand());
     }
 
     ///////////////////// OFFSET AND SPACING
 
     setOffset(horizontal: number, vertical?: number): ILabelDocumentBuilder {
-        return this.then(new Commands.OffsetCommand(horizontal, vertical, true));
+        return this.andThen(new Commands.OffsetCommand(horizontal, vertical, true));
     }
 
     addOffset(horizontal: number, vertical?: number): ILabelDocumentBuilder {
-        return this.then(new Commands.OffsetCommand(horizontal, vertical));
+        return this.andThen(new Commands.OffsetCommand(horizontal, vertical));
     }
 
     resetOffset(): ILabelDocumentBuilder {
-        return this.then(new Commands.OffsetCommand(0, 0, true));
+        return this.andThen(new Commands.OffsetCommand(0, 0, true));
     }
 
     ///////////////////// LABEL IMAGE CONTENTS
@@ -76,7 +76,7 @@ export class LabelDocumentBuilder
         imageData: ImageData,
         imageConversionOptions: ImageConversionOptions = {}
     ): ILabelDocumentBuilder {
-        return this.then(
+        return this.andThen(
             new Commands.AddImageCommand(
                 BitmapGRF.fromCanvasImageData(imageData),
                 imageConversionOptions
@@ -89,7 +89,7 @@ export class LabelDocumentBuilder
     }
 
     addLine(lengthInDots: number, heightInDots: number, color = Commands.DrawColor.black) {
-        return this.then(new Commands.AddLineCommand(lengthInDots, heightInDots, color));
+        return this.andThen(new Commands.AddLineCommand(lengthInDots, heightInDots, color));
     }
 
     addBox(
@@ -97,7 +97,9 @@ export class LabelDocumentBuilder
         heightInDots: number,
         thicknessInDots: number
     ): ILabelDocumentBuilder {
-        return this.then(new Commands.AddBoxCommand(lengthInDots, heightInDots, thicknessInDots));
+        return this.andThen(
+            new Commands.AddBoxCommand(lengthInDots, heightInDots, thicknessInDots)
+        );
     }
 }
 


### PR DESCRIPTION
Resolves #29 

This adds support for SVG images being added directly to the labels. This also supports the "put HTML into an SVG using a foreignObject" rendering trick. The only caveat is that the rendered size of the SVG needs to be explicitly passed in and will be used to override the width and height attributes. This may be a little tricky and require some trial-and-error to get correct. I'll need to add some documentation about how to test this using the BitmapGRF class directly or through the CanvasPrinter test harness I've started in #33.