### PR TITLE
Add TLP 28XX printers to detection list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webzlp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Zebra LP-series WebUSB driver",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/src/Printers/Models/EplPrinterModels.ts
+++ b/src/Printers/Models/EplPrinterModels.ts
@@ -45,3 +45,15 @@ export class LP2824 extends LP28XX {
         return PrinterModel.lp2824;
     }
 }
+
+export class TLP2824 extends LP28XX {
+    get model() {
+        return PrinterModel.tlp2824;
+    }
+}
+
+export class TLP2844 extends LP28XX {
+    get model() {
+        return PrinterModel.tlp2844;
+    }
+}

--- a/src/Printers/Models/PrinterModelDb.ts
+++ b/src/Printers/Models/PrinterModelDb.ts
@@ -23,6 +23,9 @@ export class PrinterModelDb {
         // TODO: Make this extensible so it's possible for consumers to add their own
         // printers to the enum, match list, etc.
         switch (rawModelId) {
+            case 'UKQ1935  U':
+                return PrinterModel.tlp2844;
+
             case 'UKQ1915HLU':
                 return PrinterModel.lp2824;
             case 'UKQ1935HLU':
@@ -31,6 +34,7 @@ export class PrinterModelDb {
                 // HMU units that do not have FDX in the version string appear to be UPS
                 // units. Maybe. Mostly. It's not clear.
                 return PrinterModel.lp2844ups;
+
             case 'LP2824-Z-200dpi':
                 return PrinterModel.lp2824z;
             case 'LP2844-Z-200dpi':
@@ -45,12 +49,20 @@ export class PrinterModelDb {
         // TODO: Make this extensible so it's possible for consumers to add their own
         // printers to the enum, match list, etc.
         switch (model) {
+            // LP models, direct thermal only.
             case PrinterModel.lp2824:
                 return new EPL.LP2824();
             case PrinterModel.lp2844:
             case PrinterModel.lp2844fedex:
             case PrinterModel.lp2844ups:
                 return new EPL.LP2844();
+
+            // TLP models, direct thermal or thermal transfer.
+            case PrinterModel.tlp2824:
+                return new EPL.TLP2824();
+            case PrinterModel.tlp2844:
+                return new EPL.TLP2844();
+
             default:
                 return new UnknownPrinter();
         }

--- a/src/Printers/Models/PrinterModelDb.ts
+++ b/src/Printers/Models/PrinterModelDb.ts
@@ -23,6 +23,9 @@ export class PrinterModelDb {
         // TODO: Make this extensible so it's possible for consumers to add their own
         // printers to the enum, match list, etc.
         switch (rawModelId) {
+            case 'UKQ1915  U':
+                // TODO: This is an educated guess, validate it!
+                return PrinterModel.tlp2824;
             case 'UKQ1935  U':
                 return PrinterModel.tlp2844;
 


### PR DESCRIPTION
The very lovely to work with [Pupsaur](https://linktr.ee/pupsaur) reported having issues with a TLP2844 unit. I don't have any TLP EPL printers so didn't have them in the detection list yet.

Apparently TLP2844 units report as `UKQ1935  U`, note the two spaces in there. This contrasts with LP2844 units which tend to report as `UKQ1935HLU`. I've added an educated guess that TLP2824 units will follow this pattern with `UKQ1915  U` as well but can't validate.

This is considered a patch release as it doesn't functionally change much.