### PR TITLE
Scan for EPL first

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webzlp",
-  "version": "1.0.0-rc7",
+  "version": "1.0.0-rc8",
   "description": "Zebra LP-series WebUSB driver",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/src/Printers/Printer.ts
+++ b/src/Printers/Printer.ts
@@ -145,8 +145,8 @@ export class Printer {
         // Guess order is easiest to detect and support.. to least
         const guessOrder = [
             guess,
-            PrinterCommandLanguage.zpl,
             PrinterCommandLanguage.epl,
+            PrinterCommandLanguage.zpl,
             PrinterCommandLanguage.cpcl
         ];
 


### PR DESCRIPTION
In testing I've found that ZPL printers are _very_ reliable at telling you they are ZPL printers. Since we can reliably detect them and shortcut to ZPL detection, it's more time-consuming to query an EPL printer for ZPL features. I was initially okay with this, but then I ran into my latest problem child printer.

I have a printer here, standard ELP LP2844 with the latest firmware, which prints "ERR01" if you send it a ZPL command. No clue why. Settings appear normal. If you only send it EPL it's happy as a clam.

So, given that ZPL machines can be reliably detected and EPL machines can't, and there's a non-zero number of EPL machines that throw a fit when you try to talk ZPL at them, it makes sense to default to EPL first.

Who wants to bet CPCL throws a fit if you try to talk EPL or ZPL at it and I'm going to have a barrel of fun doing this autodetection in the future?

Bumps RC8.