### PR TITLE
Add backfeed suppression and update settings interface

### DIFF
--- a/demo/advanced.html
+++ b/demo/advanced.html
@@ -105,32 +105,32 @@
         const refreshPrinterBtn = document.getElementById('refreshPrinters')!;
         refreshPrinterBtn.addEventListener('click', async () => printerMgr.forceReconnect());
 
-        // Next we wire up some events on the PrinterUsbManager itself.
+        // Next we wire up some events on the UsbDeviceManager itself.
         printerMgr.addEventListener('connectedDevice', ({ detail }) => {
 
-            // Let's print some details about the printer that was connected.
-            const printer = detail.device;
-            console.log('New printer is a', printer.printerModel);
-            const config = printer.printerOptions;
-            console.log('Printer darkness is', config.darknessPercent, 'percent');
-            console.log('Printer speed is', WebLabel.PrintSpeed[config.speed.printSpeed]);
-            console.log(
-                'Label is',
-                config.mediaWidthInches,
-                'in wide and',
-                config.mediaLengthInches,
-                'in long');
-            console.log('Printer media mode is', WebLabel.MediaMediaGapDetectionMode[config.mediaGapDetectMode]);
+          // Let's print some details about the printer that was connected.
+          const printer = detail.device;
+          console.log('New printer is a', printer.printerModel);
+          const config = printer.printerOptions;
+          console.log('Printer darkness is', config.darknessPercent, 'percent');
+          console.log('Printer speed is', WebLabel.PrintSpeed[config.speed.printSpeed]);
+          console.log(
+            'Label is',
+            config.mediaWidthInches,
+            'in wide and',
+            config.mediaLengthInches,
+            'in long');
+          console.log('Printer media mode is', WebLabel.MediaMediaGapDetectionMode[config.mediaGapDetectMode]);
 
-            // You can do stuff with the printer that connected. It's a good idea
-            // to immediately query the printer for its status.
-            printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
+          // You can do stuff with the printer that connected. It's a good idea
+          // to immediately query the printer for its status.
+          printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
         });
 
         // There's also an event that will tell you when a printer disconnects.
         printerMgr.addEventListener('disconnectedDevice', ({ detail }) => {
-            const printer = detail.device;
-            console.log('Lost printer', printer.printerModel, 'serial', printer.printerOptions.serialNumber);
+          const printer = detail.device;
+          console.log('Lost printer', printer.printerModel, 'serial', printer.printerOptions.serialNumber);
         });
 
         // When the browser first loaded the page any previously connected printers would have caused
@@ -147,192 +147,192 @@
 
         // First we create an interface to describe our settings form.
         interface ConfigModalForm extends HTMLCollection {
-            modalCancel         : HTMLButtonElement
-            modalDarkness       : HTMLSelectElement
-            modalLabelHeight    : HTMLInputElement
-            modalLabelOffsetLeft: HTMLInputElement
-            modalLabelOffsetTop : HTMLInputElement
-            modalLabelWidth     : HTMLInputElement
-            modalMediaType      : HTMLSelectElement
-            modalSpeed          : HTMLSelectElement
-            modalSubmit         : HTMLButtonElement
-            modalWithAutosense  : HTMLInputElement
+          modalCancel         : HTMLButtonElement
+          modalDarkness       : HTMLSelectElement
+          modalLabelHeight    : HTMLInputElement
+          modalLabelOffsetLeft: HTMLInputElement
+          modalLabelOffsetTop : HTMLInputElement
+          modalLabelWidth     : HTMLInputElement
+          modalMediaType      : HTMLSelectElement
+          modalSpeed          : HTMLSelectElement
+          modalSubmit         : HTMLButtonElement
+          modalWithAutosense  : HTMLInputElement
         }
 
         // The app's logic is wrapped in a class just for ease of reading.
         class BasicLabelDesignerApp {
-            constructor(
-                private manager: PrinterManager,
-                private btnContainer: HTMLElement,
-                private labelForm: HTMLElement,
-                private labelFormInstructions: HTMLElement,
-                private configModal: HTMLElement
-            ) {
-                // Based on the containers, map the various listeners.
-                this.configModalHandle = new bootstrap.Modal(this.configModal);
-                this.configModal
-                    .querySelector('form')!
-                    .addEventListener('submit', this.updatePrinterConfig.bind(this));
-                this.labelForm.addEventListener('blur', this.renderTextForm.bind(this));
-                this.labelForm.addEventListener('keyup', this.renderTextForm.bind(this));
+          constructor(
+            private manager: PrinterManager,
+            private btnContainer: HTMLElement,
+            private labelForm: HTMLElement,
+            private labelFormInstructions: HTMLElement,
+            private configModal: HTMLElement
+          ) {
+            // Based on the containers, map the various listeners.
+            this.configModalHandle = new bootstrap.Modal(this.configModal);
+            this.configModal
+              .querySelector('form')!
+              .addEventListener('submit', this.updatePrinterConfig.bind(this));
+            this.labelForm.addEventListener('blur', this.renderTextForm.bind(this));
+            this.labelForm.addEventListener('keyup', this.renderTextForm.bind(this));
 
-                // Add a second set of event listeners for printer connect and disconnect to redraw
-                // the printer list when it changes.
-                this.manager.addEventListener('connectedDevice', ({detail}) => {
-                    this.activePrinterIndex = -1;
-                    this.redrawPrinterButtons();
+            // Add a second set of event listeners for printer connect and disconnect to redraw
+            // the printer list when it changes.
+            this.manager.addEventListener('connectedDevice', ({ detail }) => {
+              this.activePrinterIndex = -1;
+              this.redrawPrinterButtons();
 
-                    // Printers themselves also have events, let's show an alert on errors.
-                    const printer = detail.device;
-                    printer.addEventListener('reportedError', ({ detail: msg }) => {
-                        // Error messages may indicate no error, we can ignore those.
-                        if (msg.errors.has(WebLabel.ErrorState.NoError)) { return; }
+              // Printers themselves also have events, let's show an alert on errors.
+              const printer = detail.device;
+              printer.addEventListener('reportedError', ({ detail: msg }) => {
+                // Error messages may indicate no error, we can ignore those.
+                if (msg.errors.has(WebLabel.ErrorState.NoError)) { return; }
 
-                        const alertWrapper = document.createElement('div');
-                        alertWrapper.innerHTML = `
-                        <div class="alert alert-warning alert-dismissible fade show alert-printererror" role="alert">
-                            <h4>Printer <strong>${printer.printerSerial}</strong> has an error</h4>
-                            <p>${JSON.stringify(msg, null, 2)}</p>
-                            <hr>
-                            <p>Fix the issue, then dismiss this alert to check the status again.</p>
-                            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                        </div>`
-                        document.getElementById('printerAlertSpace')?.appendChild(alertWrapper);
+                const alertWrapper = document.createElement('div');
+                alertWrapper.innerHTML = `
+                  <div class="alert alert-warning alert-dismissible fade show alert-printererror" role="alert">
+                      <h4>Printer <strong>${printer.printerSerial}</strong> has an error</h4>
+                      <p>${JSON.stringify(msg, null, 2)}</p>
+                      <hr>
+                      <p>Fix the issue, then dismiss this alert to check the status again.</p>
+                      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                  </div>`
+                document.getElementById('printerAlertSpace')?.appendChild(alertWrapper);
 
-                        // and even go one layer deeper!
-                        alertWrapper.firstElementChild!.addEventListener('closed.bs.alert', () => {
-                            printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
-                        });
-                    });
+                // and even go one layer deeper!
+                alertWrapper.firstElementChild!.addEventListener('closed.bs.alert', () => {
+                  printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
                 });
-                this.manager.addEventListener('disconnectedDevice', () => {
-                    this.activePrinterIndex = -1;
-                    this.redrawPrinterButtons();
-                });
+              });
+            });
+            this.manager.addEventListener('disconnectedDevice', () => {
+              this.activePrinterIndex = -1;
+              this.redrawPrinterButtons();
+            });
 
-                // Here's a nice font with a great set of emoji that work well for monochrome printing.
-                // The text font is fairly basic though, so we would like to use only the emoji out
-                // of this font and use a basic sans-serif font for regular text.
-                // https://fonts.google.com/noto/specimen/Noto+Emoji
-                const emojiFontName = 'noto-emoji';
+            // Here's a nice font with a great set of emoji that work well for monochrome printing.
+            // The text font is fairly basic though, so we would like to use only the emoji out
+            // of this font and use a basic sans-serif font for regular text.
+            // https://fonts.google.com/noto/specimen/Noto+Emoji
+            const emojiFontName = 'noto-emoji';
 
-                // We can accomplish this with the unicodeRange property of our FontFace. We just
-                // need to list EVERY SINGLE EMOJI UNICODE RANGE to make it work. Fortunately someone
-                // has done this already: https://github.com/fraction/emoji-unicode-range
-                const emojiUnicodeRange = 'U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2604,U+260E,U+2611,U+2614-2615,U+2618,U+261D,U+2620,U+2622-2623,U+2626,U+262A,U+262E-262F,U+2638-263A,U+2640,U+2642,U+2648-2653,U+265F-2660,U+2663,U+2665-2666,U+2668,U+267B,U+267E-267F,U+2692-2697,U+2699,U+269B-269C,U+26A0-26A1,U+26AA-26AB,U+26B0-26B1,U+26BD-26BE,U+26C4-26C5,U+26C8,U+26CE,U+26CF,U+26D1,U+26D3-26D4,U+26E9-26EA,U+26F0-26F5,U+26F7-26FA,U+26FD,U+2702,U+2705,U+2708-2709,U+270A-270B,U+270C-270D,U+270F,U+2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2764,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F004,U+1F0CF,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201-1F202,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F321,U+1F324-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F396-1F397,U+1F399-1F39B,U+1F39E-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F3-1F3F5,U+1F3F7,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD,U+1F4FF,U+1F500-1F53D,U+1F549-1F54A,U+1F54B-1F54E,U+1F550-1F567,U+1F56F-1F570,U+1F573-1F579,U+1F57A,U+1F587,U+1F58A-1F58D,U+1F590,U+1F595-1F596,U+1F5A4,U+1F5A5,U+1F5A8,U+1F5B1-1F5B2,U+1F5BC,U+1F5C2-1F5C4,U+1F5D1-1F5D3,U+1F5DC-1F5DE,U+1F5E1,U+1F5E3,U+1F5E8,U+1F5EF,U+1F5F3,U+1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CB-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6E0-1F6E5,U+1F6E9,U+1F6EB-1F6EC,U+1F6F0,U+1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+231A-231B,U+23E9-23EC,U+23F0,U+23F3,U+25FD-25FE,U+2614-2615,U+2648-2653,U+267F,U+2693,U+26A1,U+26AA-26AB,U+26BD-26BE,U+26C4-26C5,U+26CE,U+26D4,U+26EA,U+26F2-26F3,U+26F5,U+26FA,U+26FD,U+2705,U+270A-270B,U+2728,U+274C,U+274E,U+2753-2755,U+2757,U+2795-2797,U+27B0,U+27BF,U+2B1B-2B1C,U+2B50,U+2B55,U+1F004,U+1F0CF,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201,U+1F21A,U+1F22F,U+1F232-1F236,U+1F238-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F32D-1F32F,U+1F330-1F335,U+1F337-1F37C,U+1F37E-1F37F,U+1F380-1F393,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CF-1F3D3,U+1F3E0-1F3F0,U+1F3F4,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F440,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FF,U+1F500-1F53D,U+1F54B-1F54E,U+1F550-1F567,U+1F57A,U+1F595-1F596,U+1F5A4,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CC,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6EB-1F6EC,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+1F3FB-1F3FF,U+261D,U+26F9,U+270A-270B,U+270C-270D,U+1F385,U+1F3C2-1F3C4,U+1F3C7,U+1F3CA,U+1F3CB-1F3CC,U+1F442-1F443,U+1F446-1F450,U+1F466-1F478,U+1F47C,U+1F481-1F483,U+1F485-1F487,U+1F48F,U+1F491,U+1F4AA,U+1F574-1F575,U+1F57A,U+1F590,U+1F595-1F596,U+1F645-1F647,U+1F64B-1F64F,U+1F6A3,U+1F6B4-1F6B6,U+1F6C0,U+1F6CC,U+1F90F,U+1F918,U+1F919-1F91E,U+1F91F,U+1F926,U+1F930,U+1F931-1F932,U+1F933-1F939,U+1F93C-1F93E,U+1F9B5-1F9B6,U+1F9B8-1F9B9,U+1F9BB,U+1F9CD-1F9CF,U+1F9D1-1F9DD,U+0023,U+002A,U+0030-0039,U+200D,U+20E3,U+FE0F,U+1F1E6-1F1FF,U+1F3FB-1F3FF,U+1F9B0-1F9B3,U+E0020-E007F,U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+2388,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2605,U+2607-2612,U+2614-2615,U+2616-2617,U+2618,U+2619,U+261A-266F,U+2670-2671,U+2672-267D,U+267E-267F,U+2680-2685,U+2690-2691,U+2692-269C,U+269D,U+269E-269F,U+26A0-26A1,U+26A2-26B1,U+26B2,U+26B3-26BC,U+26BD-26BF,U+26C0-26C3,U+26C4-26CD,U+26CE,U+26CF-26E1,U+26E2,U+26E3,U+26E4-26E7,U+26E8-26FF,U+2700,U+2701-2704,U+2705,U+2708-2709,U+270A-270B,U+270C-2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2767,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F000-1F02B,U+1F02C-1F02F,U+1F030-1F093,U+1F094-1F09F,U+1F0A0-1F0AE,U+1F0AF-1F0B0,U+1F0B1-1F0BE,U+1F0BF,U+1F0C0,U+1F0C1-1F0CF,U+1F0D0,U+1F0D1-1F0DF,U+1F0E0-1F0F5,U+1F0F6-1F0FF,U+1F10D-1F10F,U+1F12F,U+1F16C,U+1F16D-1F16F,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1AD-1F1E5,U+1F201-1F202,U+1F203-1F20F,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F23C-1F23F,U+1F249-1F24F,U+1F250-1F251,U+1F252-1F25F,U+1F260-1F265,U+1F266-1F2FF,U+1F300-1F320,U+1F321-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F394-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F1-1F3F7,U+1F3F8-1F3FA,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD-1F4FE,U+1F4FF,U+1F500-1F53D,U+1F546-1F54A,U+1F54B-1F54F,U+1F550-1F567,U+1F568-1F579,U+1F57A,U+1F57B-1F5A3,U+1F5A4,U+1F5A5-1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6C6-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D3-1F6D4,U+1F6D5,U+1F6D6-1F6DF,U+1F6E0-1F6EC,U+1F6ED-1F6EF,U+1F6F0-1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F6FB-1F6FF,U+1F774-1F77F,U+1F7D5-1F7D8,U+1F7D9-1F7DF,U+1F7E0-1F7EB,U+1F7EC-1F7FF,U+1F80C-1F80F,U+1F848-1F84F,U+1F85A-1F85F,U+1F888-1F88F,U+1F8AE-1F8FF,U+1F90C,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F972,U+1F973-1F976,U+1F977-1F979,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A3-1F9A4,U+1F9A5-1F9AA,U+1F9AB-1F9AD,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CB-1F9CC,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA00-1FA53,U+1FA54-1FA5F,U+1FA60-1FA6D,U+1FA6E-1FA6F,U+1FA70-1FA73,U+1FA74-1FA77,U+1FA78-1FA7A,U+1FA7B-1FA7F,U+1FA80-1FA82,U+1FA83-1FA8F,U+1FA90-1FA95,U+1FA96-1FFFD';
+            // We can accomplish this with the unicodeRange property of our FontFace. We just
+            // need to list EVERY SINGLE EMOJI UNICODE RANGE to make it work. Fortunately someone
+            // has done this already: https://github.com/fraction/emoji-unicode-range
+            const emojiUnicodeRange = 'U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2604,U+260E,U+2611,U+2614-2615,U+2618,U+261D,U+2620,U+2622-2623,U+2626,U+262A,U+262E-262F,U+2638-263A,U+2640,U+2642,U+2648-2653,U+265F-2660,U+2663,U+2665-2666,U+2668,U+267B,U+267E-267F,U+2692-2697,U+2699,U+269B-269C,U+26A0-26A1,U+26AA-26AB,U+26B0-26B1,U+26BD-26BE,U+26C4-26C5,U+26C8,U+26CE,U+26CF,U+26D1,U+26D3-26D4,U+26E9-26EA,U+26F0-26F5,U+26F7-26FA,U+26FD,U+2702,U+2705,U+2708-2709,U+270A-270B,U+270C-270D,U+270F,U+2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2764,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F004,U+1F0CF,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201-1F202,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F321,U+1F324-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F396-1F397,U+1F399-1F39B,U+1F39E-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F3-1F3F5,U+1F3F7,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD,U+1F4FF,U+1F500-1F53D,U+1F549-1F54A,U+1F54B-1F54E,U+1F550-1F567,U+1F56F-1F570,U+1F573-1F579,U+1F57A,U+1F587,U+1F58A-1F58D,U+1F590,U+1F595-1F596,U+1F5A4,U+1F5A5,U+1F5A8,U+1F5B1-1F5B2,U+1F5BC,U+1F5C2-1F5C4,U+1F5D1-1F5D3,U+1F5DC-1F5DE,U+1F5E1,U+1F5E3,U+1F5E8,U+1F5EF,U+1F5F3,U+1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CB-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6E0-1F6E5,U+1F6E9,U+1F6EB-1F6EC,U+1F6F0,U+1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+231A-231B,U+23E9-23EC,U+23F0,U+23F3,U+25FD-25FE,U+2614-2615,U+2648-2653,U+267F,U+2693,U+26A1,U+26AA-26AB,U+26BD-26BE,U+26C4-26C5,U+26CE,U+26D4,U+26EA,U+26F2-26F3,U+26F5,U+26FA,U+26FD,U+2705,U+270A-270B,U+2728,U+274C,U+274E,U+2753-2755,U+2757,U+2795-2797,U+27B0,U+27BF,U+2B1B-2B1C,U+2B50,U+2B55,U+1F004,U+1F0CF,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201,U+1F21A,U+1F22F,U+1F232-1F236,U+1F238-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F32D-1F32F,U+1F330-1F335,U+1F337-1F37C,U+1F37E-1F37F,U+1F380-1F393,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CF-1F3D3,U+1F3E0-1F3F0,U+1F3F4,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F440,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FF,U+1F500-1F53D,U+1F54B-1F54E,U+1F550-1F567,U+1F57A,U+1F595-1F596,U+1F5A4,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CC,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6EB-1F6EC,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+1F3FB-1F3FF,U+261D,U+26F9,U+270A-270B,U+270C-270D,U+1F385,U+1F3C2-1F3C4,U+1F3C7,U+1F3CA,U+1F3CB-1F3CC,U+1F442-1F443,U+1F446-1F450,U+1F466-1F478,U+1F47C,U+1F481-1F483,U+1F485-1F487,U+1F48F,U+1F491,U+1F4AA,U+1F574-1F575,U+1F57A,U+1F590,U+1F595-1F596,U+1F645-1F647,U+1F64B-1F64F,U+1F6A3,U+1F6B4-1F6B6,U+1F6C0,U+1F6CC,U+1F90F,U+1F918,U+1F919-1F91E,U+1F91F,U+1F926,U+1F930,U+1F931-1F932,U+1F933-1F939,U+1F93C-1F93E,U+1F9B5-1F9B6,U+1F9B8-1F9B9,U+1F9BB,U+1F9CD-1F9CF,U+1F9D1-1F9DD,U+0023,U+002A,U+0030-0039,U+200D,U+20E3,U+FE0F,U+1F1E6-1F1FF,U+1F3FB-1F3FF,U+1F9B0-1F9B3,U+E0020-E007F,U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+2388,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2605,U+2607-2612,U+2614-2615,U+2616-2617,U+2618,U+2619,U+261A-266F,U+2670-2671,U+2672-267D,U+267E-267F,U+2680-2685,U+2690-2691,U+2692-269C,U+269D,U+269E-269F,U+26A0-26A1,U+26A2-26B1,U+26B2,U+26B3-26BC,U+26BD-26BF,U+26C0-26C3,U+26C4-26CD,U+26CE,U+26CF-26E1,U+26E2,U+26E3,U+26E4-26E7,U+26E8-26FF,U+2700,U+2701-2704,U+2705,U+2708-2709,U+270A-270B,U+270C-2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2767,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F000-1F02B,U+1F02C-1F02F,U+1F030-1F093,U+1F094-1F09F,U+1F0A0-1F0AE,U+1F0AF-1F0B0,U+1F0B1-1F0BE,U+1F0BF,U+1F0C0,U+1F0C1-1F0CF,U+1F0D0,U+1F0D1-1F0DF,U+1F0E0-1F0F5,U+1F0F6-1F0FF,U+1F10D-1F10F,U+1F12F,U+1F16C,U+1F16D-1F16F,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1AD-1F1E5,U+1F201-1F202,U+1F203-1F20F,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F23C-1F23F,U+1F249-1F24F,U+1F250-1F251,U+1F252-1F25F,U+1F260-1F265,U+1F266-1F2FF,U+1F300-1F320,U+1F321-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F394-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F1-1F3F7,U+1F3F8-1F3FA,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD-1F4FE,U+1F4FF,U+1F500-1F53D,U+1F546-1F54A,U+1F54B-1F54F,U+1F550-1F567,U+1F568-1F579,U+1F57A,U+1F57B-1F5A3,U+1F5A4,U+1F5A5-1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6C6-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D3-1F6D4,U+1F6D5,U+1F6D6-1F6DF,U+1F6E0-1F6EC,U+1F6ED-1F6EF,U+1F6F0-1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F6FB-1F6FF,U+1F774-1F77F,U+1F7D5-1F7D8,U+1F7D9-1F7DF,U+1F7E0-1F7EB,U+1F7EC-1F7FF,U+1F80C-1F80F,U+1F848-1F84F,U+1F85A-1F85F,U+1F888-1F88F,U+1F8AE-1F8FF,U+1F90C,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F972,U+1F973-1F976,U+1F977-1F979,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A3-1F9A4,U+1F9A5-1F9AA,U+1F9AB-1F9AD,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CB-1F9CC,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA00-1FA53,U+1FA54-1FA5F,U+1FA60-1FA6D,U+1FA6E-1FA6F,U+1FA70-1FA73,U+1FA74-1FA77,U+1FA78-1FA7A,U+1FA7B-1FA7F,U+1FA80-1FA82,U+1FA83-1FA8F,U+1FA90-1FA95,U+1FA96-1FFFD';
 
-                // And then we can use that range with our font when we load it.
-                const emojiOnlyFont = new FontFace(emojiFontName, 'url(fonts/NotoEmoji-Regular.ttf)', {
-                  unicodeRange: emojiUnicodeRange,
-                });
-                emojiOnlyFont.load().then(() => {
-                    document.fonts.add(emojiOnlyFont);
-                });
-                // We then set our fallback font as part of the font family we use in the canvas.
-                // This order matters, latter fonts will use the unicodeRange to override earlier fonts.
-                this.fontName = `Sans-serif, ${emojiFontName}`
+            // And then we can use that range with our font when we load it.
+            const emojiOnlyFont = new FontFace(emojiFontName, 'url(fonts/NotoEmoji-Regular.ttf)', {
+              unicodeRange: emojiUnicodeRange,
+            });
+            emojiOnlyFont.load().then(() => {
+              document.fonts.add(emojiOnlyFont);
+            });
+            // We then set our fallback font as part of the font family we use in the canvas.
+            // This order matters, latter fonts will use the unicodeRange to override earlier fonts.
+            this.fontName = `Sans-serif, ${emojiFontName}`
+          }
+
+          // Some storage fields and utility properties
+          private fontName: string;
+          private configModalHandle: bootstrap.Modal;
+
+          get printers(): readonly WebLabel.LabelPrinterUsb[] {
+            return this.manager.devices;
+          }
+
+          // Track which printer is currently selected for operations
+          private _activePrinter = 0;
+          get activePrinter(): WebLabel.LabelPrinterUsb | undefined {
+            return this._activePrinter < 0 || this._activePrinter > this.printers.length
+              ? undefined
+              : this.printers[this._activePrinter];
+          }
+          set activePrinterIndex(printerIdx: number) {
+            this._activePrinter = printerIdx;
+            this.redrawTextCanvas();
+          }
+
+          /** Initialize the app */
+          public async init() {
+            this.redrawPrinterButtons();
+            this.redrawTextCanvas();
+          }
+
+          /** Display the configuration for a printer. */
+          public showConfigModal(printer: WebLabel.LabelPrinterUsb, printerIdx: number) {
+            if (printer == undefined) {
+              return;
+            }
+            const config = printer.printerOptions;
+
+            // Translate the available speeds to options to be selected
+            const speedSelect = this.configModal.querySelector('#modalSpeed')! as HTMLSelectElement;
+            speedSelect.innerHTML = '';
+            const speedTable = printer.printerOptions.speedTable.table;
+            for (const [key] of speedTable) {
+              // Skip utility values, so long as there's more than the defaults.
+              // Mobile printers *only* support auto, for example.
+              if ((speedTable.size > 3)
+                && (key === WebLabel.PrintSpeed.ipsAuto
+                  || key === WebLabel.PrintSpeed.ipsPrinterMax
+                  || key === WebLabel.PrintSpeed.ipsPrinterMin
+                )) {
+                continue;
+              }
+              const opt = document.createElement('option');
+              opt.value = key.toString();
+              opt.innerHTML = WebLabel.PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
+              speedSelect.appendChild(opt);
+            }
+            speedSelect.value = config.speed.printSpeed.toString();
+
+            const mediaSelect = this.configModal.querySelector('#modalMediaType')! as HTMLSelectElement;
+            switch (config.mediaGapDetectMode) {
+              case WebLabel.MediaMediaGapDetectionMode.continuous:
+                mediaSelect.value = "continuous";
+                break;
+              default:
+              case WebLabel.MediaMediaGapDetectionMode.webSensing:
+                mediaSelect.value = "gap";
+                break;
+              case WebLabel.MediaMediaGapDetectionMode.markSensing:
+                mediaSelect.value = "mark";
+                break;
             }
 
-            // Some storage fields and utility properties
-            private fontName: string;
-            private configModalHandle: bootstrap.Modal;
+            (this.configModal.querySelector('#modalPrinterIndex')     as HTMLInputElement)!.value = config.serialNumber;
+            (this.configModal.querySelector('#modalPrinterIndexText') as HTMLSelectElement)!.textContent = printerIdx.toString();
+            (this.configModal.querySelector('#modalLabelWidth')       as HTMLSelectElement)!.value = config.mediaWidthInches.toString();
+            (this.configModal.querySelector('#modalLabelHeight')      as HTMLSelectElement)!.value = config.mediaLengthInches.toString();
+            (this.configModal.querySelector('#modalDarkness')         as HTMLSelectElement)!.value = config.darknessPercent.toString();
+            (this.configModal.querySelector('#modalLabelOffsetLeft')  as HTMLSelectElement)!.value = config.mediaPrintOriginOffsetDots.left.toString();
+            (this.configModal.querySelector('#modalLabelOffsetTop')   as HTMLSelectElement)!.value = config.mediaPrintOriginOffsetDots.top.toString();
+            this.configModalHandle.show();
+          }
 
-            get printers() {
-                return this.manager.devices;
-            }
+          /** Erase and re-draw the list of printer buttons in the UI. */
+          private redrawPrinterButtons() {
+            this.btnContainer.innerHTML = '';
+            this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
+          }
 
-            // Track which printer is currently selected for operations
-            private _activePrinter = 0;
-            get activePrinter(): WebLabel.LabelPrinterUsb | undefined {
-                return this._activePrinter < 0 || this._activePrinter > this.printers.length
-                    ? undefined
-                    : this.printers[this._activePrinter];
-            }
-            set activePrinterIndex(printerIdx: number) {
-                this._activePrinter = printerIdx;
-                this.redrawTextCanvas();
-            }
+          /** Highlight only the currently selected printer. */
+          private redrawPrinterButtonHighlights() {
+            this.printers.forEach((printer, idx) => {
+              const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
+              const element = document.getElementById(`printer_${idx}`)!;
+              element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
+            });
+          }
 
-            /** Initialize the app */
-            public async init() {
-                this.redrawPrinterButtons();
-                this.redrawTextCanvas();
-            }
+          /** Add a printer's button UI to the list of printers. */
+          private drawPrinterButton(printer: WebLabel.LabelPrinterUsb, idx: number) {
+            const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
 
-            /** Display the configuration for a printer. */
-            public showConfigModal(printer: WebLabel.LabelPrinterUsb, printerIdx: number) {
-                if (printer == undefined) {
-                    return;
-                }
-                const config = printer.printerOptions;
-
-                // Translate the available speeds to options to be selected
-                const speedSelect = this.configModal.querySelector('#modalSpeed')! as HTMLSelectElement;
-                speedSelect.innerHTML = '';
-                const speedTable = printer.printerOptions.speedTable.table;
-                for (const [key] of speedTable) {
-                    // Skip utility values, so long as there's more than the defaults.
-                    // Mobile printers *only* support auto, for example.
-                    if ((speedTable.size > 3)
-                        && (key === WebLabel.PrintSpeed.ipsAuto
-                            || key === WebLabel.PrintSpeed.ipsPrinterMax
-                            || key === WebLabel.PrintSpeed.ipsPrinterMin
-                    )) {
-                        continue;
-                    }
-                    const opt = document.createElement('option');
-                    opt.value = key.toString();
-                    opt.innerHTML = WebLabel.PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
-                    speedSelect.appendChild(opt);
-                }
-                speedSelect.value = config.speed.printSpeed.toString();
-
-                const mediaSelect = this.configModal.querySelector('#modalMediaType')! as HTMLSelectElement;
-                switch (config.mediaGapDetectMode) {
-                    case WebLabel.MediaMediaGapDetectionMode.continuous:
-                        mediaSelect.value = "continuous";
-                        break;
-                    default:
-                    case WebLabel.MediaMediaGapDetectionMode.webSensing:
-                        mediaSelect.value = "gap";
-                        break;
-                    case WebLabel.MediaMediaGapDetectionMode.markSensing:
-                        mediaSelect.value = "mark";
-                        break;
-                }
-
-                (this.configModal.querySelector('#modalPrinterIndex') as HTMLInputElement)!.value            = config.serialNumber;
-                (this.configModal.querySelector('#modalPrinterIndexText') as HTMLSelectElement)!.textContent = printerIdx.toString();
-                (this.configModal.querySelector('#modalLabelWidth') as HTMLSelectElement)!.value             = config.mediaWidthInches.toString();
-                (this.configModal.querySelector('#modalLabelHeight') as HTMLSelectElement)!.value            = config.mediaLengthInches.toString();
-                (this.configModal.querySelector('#modalDarkness') as HTMLSelectElement)!.value               = config.darknessPercent.toString();
-                (this.configModal.querySelector('#modalLabelOffsetLeft') as HTMLSelectElement)!.value        = config.mediaPrintOriginOffsetDots.left.toString();
-                (this.configModal.querySelector('#modalLabelOffsetTop') as HTMLSelectElement)!.value         = config.mediaPrintOriginOffsetDots.top.toString();
-                this.configModalHandle.show();
-            }
-
-            /** Erase and re-draw the list of printer buttons in the UI. */
-            private redrawPrinterButtons() {
-                this.btnContainer.innerHTML = '';
-                this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
-            }
-
-            /** Highlight only the currently selected printer. */
-            private redrawPrinterButtonHighlights() {
-                this.printers.forEach((printer, idx) => {
-                  const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
-                    const element = document.getElementById(`printer_${idx}`)!;
-                    element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
-                });
-            }
-
-            /** Add a printer's button UI to the list of printers. */
-            private drawPrinterButton(printer: WebLabel.LabelPrinterUsb, idx: number) {
-                const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
-
-                // Generate a new label printer button for the given printer.
-                const element = document.createElement("div");
-                element.innerHTML = `
+            // Generate a new label printer button for the given printer.
+            const element = document.createElement("div");
+            element.innerHTML = `
             <li id="printer_${idx}" data-printer-idx="${idx}"
                 class="list-group-item d-flex flex-row justify-content-between sligh-items-start"
                 style="background: linear-gradient(to right, ${highlight}, ${highlight}, grey, grey);">
@@ -368,201 +368,201 @@
                     </div>
                 </div>
             </li>`;
-                // And slap it into the button container.
-                this.btnContainer.appendChild(element);
+            // And slap it into the button container.
+            this.btnContainer.appendChild(element);
 
-                // Then wire up the button events so they work.
-                document.getElementById(`printto_${idx}`)!
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                        const printer = this.printers[printerIdx];
-                        const doc = this.addCanvasImageToLabelDoc(printer.getLabelDocument());
-                        await printer.sendDocument(doc);
-                    });
-                document.getElementById(`printer_${idx}`)!
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                        if (this._activePrinter === printerIdx) {
-                            // Don't refresh anything if we already have this printer selected..
-                            return;
-                        }
-                        this.activePrinterIndex = printerIdx;
-                        this.redrawPrinterButtonHighlights();
-                        this.redrawTextCanvas();
-                    });
-                document.getElementById(`printtest_${idx}`)!
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                        const printer = this.printers[printerIdx];
-                        const doc = WebLabel.ReadyToPrintDocuments.printTestLabelDocument(
-                            printer.printerOptions.mediaWidthDots);
-                        await printer.sendDocument(doc);
-                    });
-                document.getElementById(`feedlabel_${idx}`)!
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                        const printer = this.printers[printerIdx];
-                        const doc = WebLabel.ReadyToPrintDocuments.feedLabelDocument;
-                        await printer.sendDocument(doc);
-                    });
-                document.getElementById(`printconfig_${idx}`)!
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                        const printer = this.printers[printerIdx];
-                        const doc = WebLabel.ReadyToPrintDocuments.printConfigDocument;
-                        await printer.sendDocument(doc);
-                    });
-                document.getElementById(`configprinter_${idx}`)!
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                        const printer = this.printers[printerIdx];
-                        this.showConfigModal(printer, printerIdx);
-                    });
-            }
-
-            /** Redraw the text canvas size according to the printer. */
-            private redrawTextCanvas() {
-                const printer = this.activePrinter;
-                if (printer === undefined) {
-                    this.labelForm.classList.add('d-none');
-                    this.labelFormInstructions.classList.remove('d-none');
-                    return;
-                } else {
-                    this.labelForm.classList.remove('d-none');
-                    this.labelFormInstructions.classList.add('d-none');
-                }
-
-                // Resize the canvas to match the label size.
-                const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-                // Add a small margin as printer alignment is not exact.
-                canvas.width = printer.printerOptions.mediaWidthDots - 2;
-                canvas.height = printer.printerOptions.mediaLengthDots - 2;
-
-                const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-                textarea.value = "Enter your label text here!";
-                this.renderTextForm();
-            }
-
-            /** Render the text form to the canvas */
-            private renderTextForm() {
-                const printer = this.activePrinter;
-                if (printer === undefined) {
-                    return;
-                }
-
-                const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-                const fontsizer = this.labelForm.querySelector('#previewFontSize') as HTMLInputElement;
-                const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-                const pageContext = canvas.getContext('2d')!;
-                pageContext.clearRect(0, 0, canvas.width, canvas.height);
-
-                const fontSize = Math.trunc(parseFloat(fontsizer.value));
-
-                // We'd like the preview image to be as close as possible to what the printer will
-                // actually print. To do this we don't draw text to the page's canvas directly,
-                // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
-                // then render *that* back to the page's canvas. This is a more accurate picture of
-                // what the label will end up looking like.
-
-                // A more complex app could do this more gracefully!
-                const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d')!;
-                offscreenContext.font = `${fontSize}pt ${this.fontName}`;
-                offscreenContext.fillStyle = "#000000";
-
-                // fillText doesn't do newlines, do that manually
-                textarea.value.split('\n').forEach((l, i) => {
-                    offscreenContext.fillText(l, 5, (i * fontSize + 2) + fontSize);
-                })
-
-                // Now into the monochrome bitmap.
-                const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
-                const monoImg = WebLabel.BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
-                // And finally back onto the page.
-                pageContext.putImageData(monoImg.toImageData(), 0, 0);
-            }
-
-            /** Render the canvas to a document for printing */
-            private addCanvasImageToLabelDoc(builder: WebLabel.ILabelDocumentBuilder): WebLabel.IDocument {
-                const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-                const imgData = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
-
-                // One of the benefits of this library is being able to render images to a canvas element
-                // and sending that canvas directly to a label. This allows your webpage to generate complex
-                // images and fonts (like emoji!) that EPL/ZPL can't support.
-                return builder
-                    .addImageFromImageData(imgData)
-                    .addPrintCmd()
-                    .finalize();
-            }
-
-            /** Send the contents of the config form as a config label to the printer. */
-            private async updatePrinterConfig(e: SubmitEvent) {
+            // Then wire up the button events so they work.
+            document.getElementById(`printto_${idx}`)!
+              .addEventListener('click', async (e) => {
                 e.preventDefault();
-
-                // Figure out the right printer
-                const formElement = this.configModal.querySelector('form')!;
-                const form = formElement.elements as ConfigModalForm;
-                const printerIdx = parseInt((formElement.querySelector('#modalPrinterIndexText') as HTMLFormElement).innerText);
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
                 const printer = this.printers[printerIdx];
-                if (printer === undefined) {
-                    return;
-                }
-
-                form.modalSubmit.setAttribute("disabled", "");
-                form.modalCancel.setAttribute("disabled", "");
-
-                // Pull the values out of the form.
-                const darkness         = parseInt(form.modalDarkness.value) as WebLabel.DarknessPercent;
-                const rawSpeed         = parseInt(form.modalSpeed.value) as WebLabel.PrintSpeed;
-                const mediaWidthInches = parseFloat(form.modalLabelWidth.value);
-                const autosense        = form.modalWithAutosense.checked;
-
-                const mediaLengthInches = parseFloat(form.modalLabelHeight.value);
-                const offsetLeft        = parseInt(form.modalLabelOffsetLeft.value);
-                const offsetTop =         parseInt(form.modalLabelOffsetTop.value);
-
-                // Construct the config document with the values from the form
-                const configDoc = printer.getConfigDocument();
-
-                // Form mode should be set first for other elements to work right.
-                switch (form.modalMediaType.value) {
-                    case "continuous":
-                        configDoc.setLabelMediaToContinuous(mediaLengthInches);
-                        break;
-                    case "mark":
-                        // TODO: Make a form for black line sensing.
-                        configDoc.setLabelMediaToMarkSense(mediaLengthInches, 16, 0);
-                        break;
-                    default:
-                    case "gap":
-                        // TODO: Make a form for label gap size.
-                        configDoc.setLabelMediaToWebGapSense(mediaLengthInches, 16);
-                        break;
-                }
-
-                configDoc
-                    .setPrintDirection()
-                    .setLabelPrintOriginOffsetCommand(offsetLeft, offsetTop)
-                    .setPrintSpeed(rawSpeed)
-                    .setDarknessConfig(darkness)
-                    .setLabelDimensions(mediaWidthInches);
-                const doc = autosense
-                    ? configDoc.autosenseLabelLength()
-                    : configDoc.finalize();
-                // And send the whole shebang to the printer!
+                const doc = this.addCanvasImageToLabelDoc(printer.getLabelDocument());
                 await printer.sendDocument(doc);
-
-                form.modalSubmit.removeAttribute("disabled");
-                form.modalCancel.removeAttribute("disabled");
+              });
+            document.getElementById(`printer_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                if (this._activePrinter === printerIdx) {
+                  // Don't refresh anything if we already have this printer selected..
+                  return;
+                }
                 this.activePrinterIndex = printerIdx;
-                this.configModalHandle.hide();
+                this.redrawPrinterButtonHighlights();
+                this.redrawTextCanvas();
+              });
+            document.getElementById(`printtest_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                const doc = WebLabel.ReadyToPrintDocuments.printTestLabelDocument(
+                  printer.printerOptions.mediaWidthDots);
+                await printer.sendDocument(doc);
+              });
+            document.getElementById(`feedlabel_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                const doc = WebLabel.ReadyToPrintDocuments.feedLabelDocument;
+                await printer.sendDocument(doc);
+              });
+            document.getElementById(`printconfig_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                const doc = WebLabel.ReadyToPrintDocuments.printConfigDocument;
+                await printer.sendDocument(doc);
+              });
+            document.getElementById(`configprinter_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                this.showConfigModal(printer, printerIdx);
+              });
+          }
+
+          /** Redraw the text canvas size according to the printer. */
+          private redrawTextCanvas() {
+            const printer = this.activePrinter;
+            if (printer === undefined) {
+              this.labelForm.classList.add('d-none');
+              this.labelFormInstructions.classList.remove('d-none');
+              return;
+            } else {
+              this.labelForm.classList.remove('d-none');
+              this.labelFormInstructions.classList.add('d-none');
             }
+
+            // Resize the canvas to match the label size.
+            const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+            // Add a small margin as printer alignment is not exact.
+            canvas.width = printer.printerOptions.mediaWidthDots - 2;
+            canvas.height = printer.printerOptions.mediaLengthDots - 2;
+
+            const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+            textarea.value = "Enter your label text here!";
+            this.renderTextForm();
+          }
+
+          /** Render the text form to the canvas */
+          private renderTextForm() {
+            const printer = this.activePrinter;
+            if (printer === undefined) {
+              return;
+            }
+
+            const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+            const fontsizer = this.labelForm.querySelector('#previewFontSize') as HTMLInputElement;
+            const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+            const pageContext = canvas.getContext('2d')!;
+            pageContext.clearRect(0, 0, canvas.width, canvas.height);
+
+            const fontSize = Math.trunc(parseFloat(fontsizer.value));
+
+            // We'd like the preview image to be as close as possible to what the printer will
+            // actually print. To do this we don't draw text to the page's canvas directly,
+            // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
+            // then render *that* back to the page's canvas. This is a more accurate picture of
+            // what the label will end up looking like.
+
+            // A more complex app could do this more gracefully!
+            const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d')!;
+            offscreenContext.font = `${fontSize}pt ${this.fontName}`;
+            offscreenContext.fillStyle = "#000000";
+
+            // fillText doesn't do newlines, do that manually
+            textarea.value.split('\n').forEach((l, i) => {
+              offscreenContext.fillText(l, 5, (i * fontSize + 2) + fontSize);
+            })
+
+            // Now into the monochrome bitmap.
+            const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
+            const monoImg = WebLabel.BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
+            // And finally back onto the page.
+            pageContext.putImageData(monoImg.toImageData(), 0, 0);
+          }
+
+          /** Render the canvas to a document for printing */
+          private addCanvasImageToLabelDoc(builder: WebLabel.ILabelDocumentBuilder): WebLabel.IDocument {
+            const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+            const imgData = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
+
+            // One of the benefits of this library is being able to render images to a canvas element
+            // and sending that canvas directly to a label. This allows your webpage to generate complex
+            // images and fonts (like emoji!) that EPL/ZPL can't support.
+            return builder
+              .addImageFromImageData(imgData)
+              .addPrintCmd()
+              .finalize();
+          }
+
+          /** Send the contents of the config form as a config label to the printer. */
+          private async updatePrinterConfig(e: SubmitEvent) {
+            e.preventDefault();
+
+            // Figure out the right printer
+            const formElement = this.configModal.querySelector('form')!;
+            const form = formElement.elements as ConfigModalForm;
+            const printerIdx = parseInt((formElement.querySelector('#modalPrinterIndexText') as HTMLFormElement).innerText);
+            const printer = this.printers[printerIdx];
+            if (printer === undefined) {
+              return;
+            }
+
+            form.modalSubmit.setAttribute("disabled", "");
+            form.modalCancel.setAttribute("disabled", "");
+
+            // Pull the values out of the form.
+            const darkness = parseInt(form.modalDarkness.value) as WebLabel.DarknessPercent;
+            const rawSpeed = parseInt(form.modalSpeed.value) as WebLabel.PrintSpeed;
+            const mediaWidthInches = parseFloat(form.modalLabelWidth.value);
+            const autosense = form.modalWithAutosense.checked;
+
+            const mediaLengthInches = parseFloat(form.modalLabelHeight.value);
+            const offsetLeft = parseInt(form.modalLabelOffsetLeft.value);
+            const offsetTop = parseInt(form.modalLabelOffsetTop.value);
+
+            // Construct the config document with the values from the form
+            const configDoc = printer.getConfigDocument();
+
+            // Form mode should be set first for other elements to work right.
+            switch (form.modalMediaType.value) {
+              case "continuous":
+                configDoc.setLabelMediaToContinuous(mediaLengthInches);
+                break;
+              case "mark":
+                // TODO: Make a form for black line sensing.
+                configDoc.setLabelMediaToMarkSense(mediaLengthInches, 16, 0);
+                break;
+              default:
+              case "gap":
+                // TODO: Make a form for label gap size.
+                configDoc.setLabelMediaToWebGapSense(mediaLengthInches, 16);
+                break;
+            }
+
+            configDoc
+              .setPrintDirection()
+              .setLabelPrintOriginOffsetCommand(offsetLeft, offsetTop)
+              .setPrintSpeed(rawSpeed)
+              .setDarknessConfig(darkness)
+              .setLabelDimensions(mediaWidthInches);
+            const doc = autosense
+              ? configDoc.autosenseLabelLength()
+              : configDoc.finalize();
+            // And send the whole shebang to the printer!
+            await printer.sendDocument(doc);
+
+            form.modalSubmit.removeAttribute("disabled");
+            form.modalCancel.removeAttribute("disabled");
+            this.activePrinterIndex = printerIdx;
+            this.configModalHandle.hide();
+          }
         }
 
         // With the app class defined we can run it.

--- a/demo/advanced.html
+++ b/demo/advanced.html
@@ -155,6 +155,7 @@
           modalLabelWidth     : HTMLInputElement
           modalMediaType      : HTMLSelectElement
           modalSpeed          : HTMLSelectElement
+          modalBackfeedPercent: HTMLSelectElement
           modalSubmit         : HTMLButtonElement
           modalWithAutosense  : HTMLInputElement
         }
@@ -302,12 +303,13 @@
             }
 
             (this.configModal.querySelector('#modalPrinterIndex')     as HTMLInputElement)!.value = config.serialNumber;
-            (this.configModal.querySelector('#modalPrinterIndexText') as HTMLSelectElement)!.textContent = printerIdx.toString();
-            (this.configModal.querySelector('#modalLabelWidth')       as HTMLSelectElement)!.value = config.mediaWidthInches.toString();
-            (this.configModal.querySelector('#modalLabelHeight')      as HTMLSelectElement)!.value = config.mediaLengthInches.toString();
-            (this.configModal.querySelector('#modalDarkness')         as HTMLSelectElement)!.value = config.darknessPercent.toString();
-            (this.configModal.querySelector('#modalLabelOffsetLeft')  as HTMLSelectElement)!.value = config.mediaPrintOriginOffsetDots.left.toString();
-            (this.configModal.querySelector('#modalLabelOffsetTop')   as HTMLSelectElement)!.value = config.mediaPrintOriginOffsetDots.top.toString();
+            (this.configModal.querySelector('#modalPrinterIndexText') as HTMLInputElement)!.textContent = printerIdx.toString();
+            (this.configModal.querySelector('#modalLabelWidth')       as HTMLInputElement)!.value = config.mediaWidthInches.toString();
+            (this.configModal.querySelector('#modalLabelHeight')      as HTMLInputElement)!.value = config.mediaLengthInches.toString();
+            (this.configModal.querySelector('#modalDarkness')         as HTMLInputElement)!.value = config.darknessPercent.toString();
+            (this.configModal.querySelector('#modalLabelOffsetLeft')  as HTMLInputElement)!.value = config.mediaPrintOriginOffsetDots.left.toString();
+            (this.configModal.querySelector('#modalLabelOffsetTop')   as HTMLInputElement)!.value = config.mediaPrintOriginOffsetDots.top.toString();
+            (this.configModal.querySelector('#modalBackfeedPercent')  as HTMLSelectElement)!.value = config.backfeedAfterTaken.toString();
             this.configModalHandle.show();
           }
 
@@ -527,6 +529,8 @@
             const offsetLeft = parseInt(form.modalLabelOffsetLeft.value);
             const offsetTop = parseInt(form.modalLabelOffsetTop.value);
 
+            const backfeedAfterTaken = form.modalBackfeedPercent.value as WebLabel.BackfeedAfterTaken;
+
             // Construct the config document with the values from the form
             const configDoc = printer.getConfigDocument();
 
@@ -551,13 +555,15 @@
               .setLabelPrintOriginOffsetCommand(offsetLeft, offsetTop)
               .setPrintSpeed(rawSpeed)
               .setDarknessConfig(darkness)
-              .setLabelDimensions(mediaWidthInches);
+              .setLabelDimensions(mediaWidthInches)
+              .setBackfeedAfterTakenMode(backfeedAfterTaken);
             const doc = autosense
               ? configDoc.autosenseLabelLength()
               : configDoc.finalize();
             // And send the whole shebang to the printer!
             await printer.sendDocument(doc);
 
+            form.modalWithAutosense.checked = false;
             form.modalSubmit.removeAttribute("disabled");
             form.modalCancel.removeAttribute("disabled");
             this.activePrinterIndex = printerIdx;
@@ -590,181 +596,212 @@
         // We're done here. Bring in the dancing lobsters.
 
     </script>
-    <row>
-        <div class="container-fluid">
-            <div class="col-md-9 offset-md-1" style="margin-top: 5px">
+    <div>
+      <div class="container-fluid">
+        <div class="row" style="padding-top: 16px;">
+          <div class="col-3">
+            <div class="d-grid gap-2 col-8 mx-auto mb-3">
+              <div class="row">
+                <div class="col-9">
+                  <button class="btn btn-primary" id="addprinter">➕ Add Printer</button>
+                </div>
+                <div class="col-3">
+                  <button class="btn btn-success" id="refreshPrinters">🔃</button>
+                </div>
+              </div>
+            </div>
+            <ol id="printerlist" class="list-group list-group-numbered">
+            </ol>
+          </div>
+          <div class="col-9">
+            <div class="row">
+              <div class="col-12" id="printerAlertSpace">
                 <div class="alert alert-warning alert-dismissible d-none" role="alert" id="windowsDriverWarning">
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                    <h4>Windows may need extra configuration</h4>
-                    <p>It looks like your operating system is Windows. The <a href="https://web.dev/build-for-webusb/#windows">windows driver model conflicts with WebUSB</a> and might prevent this page from working with a printer.</p>
-                    <p>To make this demo work you'll need to <a href="https://cellivar.github.io/WebZLP/docs/windows_driver">set up your driver correctly</a>. You'll see errors in the developer console if it isn't configured correctly.</p>
+                  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                  <h4>Windows may need extra configuration</h4>
+                  <p>It looks like your operating system is Windows. The <a href="https://web.dev/build-for-webusb/#windows">windows driver model conflicts with WebUSB</a> and might prevent this page from working with a printer.</p>
+                  <p>To make this demo work you'll need to <a href="https://cellivar.github.io/WebZLP/docs/windows_driver">set up your driver correctly</a>. You'll see errors in the developer console if it isn't configured correctly.</p>
                 </div>
                 <div class="alert alert-warning alert-dismissible d-none" role="alert" id="linuxDriverWarning">
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                    <h4>Linux may need extra configuration</h4>
-                    <p>It looks like your operating system is Linux. The <a href="https://web.dev/build-for-webusb/#linux">linux default driver conflicts with WebUSB</a> and might prevent this page from working with a printer.</p>
-                    <p>If a printer doesn't connect successfully you'll need to <a href="https://github.com/anthroarts/artshow-jockey/tree/73a794bcaa0f0a10625c94d4b2876eba5b638287/udev">set up udev rules</a> to load a different driver. You'll see errors in the developer console if it isn't configured correctly.</p>
-                    <p>You may be able to find the correct USB IDs for your device by visiting either opening <pre>chrome://usb-internals</pre> in a new tab and clicking on the 'Devices' tab, or visiting the <a href="http://www.linux-usb.org/usb-ids.html">the USB ID Repository</a>.</p>
+                  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                  <h4>Linux may need extra configuration</h4>
+                  <p>It looks like your operating system is Linux. The <a href="https://web.dev/build-for-webusb/#linux">linux default driver conflicts with WebUSB</a> and might prevent this page from working with a printer.</p>
+                  <p>If a printer doesn't connect successfully you'll need to <a href="https://github.com/anthroarts/artshow-jockey/tree/73a794bcaa0f0a10625c94d4b2876eba5b638287/udev">set up udev rules</a> to load a different driver. You'll see errors in the developer console if it isn't configured correctly.</p>
+                  <p>You may be able to find the correct USB IDs for your device by visiting either opening <pre>chrome://usb-internals</pre> in a new tab and clicking on the 'Devices' tab, or visiting the <a href="http://www.linux-usb.org/usb-ids.html">the USB ID Repository</a>.</p>
                 </div>
                 <div class="alert alert-warning d-none" role="alert" id="browserNoWebUsb">
-                    <h4>Your browser doesn't support WebUSB</h4>
-                    <p>This demo uses WebUSB to function and your browser doesn't seem to have that available.</p>
+                  <h4>Your browser doesn't support WebUSB</h4>
+                  <p>This demo uses WebUSB to function and your browser doesn't seem to have that available.</p>
                 </div>
                 <div class="alert alert-warning d-none" role="alert" id="urlNotSecure">
-                    <h4>WebUSB requires HTTPS</h4>
-                    <p>It looks like this URL is not using HTTPS, and WebUSB <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebUSB_API">only works in a secure context.</a> You'll need to load this page over HTTPS instead.</p>
+                  <h4>WebUSB requires HTTPS</h4>
+                  <p>It looks like this URL is not using HTTPS, and WebUSB <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebUSB_API">only works in a secure context.</a> You'll need to load this page over HTTPS instead.</p>
                 </div>
                 <div class="alert alert-info" role="alert" id="loadingIndicator">
-                    <h4>Loading....</h4>
-                    <p>If you see this for a long time check the dev console for errors and try the <button id="emergencyRefreshBtn">emergency reset button.</button></p>
+                  <h4>Loading....</h4>
+                  <p>If you see this for a long time check the dev console for errors and try the <button id="emergencyRefreshBtn">emergency reset button.</button></p>
                 </div>
+              </div>
             </div>
-        </div>
-    </row>
-    <row>
-        <div class="container-fluid">
-            <div class="row" style="padding-top: 16px;">
-                <div class="col-3">
-                    <div class="d-grid gap-2 col-8 mx-auto mb-3">
-                        <div class="row">
-                            <div class="col-9">
-                                <button class="btn btn-primary" id="addprinter">➕ Add Printer</button>
-                            </div>
-                            <div class="col-3">
-                                <button class="btn btn-success" id="refreshPrinters">🔃</button>
-                            </div>
-                        </div>
-                    </div>
-                    <ol id="printerlist" class="list-group list-group-numbered">
-                    </ol>
-                </div>
-                <div class="col-9">
-                    <div id="printerAlertSpace"></div>
-                    <form id="labelForm" action="javascript:void(0);" class="d-none">
-                        <h5>Preview</h5>
-                        <canvas id="labelCanvas" width="584" height="160" style="border: 2px solid blue; background-color: white; margin-bottom: 10px;"></canvas>
-                        <h5>Input</h5>
-                        <label for="previewFontSize" class="form-label">Font Size</label>
-                        <div class="input-group">
-                            <input id="previewFontSize" type="number" class="form-control" placeholder="16"
-                                aria-label="Font Size" value="16">
-                        </div>
-                        <textarea id="labelFormText" name="labelText" cols="40" rows="10" wrap="hard"
-                            style="font-family: monospace; resize: both;"
-                            placeholder="Enter your label text here!"></textarea>
-                    </form>
-                    <div id="labelFormInstructions">
-                        <p>Connect a printer to your computer, then click Add Printer!</p>
-                        <p>Once a printer is connected select it by clicking on it on the left.</p>
-                    </div>
-                </div>
+            <div id="labelFormInstructions" class="row">
+              <p>Connect a printer to your computer, then click Add Printer!</p>
+              <p>Once a printer is connected select it by clicking on it on the left.</p>
             </div>
+            <div class="row">
+              <form id="labelForm" action="javascript:void(0);" class="d-none">
+                <h5>Input</h5>
+                <label for="previewFontSize" class="form-label">Font Size</label>
+                <div class="input-group">
+                  <input id="previewFontSize" type="number" class="form-control" placeholder="16"
+                    aria-label="Font Size" value="16">
+                </div>
+                <textarea id="labelFormText" name="labelText" cols="40" rows="10" wrap="hard"
+                  style="font-family: monospace; resize: both;"
+                  placeholder="Enter your label text here!"></textarea>
+                <h5>Preview</h5>
+                <canvas id="labelCanvas" width="584" height="160" style="border: 2px solid blue; background-color: white; margin-bottom: 10px;"></canvas>
+              </form>
+            </div>
+          </div>
         </div>
-    </row>
+      </div>
+    </div>
     <div id="printerOptionModal" class="modal" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <form id="printerSettingsForm">
-                    <div class="modal-header">
-                        <h5 class="modal-title">Label Settings</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body">
-                        <label for="modalPrinterIndex" class="form-label">Printer ID</label>
-                        <div class="input-group mb-3">
-                            <span id="modalPrinterIndexText" class="input-group-text">42Q424242424</span>
-                            <input id="modalPrinterIndex" class="form-control" type="text" value="-1"
-                                aria-label="Printer ID" aria-describedby="modalPrinterIndexText" disabled readonly>
-                        </div>
-                        <div class="mb-3">
-                            <div class="row">
-                                <div class="col">
-                                    <label for="modalLabelWidth" class="form-label">Label Width</label>
-                                    <div class="input-group mb-3">
-                                        <input id="modalLabelWidth" type="text" class="form-control" placeholder="2.25"
-                                            aria-label="Width" required pattern="\d+\.*\d*">
-                                        <span id="modalLabelWidthText" class="input-group-text">in</span>
-                                    </div>
-                                </div>
-                                <div class="col">
-                                    <label for="modalLabelHeight" class="form-label">Label Height</label>
-                                    <div class="input-group mb-3">
-                                        <input id="modalLabelHeight" type="text" class="form-control" placeholder="2.25"
-                                            aria-label="Height" required pattern="\d+\.*\d*">
-                                        <span id="modalLabelHeightText" class="input-group-text">in</span>
-                                    </div>
-                                </div>
-                                <div class="col">
-                                    <div class="form-check form-switch">
-                                        <input id="modalWithAutosense" type="checkbox" role="switch" class="form-check-input"
-                                            aria-label="RunAutosense">
-                                        <label for="modalWithAutosense" class="form-check-label">Perform autosense</label>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="mb-3">
-                            <div class="row">
-                                <div class="col row mb-3">
-                                    <label for="modalDarkness" class="col-sm-5 col-form-label">Darkness</label>
-                                    <div class="col-sm-7">
-                                        <div class="input-group col-sm-7">
-                                            <input type="number" min="1" max="99" id="modalDarkness" class="form-control" aria-label="Darkness"/>
-                                            <span class="input-group-text">%</span>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col row mb-3">
-                                    <label for="modalSpeed" class="col-sm-5 col-form-label">Speed</label>
-                                    <div class="col-sm-7">
-                                        <select id="modalSpeed" class="form-select" aria-label="Speed">
-                                            <option value="3">1.5 ips</option>
-                                            <option value="4">2 ips</option>
-                                            <option value="5">2.5 ips</option>
-                                            <option value="7">3.5 ips</option>
-                                        </select>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="mb-3">
-                            <div class="row">
-                                <div class="col">
-                                    <label for="modalLabelOffsetLeft" class="form-label">Left Offset</label>
-                                    <div class="input-group mb-3">
-                                        <input id="modalLabelOffsetLeft" type="text" class="form-control" placeholder="0"
-                                            aria-label="Width" required pattern="-?\d+">
-                                        <span class="input-group-text">dots</span>
-                                    </div>
-                                </div>
-                                <div class="col">
-                                    <label for="modalLabelOffsetTop" class="form-label">Top Offset</label>
-                                    <div class="input-group mb-3">
-                                        <input id="modalLabelOffsetTop" type="text" class="form-control" placeholder="0"
-                                            aria-label="Height" required pattern="-?\d+">
-                                        <span class="input-group-text">dots</span>
-                                    </div>
-                                </div>
-                                <div class="col">
-                                    <label for="modalMediaType" class="form-label">Media Type</label>
-                                    <div class="mb-3">
-                                        <select id="modalMediaType" class="form-select" aria-label="Media Type">
-                                            <option value="continuous">Continuous</option>
-                                            <option value="gap">Gap-sense</option>
-                                            <option value="mark">Mark-sense</option>
-                                        </select>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button id="modalCancel" type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                        <input id="modalSubmit" type="submit" class="btn btn-primary" value="Save">
-                    </div>
-                </form>
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <form id="printerSettingsForm">
+            <div class="modal-header">
+              <h4 class="modal-title">Settings</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
+            <div class="modal-body">
+              <div class="row">
+                <label for="modalPrinterIndex" class="form-label">Printer ID</label>
+                <div class="input-group mb-3">
+                  <span id="modalPrinterIndexText" class="input-group-text">42Q424242424</span>
+                  <input id="modalPrinterIndex" class="form-control" type="text" value="-1"
+                    aria-label="Printer ID" aria-describedby="modalPrinterIndexText" disabled readonly>
+                </div>
+              </div>
+              <div class="mb-3">
+                <div class="row">
+                  <h5>Media Settings</h5>
+                </div>
+                <div class="row">
+                  <div class="col">
+                    <label for="modalLabelWidth" class="form-label">Media Width</label>
+                    <div class="input-group mb-3">
+                      <input id="modalLabelWidth" type="text" class="form-control" placeholder="2.25"
+                        aria-label="Width" required pattern="\d+\.*\d*">
+                      <span id="modalLabelWidthText" class="input-group-text">in</span>
+                    </div>
+                  </div>
+                  <div class="col">
+                    <label for="modalLabelHeight" class="form-label">Media Length</label>
+                    <div class="input-group mb-3">
+                      <input id="modalLabelHeight" type="text" class="form-control" placeholder="2.25"
+                        aria-label="Height" required pattern="\d+\.*\d*">
+                      <span id="modalLabelHeightText" class="input-group-text">in</span>
+                    </div>
+                  </div>
+                  <div class="col">
+                    <label class="form-label">Auto-Calibrate</label>
+                    <div class="input-group mb-3">
+                      <input id="modalWithAutosense" type="checkbox" class="btn-check"
+                        aria-label="RunAutosense" autocomplete="off">
+                      <label for="modalWithAutosense" class="btn btn-outline-primary"
+                        data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right" title="Will feed several labels to calibrate sensor.<br/><b>Make sure to unspool peeler first!</b>"
+                        >Run on save</label>
+                    </div>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col">
+                    <label for="modalLabelOffsetLeft" class="form-label">Left Offset</label>
+                    <div class="input-group mb-3">
+                      <input id="modalLabelOffsetLeft" type="text" class="form-control" placeholder="0"
+                        aria-label="Width" required pattern="-?\d+">
+                      <span class="input-group-text">dots</span>
+                    </div>
+                  </div>
+                  <div class="col">
+                    <label for="modalLabelOffsetTop" class="form-label">Top Offset</label>
+                    <div class="input-group mb-3">
+                      <input id="modalLabelOffsetTop" type="text" class="form-control" placeholder="0"
+                        aria-label="Height" required pattern="-?\d+">
+                      <span class="input-group-text">dots</span>
+                    </div>
+                  </div>
+                  <div class="col">
+                    <label for="modalMediaType" class="form-label">Media Type</label>
+                    <div class="mb-3">
+                      <select id="modalMediaType" class="form-select" aria-label="Media Type">
+                        <option value="continuous">Continuous</option>
+                        <option value="gap">Web/gap sense</option>
+                        <option value="mark">Line mark sense</option>
+                      </select>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="mb-3">
+                <div class="row">
+                  <h5>Printer Settings</h5>
+                </div>
+                <div class="row">
+                  <div class="col row mb-3">
+                    <label for="modalDarkness" class="col-sm-5 col-form-label">Darkness</label>
+                    <div class="col-sm-7">
+                      <div class="input-group col-sm-7">
+                        <input type="number" min="1" max="99" id="modalDarkness" class="form-control" aria-label="Darkness"/>
+                        <span class="input-group-text">%</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="col row mb-3">
+                    <label for="modalSpeed" class="col-sm-5 col-form-label">Speed</label>
+                    <div class="col-sm-7">
+                      <select id="modalSpeed" class="form-select" aria-label="Speed">
+                        <option value="3">1.5 ips</option>
+                        <option value="4">2 ips</option>
+                        <option value="5">2.5 ips</option>
+                        <option value="7">3.5 ips</option>
+                      </select>
+                    </div>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col">
+                    <label for="modalBackfeedPercent" class="form-label">Backfeed sequence</label>
+                    <div class="mb-3">
+                      <select id="modalBackfeedPercent" class="form-select" aria-label="Media Type"
+                      data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right" title="Percent of backfeed after cut/take, then rest is at next print.<br>Disabled prevents any backfeed."
+                      >
+                        <option value="disabled">Disabled</option>
+                        <option value="0">0%</option>
+                        <option value="10">10%</option>
+                        <option value="20">20%</option>
+                        <option value="30">30%</option>
+                        <option value="40">40%</option>
+                        <option value="50">50%</option>
+                        <option value="60">60%</option>
+                        <option value="70">70%</option>
+                        <option value="80">80%</option>
+                        <option value="90">90%</option>
+                        <option value="100">100%</option>
+                      </select>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button id="modalCancel" type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+              <input id="modalSubmit" type="submit" class="btn btn-primary" value="Save">
+            </div>
+          </form>
         </div>
+      </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.10.2/dist/umd/popper.min.js"
         integrity="sha384-7+zCNj/IqJ95wo16oMtfsKbZ9ccEh31eOz1HGyDuCQ6wgnyJNSYdrPa03rtR1zdB"
@@ -772,6 +809,13 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.min.js"
         integrity="sha384-QJHtvGhmr9XOIpI6YVutG+2QOK9T+ZnN4kzFN1RtK3zEFEIsxhlmWl5/YESvpZ13"
         crossorigin="anonymous"></script>
+    <script type="text/javascript">
+      // Enable tooltips for bootstrap
+      var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+      var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl)
+      })
+    </script>
 </body>
 
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -113,24 +113,24 @@
 
         // Next we wire up some events on the UsbDeviceManager itself.
         printerMgr.addEventListener('connectedDevice', ({ detail }) => {
-            const printer = detail.device;
-            console.log('New printer is a', printer.printerModel);
-            const config = printer.printerOptions;
-            console.log('Printer darkness is', config.darknessPercent, 'percent');
-            console.log('Printer speed is', WebLabel.PrintSpeed[config.speed.printSpeed]);
-            console.log(
-                'Label is',
-                config.mediaWidthInches,
-                'in wide and',
-                config.mediaLengthInches,
-                'in long');
-            console.log('Printer media mode is', WebLabel.MediaMediaGapDetectionMode[config.mediaGapDetectMode]);
+          const printer = detail.device;
+          console.log('New printer is a', printer.printerModel);
+          const config = printer.printerOptions;
+          console.log('Printer darkness is', config.darknessPercent, 'percent');
+          console.log('Printer speed is', WebLabel.PrintSpeed[config.speed.printSpeed]);
+          console.log(
+            'Label is',
+            config.mediaWidthInches,
+            'in wide and',
+            config.mediaLengthInches,
+            'in long');
+          console.log('Printer media mode is', WebLabel.MediaMediaGapDetectionMode[config.mediaGapDetectMode]);
         });
 
         // There's also an event that will tell you when a printer disconnects.
         printerMgr.addEventListener('disconnectedDevice', ({ detail }) => {
-            const printer = detail.device;
-            console.log('Lost printer', printer.printerModel, 'serial', printer.printerOptions.serialNumber);
+          const printer = detail.device;
+          console.log('Lost printer', printer.printerModel, 'serial', printer.printerOptions.serialNumber);
         });
 
         // When the browser first loaded the page any previously connected printers would have caused
@@ -147,153 +147,153 @@
 
         // First we create an interface to describe our settings form.
         interface ConfigModalForm extends HTMLCollection {
-            modalCancel         : HTMLButtonElement
-            modalDarkness       : HTMLSelectElement
-            modalLabelHeight    : HTMLInputElement
-            modalLabelOffsetLeft: HTMLInputElement
-            modalLabelOffsetTop : HTMLInputElement
-            modalLabelWidth     : HTMLInputElement
-            modalMediaType      : HTMLSelectElement
-            modalSpeed          : HTMLSelectElement
-            modalSubmit         : HTMLButtonElement
-            modalWithAutosense  : HTMLInputElement
+          modalCancel         : HTMLButtonElement
+          modalDarkness       : HTMLSelectElement
+          modalLabelHeight    : HTMLInputElement
+          modalLabelOffsetLeft: HTMLInputElement
+          modalLabelOffsetTop : HTMLInputElement
+          modalLabelWidth     : HTMLInputElement
+          modalMediaType      : HTMLSelectElement
+          modalSpeed          : HTMLSelectElement
+          modalSubmit         : HTMLButtonElement
+          modalWithAutosense  : HTMLInputElement
         }
 
         // The app's logic is wrapped in a class just for ease of reading.
         class BasicLabelDesignerApp {
-            constructor(
-                private manager: PrinterManager,
-                private btnContainer: HTMLElement,
-                private labelForm: HTMLElement,
-                private labelFormInstructions: HTMLElement,
-                private configModal: HTMLElement
-            ) {
-                // Based on the containers, map the various listeners.
-                this.configModalHandle = new bootstrap.Modal(this.configModal);
-                this.configModal
-                    .querySelector('form')!
-                    .addEventListener('submit', this.updatePrinterConfig.bind(this));
-                this.labelForm.addEventListener('blur', this.renderTextForm.bind(this));
-                this.labelForm.addEventListener('keyup', this.renderTextForm.bind(this));
+          constructor(
+            private manager: PrinterManager,
+            private btnContainer: HTMLElement,
+            private labelForm: HTMLElement,
+            private labelFormInstructions: HTMLElement,
+            private configModal: HTMLElement
+          ) {
+            // Based on the containers, map the various listeners.
+            this.configModalHandle = new bootstrap.Modal(this.configModal);
+            this.configModal
+              .querySelector('form')!
+              .addEventListener('submit', this.updatePrinterConfig.bind(this));
+            this.labelForm.addEventListener('blur', this.renderTextForm.bind(this));
+            this.labelForm.addEventListener('keyup', this.renderTextForm.bind(this));
 
-                // Add a second set of event listeners for printer connect and disconnect to redraw
-                // the printer list when it changes.
-                this.manager.addEventListener('connectedDevice', () => {
-                    this.activePrinterIndex = -1;
-                    this.redrawPrinterButtons();
-                });
-                this.manager.addEventListener('disconnectedDevice', () => {
-                    this.activePrinterIndex = -1;
-                    this.redrawPrinterButtons();
-                });
+            // Add a second set of event listeners for printer connect and disconnect to redraw
+            // the printer list when it changes.
+            this.manager.addEventListener('connectedDevice', () => {
+              this.activePrinterIndex = -1;
+              this.redrawPrinterButtons();
+            });
+            this.manager.addEventListener('disconnectedDevice', () => {
+              this.activePrinterIndex = -1;
+              this.redrawPrinterButtons();
+            });
 
-                // Here's a nice font with a great set of emoji that work well for monochrome printing.
-                // The text font is fairly basic though, so we would like to use only the emoji out
-                // of this font and use a basic sans-serif font for regular text.
-                // https://fonts.google.com/noto/specimen/Noto+Emoji
-                const emojiFontName = 'noto-emoji';
+            // Here's a nice font with a great set of emoji that work well for monochrome printing.
+            // The text font is fairly basic though, so we would like to use only the emoji out
+            // of this font and use a basic sans-serif font for regular text.
+            // https://fonts.google.com/noto/specimen/Noto+Emoji
+            const emojiFontName = 'noto-emoji';
 
-                // We can accomplish this with the unicodeRange property of our FontFace. We just
-                // need to list EVERY SINGLE EMOJI UNICODE RANGE to make it work. Fortunately someone
-                // has done this already: https://github.com/fraction/emoji-unicode-range
-                const emojiUnicodeRange = 'U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2604,U+260E,U+2611,U+2614-2615,U+2618,U+261D,U+2620,U+2622-2623,U+2626,U+262A,U+262E-262F,U+2638-263A,U+2640,U+2642,U+2648-2653,U+265F-2660,U+2663,U+2665-2666,U+2668,U+267B,U+267E-267F,U+2692-2697,U+2699,U+269B-269C,U+26A0-26A1,U+26AA-26AB,U+26B0-26B1,U+26BD-26BE,U+26C4-26C5,U+26C8,U+26CE,U+26CF,U+26D1,U+26D3-26D4,U+26E9-26EA,U+26F0-26F5,U+26F7-26FA,U+26FD,U+2702,U+2705,U+2708-2709,U+270A-270B,U+270C-270D,U+270F,U+2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2764,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F004,U+1F0CF,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201-1F202,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F321,U+1F324-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F396-1F397,U+1F399-1F39B,U+1F39E-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F3-1F3F5,U+1F3F7,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD,U+1F4FF,U+1F500-1F53D,U+1F549-1F54A,U+1F54B-1F54E,U+1F550-1F567,U+1F56F-1F570,U+1F573-1F579,U+1F57A,U+1F587,U+1F58A-1F58D,U+1F590,U+1F595-1F596,U+1F5A4,U+1F5A5,U+1F5A8,U+1F5B1-1F5B2,U+1F5BC,U+1F5C2-1F5C4,U+1F5D1-1F5D3,U+1F5DC-1F5DE,U+1F5E1,U+1F5E3,U+1F5E8,U+1F5EF,U+1F5F3,U+1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CB-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6E0-1F6E5,U+1F6E9,U+1F6EB-1F6EC,U+1F6F0,U+1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+231A-231B,U+23E9-23EC,U+23F0,U+23F3,U+25FD-25FE,U+2614-2615,U+2648-2653,U+267F,U+2693,U+26A1,U+26AA-26AB,U+26BD-26BE,U+26C4-26C5,U+26CE,U+26D4,U+26EA,U+26F2-26F3,U+26F5,U+26FA,U+26FD,U+2705,U+270A-270B,U+2728,U+274C,U+274E,U+2753-2755,U+2757,U+2795-2797,U+27B0,U+27BF,U+2B1B-2B1C,U+2B50,U+2B55,U+1F004,U+1F0CF,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201,U+1F21A,U+1F22F,U+1F232-1F236,U+1F238-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F32D-1F32F,U+1F330-1F335,U+1F337-1F37C,U+1F37E-1F37F,U+1F380-1F393,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CF-1F3D3,U+1F3E0-1F3F0,U+1F3F4,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F440,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FF,U+1F500-1F53D,U+1F54B-1F54E,U+1F550-1F567,U+1F57A,U+1F595-1F596,U+1F5A4,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CC,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6EB-1F6EC,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+1F3FB-1F3FF,U+261D,U+26F9,U+270A-270B,U+270C-270D,U+1F385,U+1F3C2-1F3C4,U+1F3C7,U+1F3CA,U+1F3CB-1F3CC,U+1F442-1F443,U+1F446-1F450,U+1F466-1F478,U+1F47C,U+1F481-1F483,U+1F485-1F487,U+1F48F,U+1F491,U+1F4AA,U+1F574-1F575,U+1F57A,U+1F590,U+1F595-1F596,U+1F645-1F647,U+1F64B-1F64F,U+1F6A3,U+1F6B4-1F6B6,U+1F6C0,U+1F6CC,U+1F90F,U+1F918,U+1F919-1F91E,U+1F91F,U+1F926,U+1F930,U+1F931-1F932,U+1F933-1F939,U+1F93C-1F93E,U+1F9B5-1F9B6,U+1F9B8-1F9B9,U+1F9BB,U+1F9CD-1F9CF,U+1F9D1-1F9DD,U+0023,U+002A,U+0030-0039,U+200D,U+20E3,U+FE0F,U+1F1E6-1F1FF,U+1F3FB-1F3FF,U+1F9B0-1F9B3,U+E0020-E007F,U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+2388,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2605,U+2607-2612,U+2614-2615,U+2616-2617,U+2618,U+2619,U+261A-266F,U+2670-2671,U+2672-267D,U+267E-267F,U+2680-2685,U+2690-2691,U+2692-269C,U+269D,U+269E-269F,U+26A0-26A1,U+26A2-26B1,U+26B2,U+26B3-26BC,U+26BD-26BF,U+26C0-26C3,U+26C4-26CD,U+26CE,U+26CF-26E1,U+26E2,U+26E3,U+26E4-26E7,U+26E8-26FF,U+2700,U+2701-2704,U+2705,U+2708-2709,U+270A-270B,U+270C-2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2767,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F000-1F02B,U+1F02C-1F02F,U+1F030-1F093,U+1F094-1F09F,U+1F0A0-1F0AE,U+1F0AF-1F0B0,U+1F0B1-1F0BE,U+1F0BF,U+1F0C0,U+1F0C1-1F0CF,U+1F0D0,U+1F0D1-1F0DF,U+1F0E0-1F0F5,U+1F0F6-1F0FF,U+1F10D-1F10F,U+1F12F,U+1F16C,U+1F16D-1F16F,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1AD-1F1E5,U+1F201-1F202,U+1F203-1F20F,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F23C-1F23F,U+1F249-1F24F,U+1F250-1F251,U+1F252-1F25F,U+1F260-1F265,U+1F266-1F2FF,U+1F300-1F320,U+1F321-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F394-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F1-1F3F7,U+1F3F8-1F3FA,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD-1F4FE,U+1F4FF,U+1F500-1F53D,U+1F546-1F54A,U+1F54B-1F54F,U+1F550-1F567,U+1F568-1F579,U+1F57A,U+1F57B-1F5A3,U+1F5A4,U+1F5A5-1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6C6-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D3-1F6D4,U+1F6D5,U+1F6D6-1F6DF,U+1F6E0-1F6EC,U+1F6ED-1F6EF,U+1F6F0-1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F6FB-1F6FF,U+1F774-1F77F,U+1F7D5-1F7D8,U+1F7D9-1F7DF,U+1F7E0-1F7EB,U+1F7EC-1F7FF,U+1F80C-1F80F,U+1F848-1F84F,U+1F85A-1F85F,U+1F888-1F88F,U+1F8AE-1F8FF,U+1F90C,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F972,U+1F973-1F976,U+1F977-1F979,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A3-1F9A4,U+1F9A5-1F9AA,U+1F9AB-1F9AD,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CB-1F9CC,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA00-1FA53,U+1FA54-1FA5F,U+1FA60-1FA6D,U+1FA6E-1FA6F,U+1FA70-1FA73,U+1FA74-1FA77,U+1FA78-1FA7A,U+1FA7B-1FA7F,U+1FA80-1FA82,U+1FA83-1FA8F,U+1FA90-1FA95,U+1FA96-1FFFD';
+            // We can accomplish this with the unicodeRange property of our FontFace. We just
+            // need to list EVERY SINGLE EMOJI UNICODE RANGE to make it work. Fortunately someone
+            // has done this already: https://github.com/fraction/emoji-unicode-range
+            const emojiUnicodeRange = 'U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2604,U+260E,U+2611,U+2614-2615,U+2618,U+261D,U+2620,U+2622-2623,U+2626,U+262A,U+262E-262F,U+2638-263A,U+2640,U+2642,U+2648-2653,U+265F-2660,U+2663,U+2665-2666,U+2668,U+267B,U+267E-267F,U+2692-2697,U+2699,U+269B-269C,U+26A0-26A1,U+26AA-26AB,U+26B0-26B1,U+26BD-26BE,U+26C4-26C5,U+26C8,U+26CE,U+26CF,U+26D1,U+26D3-26D4,U+26E9-26EA,U+26F0-26F5,U+26F7-26FA,U+26FD,U+2702,U+2705,U+2708-2709,U+270A-270B,U+270C-270D,U+270F,U+2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2764,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F004,U+1F0CF,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201-1F202,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F321,U+1F324-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F396-1F397,U+1F399-1F39B,U+1F39E-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F3-1F3F5,U+1F3F7,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD,U+1F4FF,U+1F500-1F53D,U+1F549-1F54A,U+1F54B-1F54E,U+1F550-1F567,U+1F56F-1F570,U+1F573-1F579,U+1F57A,U+1F587,U+1F58A-1F58D,U+1F590,U+1F595-1F596,U+1F5A4,U+1F5A5,U+1F5A8,U+1F5B1-1F5B2,U+1F5BC,U+1F5C2-1F5C4,U+1F5D1-1F5D3,U+1F5DC-1F5DE,U+1F5E1,U+1F5E3,U+1F5E8,U+1F5EF,U+1F5F3,U+1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CB-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6E0-1F6E5,U+1F6E9,U+1F6EB-1F6EC,U+1F6F0,U+1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+231A-231B,U+23E9-23EC,U+23F0,U+23F3,U+25FD-25FE,U+2614-2615,U+2648-2653,U+267F,U+2693,U+26A1,U+26AA-26AB,U+26BD-26BE,U+26C4-26C5,U+26CE,U+26D4,U+26EA,U+26F2-26F3,U+26F5,U+26FA,U+26FD,U+2705,U+270A-270B,U+2728,U+274C,U+274E,U+2753-2755,U+2757,U+2795-2797,U+27B0,U+27BF,U+2B1B-2B1C,U+2B50,U+2B55,U+1F004,U+1F0CF,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201,U+1F21A,U+1F22F,U+1F232-1F236,U+1F238-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F32D-1F32F,U+1F330-1F335,U+1F337-1F37C,U+1F37E-1F37F,U+1F380-1F393,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CF-1F3D3,U+1F3E0-1F3F0,U+1F3F4,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F440,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FF,U+1F500-1F53D,U+1F54B-1F54E,U+1F550-1F567,U+1F57A,U+1F595-1F596,U+1F5A4,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CC,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6EB-1F6EC,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+1F3FB-1F3FF,U+261D,U+26F9,U+270A-270B,U+270C-270D,U+1F385,U+1F3C2-1F3C4,U+1F3C7,U+1F3CA,U+1F3CB-1F3CC,U+1F442-1F443,U+1F446-1F450,U+1F466-1F478,U+1F47C,U+1F481-1F483,U+1F485-1F487,U+1F48F,U+1F491,U+1F4AA,U+1F574-1F575,U+1F57A,U+1F590,U+1F595-1F596,U+1F645-1F647,U+1F64B-1F64F,U+1F6A3,U+1F6B4-1F6B6,U+1F6C0,U+1F6CC,U+1F90F,U+1F918,U+1F919-1F91E,U+1F91F,U+1F926,U+1F930,U+1F931-1F932,U+1F933-1F939,U+1F93C-1F93E,U+1F9B5-1F9B6,U+1F9B8-1F9B9,U+1F9BB,U+1F9CD-1F9CF,U+1F9D1-1F9DD,U+0023,U+002A,U+0030-0039,U+200D,U+20E3,U+FE0F,U+1F1E6-1F1FF,U+1F3FB-1F3FF,U+1F9B0-1F9B3,U+E0020-E007F,U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+2388,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2605,U+2607-2612,U+2614-2615,U+2616-2617,U+2618,U+2619,U+261A-266F,U+2670-2671,U+2672-267D,U+267E-267F,U+2680-2685,U+2690-2691,U+2692-269C,U+269D,U+269E-269F,U+26A0-26A1,U+26A2-26B1,U+26B2,U+26B3-26BC,U+26BD-26BF,U+26C0-26C3,U+26C4-26CD,U+26CE,U+26CF-26E1,U+26E2,U+26E3,U+26E4-26E7,U+26E8-26FF,U+2700,U+2701-2704,U+2705,U+2708-2709,U+270A-270B,U+270C-2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2767,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F000-1F02B,U+1F02C-1F02F,U+1F030-1F093,U+1F094-1F09F,U+1F0A0-1F0AE,U+1F0AF-1F0B0,U+1F0B1-1F0BE,U+1F0BF,U+1F0C0,U+1F0C1-1F0CF,U+1F0D0,U+1F0D1-1F0DF,U+1F0E0-1F0F5,U+1F0F6-1F0FF,U+1F10D-1F10F,U+1F12F,U+1F16C,U+1F16D-1F16F,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1AD-1F1E5,U+1F201-1F202,U+1F203-1F20F,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F23C-1F23F,U+1F249-1F24F,U+1F250-1F251,U+1F252-1F25F,U+1F260-1F265,U+1F266-1F2FF,U+1F300-1F320,U+1F321-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F394-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F1-1F3F7,U+1F3F8-1F3FA,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD-1F4FE,U+1F4FF,U+1F500-1F53D,U+1F546-1F54A,U+1F54B-1F54F,U+1F550-1F567,U+1F568-1F579,U+1F57A,U+1F57B-1F5A3,U+1F5A4,U+1F5A5-1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6C6-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D3-1F6D4,U+1F6D5,U+1F6D6-1F6DF,U+1F6E0-1F6EC,U+1F6ED-1F6EF,U+1F6F0-1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F6FB-1F6FF,U+1F774-1F77F,U+1F7D5-1F7D8,U+1F7D9-1F7DF,U+1F7E0-1F7EB,U+1F7EC-1F7FF,U+1F80C-1F80F,U+1F848-1F84F,U+1F85A-1F85F,U+1F888-1F88F,U+1F8AE-1F8FF,U+1F90C,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F972,U+1F973-1F976,U+1F977-1F979,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A3-1F9A4,U+1F9A5-1F9AA,U+1F9AB-1F9AD,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CB-1F9CC,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA00-1FA53,U+1FA54-1FA5F,U+1FA60-1FA6D,U+1FA6E-1FA6F,U+1FA70-1FA73,U+1FA74-1FA77,U+1FA78-1FA7A,U+1FA7B-1FA7F,U+1FA80-1FA82,U+1FA83-1FA8F,U+1FA90-1FA95,U+1FA96-1FFFD';
 
-                // And then we can use that range with our font when we load it.
-                const emojiOnlyFont = new FontFace(emojiFontName, 'url(fonts/NotoEmoji-Regular.ttf)', {
-                  unicodeRange: emojiUnicodeRange,
-                });
-                emojiOnlyFont.load().then(() => {
-                    document.fonts.add(emojiOnlyFont);
-                });
-                // We then set our fallback font as part of the font family we use in the canvas.
-                // This order matters, latter fonts will use the unicodeRange to override earlier fonts.
-                this.fontName = `Sans-serif, ${emojiFontName}`
+            // And then we can use that range with our font when we load it.
+            const emojiOnlyFont = new FontFace(emojiFontName, 'url(fonts/NotoEmoji-Regular.ttf)', {
+              unicodeRange: emojiUnicodeRange,
+            });
+            emojiOnlyFont.load().then(() => {
+              document.fonts.add(emojiOnlyFont);
+            });
+            // We then set our fallback font as part of the font family we use in the canvas.
+            // This order matters, latter fonts will use the unicodeRange to override earlier fonts.
+            this.fontName = `Sans-serif, ${emojiFontName}`
+          }
+
+          // Some storage fields and utility properties
+          private fontName: string;
+          private configModalHandle: bootstrap.Modal;
+
+          get printers(): readonly WebLabel.LabelPrinterUsb[] {
+            return this.manager.devices;
+          }
+
+          // Track which printer is currently selected for operations
+          private _activePrinter = 0;
+          get activePrinter(): WebLabel.LabelPrinterUsb | undefined {
+            return this._activePrinter < 0 || this._activePrinter > this.printers.length
+              ? undefined
+              : this.printers[this._activePrinter];
+          }
+          set activePrinterIndex(printerIdx: number) {
+            this._activePrinter = printerIdx;
+            this.redrawTextCanvas();
+          }
+
+          /** Initialize the app */
+          public async init() {
+            this.redrawPrinterButtons();
+            this.redrawTextCanvas();
+          }
+
+          /** Display the configuration for a printer. */
+          public showConfigModal(printer: WebLabel.LabelPrinterUsb, printerIdx: number) {
+            if (printer == undefined) {
+              return;
             }
+            const config = printer.printerOptions;
 
-            // Some storage fields and utility properties
-            private fontName: string;
-            private configModalHandle: bootstrap.Modal;
-
-            get printers() {
-                return this.manager.devices;
+            // Translate the available speeds to options to be selected
+            const speedSelect = this.configModal.querySelector('#modalSpeed')! as HTMLSelectElement;
+            speedSelect.innerHTML = '';
+            const speedTable = printer.printerOptions.speedTable.table;
+            for (const [key] of speedTable) {
+              // Skip utility values, so long as there's more than the defaults.
+              // Mobile printers *only* support auto, for example.
+              if ((speedTable.size > 3)
+                && (key === WebLabel.PrintSpeed.ipsAuto
+                  || key === WebLabel.PrintSpeed.ipsPrinterMax
+                  || key === WebLabel.PrintSpeed.ipsPrinterMin
+                )) {
+                continue;
+              }
+              const opt = document.createElement('option');
+              opt.value = key.toString();
+              opt.innerHTML = WebLabel.PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
+              speedSelect.appendChild(opt);
             }
+            speedSelect.value = config.speed.printSpeed.toString();
 
-            // Track which printer is currently selected for operations
-            private _activePrinter = 0;
-            get activePrinter(): WebLabel.LabelPrinterUsb | undefined {
-                return this._activePrinter < 0 || this._activePrinter > this.printers.length
-                    ? undefined
-                    : this.printers[this._activePrinter];
-            }
-            set activePrinterIndex(printerIdx: number) {
-                this._activePrinter = printerIdx;
-                this.redrawTextCanvas();
-            }
+            (this.configModal.querySelector('#modalPrinterIndex')     as HTMLInputElement)!.value = config.serialNumber;
+            (this.configModal.querySelector('#modalPrinterIndexText') as HTMLSelectElement)!.textContent = printerIdx.toString();
+            (this.configModal.querySelector('#modalLabelWidth')       as HTMLSelectElement)!.value = config.mediaWidthInches.toString();
+            (this.configModal.querySelector('#modalLabelHeight')      as HTMLSelectElement)!.value = config.mediaLengthInches.toString();
+            (this.configModal.querySelector('#modalDarkness')         as HTMLSelectElement)!.value = config.darknessPercent.toString();
+            this.configModalHandle.show();
+          }
 
-            /** Initialize the app */
-            public async init() {
-                this.redrawPrinterButtons();
-                this.redrawTextCanvas();
-            }
+          /** Erase and re-draw the list of printer buttons in the UI. */
+          private redrawPrinterButtons() {
+            this.btnContainer.innerHTML = '';
+            this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
+          }
 
-            /** Display the configuration for a printer. */
-            public showConfigModal(printer: WebLabel.LabelPrinterUsb, printerIdx: number) {
-                if (printer == undefined) {
-                    return;
-                }
-                const config = printer.printerOptions;
+          /** Highlight only the currently selected printer. */
+          private redrawPrinterButtonHighlights() {
+            this.printers.forEach((printer, idx) => {
+              const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
+              const element = document.getElementById(`printer_${idx}`)!;
+              element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
+            });
+          }
 
-                // Translate the available speeds to options to be selected
-                const speedSelect = this.configModal.querySelector('#modalSpeed')! as HTMLSelectElement;
-                speedSelect.innerHTML = '';
-                const speedTable = printer.printerOptions.speedTable.table;
-                for (const [key] of speedTable) {
-                    // Skip utility values, so long as there's more than the defaults.
-                    // Mobile printers *only* support auto, for example.
-                    if ((speedTable.size > 3)
-                        && (key === WebLabel.PrintSpeed.ipsAuto
-                            || key === WebLabel.PrintSpeed.ipsPrinterMax
-                            || key === WebLabel.PrintSpeed.ipsPrinterMin
-                    )) {
-                        continue;
-                    }
-                    const opt = document.createElement('option');
-                    opt.value = key.toString();
-                    opt.innerHTML = WebLabel.PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
-                    speedSelect.appendChild(opt);
-                }
-                speedSelect.value = config.speed.printSpeed.toString();
+          /** Add a printer's button UI to the list of printers. */
+          private drawPrinterButton(printer: WebLabel.LabelPrinterUsb, idx: number) {
+            const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
 
-                (this.configModal.querySelector('#modalPrinterIndex') as HTMLInputElement)!.value            = config.serialNumber;
-                (this.configModal.querySelector('#modalPrinterIndexText') as HTMLSelectElement)!.textContent = printerIdx.toString();
-                (this.configModal.querySelector('#modalLabelWidth') as HTMLSelectElement)!.value             = config.mediaWidthInches.toString();
-                (this.configModal.querySelector('#modalLabelHeight') as HTMLSelectElement)!.value            = config.mediaLengthInches.toString();
-                (this.configModal.querySelector('#modalDarkness') as HTMLSelectElement)!.value               = config.darknessPercent.toString();
-                this.configModalHandle.show();
-            }
-
-            /** Erase and re-draw the list of printer buttons in the UI. */
-            private redrawPrinterButtons() {
-                this.btnContainer.innerHTML = '';
-                this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
-            }
-
-            /** Highlight only the currently selected printer. */
-            private redrawPrinterButtonHighlights() {
-                this.printers.forEach((printer, idx) => {
-                  const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
-                    const element = document.getElementById(`printer_${idx}`)!;
-                    element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
-                });
-            }
-
-            /** Add a printer's button UI to the list of printers. */
-            private drawPrinterButton(printer: WebLabel.LabelPrinterUsb, idx: number) {
-                const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
-
-                // Generate a new label printer button for the given printer.
-                const element = document.createElement("div");
-                element.innerHTML = `
+            // Generate a new label printer button for the given printer.
+            const element = document.createElement("div");
+            element.innerHTML = `
             <li id="printer_${idx}" data-printer-idx="${idx}"
                 class="list-group-item d-flex flex-row justify-content-between sligh-items-start"
                 style="background: linear-gradient(to right, ${highlight}, ${highlight}, grey, grey);">
@@ -329,180 +329,180 @@
                     </div>
                 </div>
             </li>`;
-                // And slap it into the button container.
-                this.btnContainer.appendChild(element);
+            // And slap it into the button container.
+            this.btnContainer.appendChild(element);
 
-                // Then wire up the button events so they work.
-                document.getElementById(`printto_${idx}`)!
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                        const printer = this.printers[printerIdx];
-                        const doc = this.addCanvasImageToLabelDoc(printer.getLabelDocument());
-                        await printer.sendDocument(doc);
-                    });
-                document.getElementById(`printer_${idx}`)!
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                        if (this._activePrinter === printerIdx) {
-                            // Don't refresh anything if we already have this printer selected..
-                            return;
-                        }
-                        this.activePrinterIndex = printerIdx;
-                        this.redrawPrinterButtonHighlights();
-                        this.redrawTextCanvas();
-                    });
-                document.getElementById(`printtest_${idx}`)!
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                        const printer = this.printers[printerIdx];
-                        const doc = WebLabel.ReadyToPrintDocuments.printTestLabelDocument(
-                            printer.printerOptions.mediaWidthDots);
-                        await printer.sendDocument(doc);
-                    });
-                document.getElementById(`feedlabel_${idx}`)!
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                        const printer = this.printers[printerIdx];
-                        const doc = WebLabel.ReadyToPrintDocuments.feedLabelDocument;
-                        await printer.sendDocument(doc);
-                    });
-                document.getElementById(`printconfig_${idx}`)!
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                        const printer = this.printers[printerIdx];
-                        const doc = WebLabel.ReadyToPrintDocuments.printConfigDocument;
-                        await printer.sendDocument(doc);
-                    });
-                document.getElementById(`configprinter_${idx}`)!
-                    .addEventListener('click', async (e) => {
-                        e.preventDefault();
-                        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                        const printer = this.printers[printerIdx];
-                        this.showConfigModal(printer, printerIdx);
-                    });
-            }
-
-            /** Redraw the text canvas size according to the printer. */
-            private redrawTextCanvas() {
-                const printer = this.activePrinter;
-                if (printer === undefined) {
-                    this.labelForm.classList.add('d-none');
-                    this.labelFormInstructions.classList.remove('d-none');
-                    return;
-                } else {
-                    this.labelForm.classList.remove('d-none');
-                    this.labelFormInstructions.classList.add('d-none');
-                }
-
-                // Resize the canvas to match the label size.
-                const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-                // Add a small margin as printer alignment is not exact.
-                canvas.width = printer.printerOptions.mediaWidthDots - 2;
-                canvas.height = printer.printerOptions.mediaLengthDots - 2;
-
-                const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-                textarea.value = "Enter your label text here!";
-                this.renderTextForm();
-            }
-
-            /** Render the text form to the canvas */
-            private renderTextForm() {
-                const printer = this.activePrinter;
-                if (printer === undefined) {
-                    return;
-                }
-
-                const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-                const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-                const pageContext = canvas.getContext('2d')!;
-                pageContext.clearRect(0, 0, canvas.width, canvas.height);
-
-                const fontSize = 30;
-
-                // We'd like the preview image to be as close as possible to what the printer will
-                // actually print. To do this we don't draw text to the page's canvas directly,
-                // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
-                // then render *that* back to the page's canvas. This is a more accurate picture of
-                // what the label will end up looking like.
-
-                // A more complex app could do this more gracefully!
-                const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d')!;
-                offscreenContext.font = `${fontSize}pt ${this.fontName}`;
-                offscreenContext.fillStyle = "#000000";
-
-                // fillText doesn't do newlines, do that manually
-                textarea.value.split('\n').forEach((l, i) => {
-                    offscreenContext.fillText(l, 5, (i * fontSize + 2) + fontSize);
-                })
-
-                // Now into the monochrome bitmap.
-                const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
-                const monoImg = WebLabel.BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
-                // And finally back onto the page.
-                pageContext.putImageData(monoImg.toImageData(), 0, 0);
-            }
-
-            /** Render the canvas to a document for printing */
-            private addCanvasImageToLabelDoc(builder: WebLabel.ILabelDocumentBuilder): WebLabel.IDocument {
-                const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-                const imgData = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
-
-                // One of the benefits of this library is being able to render images to a canvas element
-                // and sending that canvas directly to a label. This allows your webpage to generate complex
-                // images and fonts (like emoji!) that EPL/ZPL can't support.
-                return builder
-                    .addImageFromImageData(imgData)
-                    .addPrintCmd()
-                    .finalize();
-            }
-
-            /** Send the contents of the config form as a config label to the printer. */
-            private async updatePrinterConfig(e: SubmitEvent) {
+            // Then wire up the button events so they work.
+            document.getElementById(`printto_${idx}`)!
+              .addEventListener('click', async (e) => {
                 e.preventDefault();
-
-                // Figure out the right printer
-                const formElement = this.configModal.querySelector('form')!;
-                const form = formElement.elements as ConfigModalForm;
-                const printerIdx = parseInt((formElement.querySelector('#modalPrinterIndexText') as HTMLFormElement).innerText);
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
                 const printer = this.printers[printerIdx];
-                if (printer === undefined) {
-                    return;
-                }
-
-                form.modalSubmit.setAttribute("disabled", "");
-                form.modalCancel.setAttribute("disabled", "");
-
-                // Pull the values out of the form.
-                const darkness         = parseInt(form.modalDarkness.value) as WebLabel.DarknessPercent;
-                const rawSpeed         = parseInt(form.modalSpeed.value) as WebLabel.PrintSpeed;
-                const mediaWidthInches = parseFloat(form.modalLabelWidth.value);
-                const autosense        = form.modalWithAutosense.checked;
-
-                // Construct the config document with the values from the form
-                const configDoc = printer.getConfigDocument();
-
-                configDoc
-                    .setPrintDirection()
-                    .setLabelHomeOffsetDots(0, 0)
-                    .setPrintSpeed(rawSpeed)
-                    .setDarknessConfig(darkness)
-                    .setLabelDimensions(mediaWidthInches);
-                const doc = autosense
-                    ? configDoc.autosenseLabelLength()
-                    : configDoc.finalize();
-                // And send the whole shebang to the printer!
+                const doc = this.addCanvasImageToLabelDoc(printer.getLabelDocument());
                 await printer.sendDocument(doc);
-
-                form.modalSubmit.removeAttribute("disabled");
-                form.modalCancel.removeAttribute("disabled");
+              });
+            document.getElementById(`printer_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                if (this._activePrinter === printerIdx) {
+                  // Don't refresh anything if we already have this printer selected..
+                  return;
+                }
                 this.activePrinterIndex = printerIdx;
-                this.configModalHandle.hide();
+                this.redrawPrinterButtonHighlights();
+                this.redrawTextCanvas();
+              });
+            document.getElementById(`printtest_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                const doc = WebLabel.ReadyToPrintDocuments.printTestLabelDocument(
+                  printer.printerOptions.mediaWidthDots);
+                await printer.sendDocument(doc);
+              });
+            document.getElementById(`feedlabel_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                const doc = WebLabel.ReadyToPrintDocuments.feedLabelDocument;
+                await printer.sendDocument(doc);
+              });
+            document.getElementById(`printconfig_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                const doc = WebLabel.ReadyToPrintDocuments.printConfigDocument;
+                await printer.sendDocument(doc);
+              });
+            document.getElementById(`configprinter_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                this.showConfigModal(printer, printerIdx);
+              });
+          }
+
+          /** Redraw the text canvas size according to the printer. */
+          private redrawTextCanvas() {
+            const printer = this.activePrinter;
+            if (printer === undefined) {
+              this.labelForm.classList.add('d-none');
+              this.labelFormInstructions.classList.remove('d-none');
+              return;
+            } else {
+              this.labelForm.classList.remove('d-none');
+              this.labelFormInstructions.classList.add('d-none');
             }
+
+            // Resize the canvas to match the label size.
+            const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+            // Add a small margin as printer alignment is not exact.
+            canvas.width = printer.printerOptions.mediaWidthDots - 2;
+            canvas.height = printer.printerOptions.mediaLengthDots - 2;
+
+            const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+            textarea.value = "Enter your label text here!";
+            this.renderTextForm();
+          }
+
+          /** Render the text form to the canvas */
+          private renderTextForm() {
+            const printer = this.activePrinter;
+            if (printer === undefined) {
+              return;
+            }
+
+            const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+            const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+            const pageContext = canvas.getContext('2d')!;
+            pageContext.clearRect(0, 0, canvas.width, canvas.height);
+
+            const fontSize = 30;
+
+            // We'd like the preview image to be as close as possible to what the printer will
+            // actually print. To do this we don't draw text to the page's canvas directly,
+            // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
+            // then render *that* back to the page's canvas. This is a more accurate picture of
+            // what the label will end up looking like.
+
+            // A more complex app could do this more gracefully!
+            const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d')!;
+            offscreenContext.font = `${fontSize}pt ${this.fontName}`;
+            offscreenContext.fillStyle = "#000000";
+
+            // fillText doesn't do newlines, do that manually
+            textarea.value.split('\n').forEach((l, i) => {
+              offscreenContext.fillText(l, 5, (i * fontSize + 2) + fontSize);
+            })
+
+            // Now into the monochrome bitmap.
+            const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
+            const monoImg = WebLabel.BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
+            // And finally back onto the page.
+            pageContext.putImageData(monoImg.toImageData(), 0, 0);
+          }
+
+          /** Render the canvas to a document for printing */
+          private addCanvasImageToLabelDoc(builder: WebLabel.ILabelDocumentBuilder): WebLabel.IDocument {
+            const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+            const imgData = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
+
+            // One of the benefits of this library is being able to render images to a canvas element
+            // and sending that canvas directly to a label. This allows your webpage to generate complex
+            // images and fonts (like emoji!) that EPL/ZPL can't support.
+            return builder
+              .addImageFromImageData(imgData)
+              .addPrintCmd()
+              .finalize();
+          }
+
+          /** Send the contents of the config form as a config label to the printer. */
+          private async updatePrinterConfig(e: SubmitEvent) {
+            e.preventDefault();
+
+            // Figure out the right printer
+            const formElement = this.configModal.querySelector('form')!;
+            const form = formElement.elements as ConfigModalForm;
+            const printerIdx = parseInt((formElement.querySelector('#modalPrinterIndexText') as HTMLFormElement).innerText);
+            const printer = this.printers[printerIdx];
+            if (printer === undefined) {
+              return;
+            }
+
+            form.modalSubmit.setAttribute("disabled", "");
+            form.modalCancel.setAttribute("disabled", "");
+
+            // Pull the values out of the form.
+            const darkness = parseInt(form.modalDarkness.value) as WebLabel.DarknessPercent;
+            const rawSpeed = parseInt(form.modalSpeed.value) as WebLabel.PrintSpeed;
+            const mediaWidthInches = parseFloat(form.modalLabelWidth.value);
+            const autosense = form.modalWithAutosense.checked;
+
+            // Construct the config document with the values from the form
+            const configDoc = printer.getConfigDocument();
+
+            configDoc
+              .setPrintDirection()
+              .setLabelHomeOffsetDots(0, 0)
+              .setPrintSpeed(rawSpeed)
+              .setDarknessConfig(darkness)
+              .setLabelDimensions(mediaWidthInches);
+            const doc = autosense
+              ? configDoc.autosenseLabelLength()
+              : configDoc.finalize();
+            // And send the whole shebang to the printer!
+            await printer.sendDocument(doc);
+
+            form.modalSubmit.removeAttribute("disabled");
+            form.modalCancel.removeAttribute("disabled");
+            this.activePrinterIndex = printerIdx;
+            this.configModalHandle.hide();
+          }
         }
 
         // With the app class defined we can run it.

--- a/demo/test_advanced.ts
+++ b/demo/test_advanced.ts
@@ -90,6 +90,7 @@ interface ConfigModalForm extends HTMLCollection {
   modalLabelWidth     : HTMLInputElement
   modalMediaType      : HTMLSelectElement
   modalSpeed          : HTMLSelectElement
+  modalBackfeedPercent: HTMLSelectElement
   modalSubmit         : HTMLButtonElement
   modalWithAutosense  : HTMLInputElement
 }
@@ -236,13 +237,14 @@ class BasicLabelDesignerApp {
         break;
     }
 
-    (this.configModal.querySelector('#modalPrinterIndex')     as HTMLInputElement)!.value = config.serialNumber;
-    (this.configModal.querySelector('#modalPrinterIndexText') as HTMLSelectElement)!.textContent = printerIdx.toString();
-    (this.configModal.querySelector('#modalLabelWidth')       as HTMLSelectElement)!.value = config.mediaWidthInches.toString();
-    (this.configModal.querySelector('#modalLabelHeight')      as HTMLSelectElement)!.value = config.mediaLengthInches.toString();
-    (this.configModal.querySelector('#modalDarkness')         as HTMLSelectElement)!.value = config.darknessPercent.toString();
-    (this.configModal.querySelector('#modalLabelOffsetLeft')  as HTMLSelectElement)!.value = config.mediaPrintOriginOffsetDots.left.toString();
-    (this.configModal.querySelector('#modalLabelOffsetTop')   as HTMLSelectElement)!.value = config.mediaPrintOriginOffsetDots.top.toString();
+    (this.configModal.querySelector('#modalPrinterIndex') as HTMLInputElement)!.value = config.serialNumber;
+    (this.configModal.querySelector('#modalPrinterIndexText') as HTMLInputElement)!.textContent = printerIdx.toString();
+    (this.configModal.querySelector('#modalLabelWidth') as HTMLInputElement)!.value = config.mediaWidthInches.toString();
+    (this.configModal.querySelector('#modalLabelHeight') as HTMLInputElement)!.value = config.mediaLengthInches.toString();
+    (this.configModal.querySelector('#modalDarkness') as HTMLInputElement)!.value = config.darknessPercent.toString();
+    (this.configModal.querySelector('#modalLabelOffsetLeft') as HTMLInputElement)!.value = config.mediaPrintOriginOffsetDots.left.toString();
+    (this.configModal.querySelector('#modalLabelOffsetTop') as HTMLInputElement)!.value = config.mediaPrintOriginOffsetDots.top.toString();
+    (this.configModal.querySelector('#modalBackfeedPercent') as HTMLSelectElement)!.value = config.backfeedAfterTaken.toString();
     this.configModalHandle.show();
   }
 
@@ -462,6 +464,8 @@ class BasicLabelDesignerApp {
     const offsetLeft = parseInt(form.modalLabelOffsetLeft.value);
     const offsetTop = parseInt(form.modalLabelOffsetTop.value);
 
+    const backfeedAfterTaken = form.modalBackfeedPercent.value as WebLabel.BackfeedAfterTaken;
+
     // Construct the config document with the values from the form
     const configDoc = printer.getConfigDocument();
 
@@ -486,13 +490,15 @@ class BasicLabelDesignerApp {
       .setLabelPrintOriginOffsetCommand(offsetLeft, offsetTop)
       .setPrintSpeed(rawSpeed)
       .setDarknessConfig(darkness)
-      .setLabelDimensions(mediaWidthInches);
+      .setLabelDimensions(mediaWidthInches)
+      .setBackfeedAfterTakenMode(backfeedAfterTaken);
     const doc = autosense
       ? configDoc.autosenseLabelLength()
       : configDoc.finalize();
     // And send the whole shebang to the printer!
     await printer.sendDocument(doc);
 
+    form.modalWithAutosense.checked = false;
     form.modalSubmit.removeAttribute("disabled");
     form.modalCancel.removeAttribute("disabled");
     this.activePrinterIndex = printerIdx;

--- a/demo/test_advanced.ts
+++ b/demo/test_advanced.ts
@@ -40,32 +40,32 @@ addPrinterBtn.addEventListener('click', async () => printerMgr.promptForNewDevic
 const refreshPrinterBtn = document.getElementById('refreshPrinters')!;
 refreshPrinterBtn.addEventListener('click', async () => printerMgr.forceReconnect());
 
-// Next we wire up some events on the PrinterUsbManager itself.
+// Next we wire up some events on the UsbDeviceManager itself.
 printerMgr.addEventListener('connectedDevice', ({ detail }) => {
 
-    // Let's print some details about the printer that was connected.
-    const printer = detail.device;
-    console.log('New printer is a', printer.printerModel);
-    const config = printer.printerOptions;
-    console.log('Printer darkness is', config.darknessPercent, 'percent');
-    console.log('Printer speed is', WebLabel.PrintSpeed[config.speed.printSpeed]);
-    console.log(
-        'Label is',
-        config.mediaWidthInches,
-        'in wide and',
-        config.mediaLengthInches,
-        'in long');
-    console.log('Printer media mode is', WebLabel.MediaMediaGapDetectionMode[config.mediaGapDetectMode]);
+  // Let's print some details about the printer that was connected.
+  const printer = detail.device;
+  console.log('New printer is a', printer.printerModel);
+  const config = printer.printerOptions;
+  console.log('Printer darkness is', config.darknessPercent, 'percent');
+  console.log('Printer speed is', WebLabel.PrintSpeed[config.speed.printSpeed]);
+  console.log(
+    'Label is',
+    config.mediaWidthInches,
+    'in wide and',
+    config.mediaLengthInches,
+    'in long');
+  console.log('Printer media mode is', WebLabel.MediaMediaGapDetectionMode[config.mediaGapDetectMode]);
 
-    // You can do stuff with the printer that connected. It's a good idea
-    // to immediately query the printer for its status.
-    printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
+  // You can do stuff with the printer that connected. It's a good idea
+  // to immediately query the printer for its status.
+  printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
 });
 
 // There's also an event that will tell you when a printer disconnects.
 printerMgr.addEventListener('disconnectedDevice', ({ detail }) => {
-    const printer = detail.device;
-    console.log('Lost printer', printer.printerModel, 'serial', printer.printerOptions.serialNumber);
+  const printer = detail.device;
+  console.log('Lost printer', printer.printerModel, 'serial', printer.printerOptions.serialNumber);
 });
 
 // When the browser first loaded the page any previously connected printers would have caused
@@ -82,192 +82,192 @@ printerMgr.addEventListener('disconnectedDevice', ({ detail }) => {
 
 // First we create an interface to describe our settings form.
 interface ConfigModalForm extends HTMLCollection {
-    modalCancel         : HTMLButtonElement
-    modalDarkness       : HTMLSelectElement
-    modalLabelHeight    : HTMLInputElement
-    modalLabelOffsetLeft: HTMLInputElement
-    modalLabelOffsetTop : HTMLInputElement
-    modalLabelWidth     : HTMLInputElement
-    modalMediaType      : HTMLSelectElement
-    modalSpeed          : HTMLSelectElement
-    modalSubmit         : HTMLButtonElement
-    modalWithAutosense  : HTMLInputElement
+  modalCancel         : HTMLButtonElement
+  modalDarkness       : HTMLSelectElement
+  modalLabelHeight    : HTMLInputElement
+  modalLabelOffsetLeft: HTMLInputElement
+  modalLabelOffsetTop : HTMLInputElement
+  modalLabelWidth     : HTMLInputElement
+  modalMediaType      : HTMLSelectElement
+  modalSpeed          : HTMLSelectElement
+  modalSubmit         : HTMLButtonElement
+  modalWithAutosense  : HTMLInputElement
 }
 
 // The app's logic is wrapped in a class just for ease of reading.
 class BasicLabelDesignerApp {
-    constructor(
-        private manager: PrinterManager,
-        private btnContainer: HTMLElement,
-        private labelForm: HTMLElement,
-        private labelFormInstructions: HTMLElement,
-        private configModal: HTMLElement
-    ) {
-        // Based on the containers, map the various listeners.
-        this.configModalHandle = new bootstrap.Modal(this.configModal);
-        this.configModal
-            .querySelector('form')!
-            .addEventListener('submit', this.updatePrinterConfig.bind(this));
-        this.labelForm.addEventListener('blur', this.renderTextForm.bind(this));
-        this.labelForm.addEventListener('keyup', this.renderTextForm.bind(this));
+  constructor(
+    private manager: PrinterManager,
+    private btnContainer: HTMLElement,
+    private labelForm: HTMLElement,
+    private labelFormInstructions: HTMLElement,
+    private configModal: HTMLElement
+  ) {
+    // Based on the containers, map the various listeners.
+    this.configModalHandle = new bootstrap.Modal(this.configModal);
+    this.configModal
+      .querySelector('form')!
+      .addEventListener('submit', this.updatePrinterConfig.bind(this));
+    this.labelForm.addEventListener('blur', this.renderTextForm.bind(this));
+    this.labelForm.addEventListener('keyup', this.renderTextForm.bind(this));
 
-        // Add a second set of event listeners for printer connect and disconnect to redraw
-        // the printer list when it changes.
-        this.manager.addEventListener('connectedDevice', ({detail}) => {
-            this.activePrinterIndex = -1;
-            this.redrawPrinterButtons();
+    // Add a second set of event listeners for printer connect and disconnect to redraw
+    // the printer list when it changes.
+    this.manager.addEventListener('connectedDevice', ({ detail }) => {
+      this.activePrinterIndex = -1;
+      this.redrawPrinterButtons();
 
-            // Printers themselves also have events, let's show an alert on errors.
-            const printer = detail.device;
-            printer.addEventListener('reportedError', ({ detail: msg }) => {
-                // Error messages may indicate no error, we can ignore those.
-                if (msg.errors.has(WebLabel.ErrorState.NoError)) { return; }
+      // Printers themselves also have events, let's show an alert on errors.
+      const printer = detail.device;
+      printer.addEventListener('reportedError', ({ detail: msg }) => {
+        // Error messages may indicate no error, we can ignore those.
+        if (msg.errors.has(WebLabel.ErrorState.NoError)) { return; }
 
-                const alertWrapper = document.createElement('div');
-                alertWrapper.innerHTML = `
-                <div class="alert alert-warning alert-dismissible fade show alert-printererror" role="alert">
-                    <h4>Printer <strong>${printer.printerSerial}</strong> has an error</h4>
-                    <p>${JSON.stringify(msg, null, 2)}</p>
-                    <hr>
-                    <p>Fix the issue, then dismiss this alert to check the status again.</p>
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                </div>`
-                document.getElementById('printerAlertSpace')?.appendChild(alertWrapper);
+        const alertWrapper = document.createElement('div');
+        alertWrapper.innerHTML = `
+          <div class="alert alert-warning alert-dismissible fade show alert-printererror" role="alert">
+              <h4>Printer <strong>${printer.printerSerial}</strong> has an error</h4>
+              <p>${JSON.stringify(msg, null, 2)}</p>
+              <hr>
+              <p>Fix the issue, then dismiss this alert to check the status again.</p>
+              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+          </div>`
+        document.getElementById('printerAlertSpace')?.appendChild(alertWrapper);
 
-                // and even go one layer deeper!
-                alertWrapper.firstElementChild!.addEventListener('closed.bs.alert', () => {
-                    printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
-                });
-            });
+        // and even go one layer deeper!
+        alertWrapper.firstElementChild!.addEventListener('closed.bs.alert', () => {
+          printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
         });
-        this.manager.addEventListener('disconnectedDevice', () => {
-            this.activePrinterIndex = -1;
-            this.redrawPrinterButtons();
-        });
+      });
+    });
+    this.manager.addEventListener('disconnectedDevice', () => {
+      this.activePrinterIndex = -1;
+      this.redrawPrinterButtons();
+    });
 
-        // Here's a nice font with a great set of emoji that work well for monochrome printing.
-        // The text font is fairly basic though, so we would like to use only the emoji out
-        // of this font and use a basic sans-serif font for regular text.
-        // https://fonts.google.com/noto/specimen/Noto+Emoji
-        const emojiFontName = 'noto-emoji';
+    // Here's a nice font with a great set of emoji that work well for monochrome printing.
+    // The text font is fairly basic though, so we would like to use only the emoji out
+    // of this font and use a basic sans-serif font for regular text.
+    // https://fonts.google.com/noto/specimen/Noto+Emoji
+    const emojiFontName = 'noto-emoji';
 
-        // We can accomplish this with the unicodeRange property of our FontFace. We just
-        // need to list EVERY SINGLE EMOJI UNICODE RANGE to make it work. Fortunately someone
-        // has done this already: https://github.com/fraction/emoji-unicode-range
-        const emojiUnicodeRange = 'U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2604,U+260E,U+2611,U+2614-2615,U+2618,U+261D,U+2620,U+2622-2623,U+2626,U+262A,U+262E-262F,U+2638-263A,U+2640,U+2642,U+2648-2653,U+265F-2660,U+2663,U+2665-2666,U+2668,U+267B,U+267E-267F,U+2692-2697,U+2699,U+269B-269C,U+26A0-26A1,U+26AA-26AB,U+26B0-26B1,U+26BD-26BE,U+26C4-26C5,U+26C8,U+26CE,U+26CF,U+26D1,U+26D3-26D4,U+26E9-26EA,U+26F0-26F5,U+26F7-26FA,U+26FD,U+2702,U+2705,U+2708-2709,U+270A-270B,U+270C-270D,U+270F,U+2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2764,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F004,U+1F0CF,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201-1F202,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F321,U+1F324-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F396-1F397,U+1F399-1F39B,U+1F39E-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F3-1F3F5,U+1F3F7,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD,U+1F4FF,U+1F500-1F53D,U+1F549-1F54A,U+1F54B-1F54E,U+1F550-1F567,U+1F56F-1F570,U+1F573-1F579,U+1F57A,U+1F587,U+1F58A-1F58D,U+1F590,U+1F595-1F596,U+1F5A4,U+1F5A5,U+1F5A8,U+1F5B1-1F5B2,U+1F5BC,U+1F5C2-1F5C4,U+1F5D1-1F5D3,U+1F5DC-1F5DE,U+1F5E1,U+1F5E3,U+1F5E8,U+1F5EF,U+1F5F3,U+1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CB-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6E0-1F6E5,U+1F6E9,U+1F6EB-1F6EC,U+1F6F0,U+1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+231A-231B,U+23E9-23EC,U+23F0,U+23F3,U+25FD-25FE,U+2614-2615,U+2648-2653,U+267F,U+2693,U+26A1,U+26AA-26AB,U+26BD-26BE,U+26C4-26C5,U+26CE,U+26D4,U+26EA,U+26F2-26F3,U+26F5,U+26FA,U+26FD,U+2705,U+270A-270B,U+2728,U+274C,U+274E,U+2753-2755,U+2757,U+2795-2797,U+27B0,U+27BF,U+2B1B-2B1C,U+2B50,U+2B55,U+1F004,U+1F0CF,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201,U+1F21A,U+1F22F,U+1F232-1F236,U+1F238-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F32D-1F32F,U+1F330-1F335,U+1F337-1F37C,U+1F37E-1F37F,U+1F380-1F393,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CF-1F3D3,U+1F3E0-1F3F0,U+1F3F4,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F440,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FF,U+1F500-1F53D,U+1F54B-1F54E,U+1F550-1F567,U+1F57A,U+1F595-1F596,U+1F5A4,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CC,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6EB-1F6EC,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+1F3FB-1F3FF,U+261D,U+26F9,U+270A-270B,U+270C-270D,U+1F385,U+1F3C2-1F3C4,U+1F3C7,U+1F3CA,U+1F3CB-1F3CC,U+1F442-1F443,U+1F446-1F450,U+1F466-1F478,U+1F47C,U+1F481-1F483,U+1F485-1F487,U+1F48F,U+1F491,U+1F4AA,U+1F574-1F575,U+1F57A,U+1F590,U+1F595-1F596,U+1F645-1F647,U+1F64B-1F64F,U+1F6A3,U+1F6B4-1F6B6,U+1F6C0,U+1F6CC,U+1F90F,U+1F918,U+1F919-1F91E,U+1F91F,U+1F926,U+1F930,U+1F931-1F932,U+1F933-1F939,U+1F93C-1F93E,U+1F9B5-1F9B6,U+1F9B8-1F9B9,U+1F9BB,U+1F9CD-1F9CF,U+1F9D1-1F9DD,U+0023,U+002A,U+0030-0039,U+200D,U+20E3,U+FE0F,U+1F1E6-1F1FF,U+1F3FB-1F3FF,U+1F9B0-1F9B3,U+E0020-E007F,U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+2388,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2605,U+2607-2612,U+2614-2615,U+2616-2617,U+2618,U+2619,U+261A-266F,U+2670-2671,U+2672-267D,U+267E-267F,U+2680-2685,U+2690-2691,U+2692-269C,U+269D,U+269E-269F,U+26A0-26A1,U+26A2-26B1,U+26B2,U+26B3-26BC,U+26BD-26BF,U+26C0-26C3,U+26C4-26CD,U+26CE,U+26CF-26E1,U+26E2,U+26E3,U+26E4-26E7,U+26E8-26FF,U+2700,U+2701-2704,U+2705,U+2708-2709,U+270A-270B,U+270C-2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2767,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F000-1F02B,U+1F02C-1F02F,U+1F030-1F093,U+1F094-1F09F,U+1F0A0-1F0AE,U+1F0AF-1F0B0,U+1F0B1-1F0BE,U+1F0BF,U+1F0C0,U+1F0C1-1F0CF,U+1F0D0,U+1F0D1-1F0DF,U+1F0E0-1F0F5,U+1F0F6-1F0FF,U+1F10D-1F10F,U+1F12F,U+1F16C,U+1F16D-1F16F,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1AD-1F1E5,U+1F201-1F202,U+1F203-1F20F,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F23C-1F23F,U+1F249-1F24F,U+1F250-1F251,U+1F252-1F25F,U+1F260-1F265,U+1F266-1F2FF,U+1F300-1F320,U+1F321-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F394-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F1-1F3F7,U+1F3F8-1F3FA,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD-1F4FE,U+1F4FF,U+1F500-1F53D,U+1F546-1F54A,U+1F54B-1F54F,U+1F550-1F567,U+1F568-1F579,U+1F57A,U+1F57B-1F5A3,U+1F5A4,U+1F5A5-1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6C6-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D3-1F6D4,U+1F6D5,U+1F6D6-1F6DF,U+1F6E0-1F6EC,U+1F6ED-1F6EF,U+1F6F0-1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F6FB-1F6FF,U+1F774-1F77F,U+1F7D5-1F7D8,U+1F7D9-1F7DF,U+1F7E0-1F7EB,U+1F7EC-1F7FF,U+1F80C-1F80F,U+1F848-1F84F,U+1F85A-1F85F,U+1F888-1F88F,U+1F8AE-1F8FF,U+1F90C,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F972,U+1F973-1F976,U+1F977-1F979,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A3-1F9A4,U+1F9A5-1F9AA,U+1F9AB-1F9AD,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CB-1F9CC,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA00-1FA53,U+1FA54-1FA5F,U+1FA60-1FA6D,U+1FA6E-1FA6F,U+1FA70-1FA73,U+1FA74-1FA77,U+1FA78-1FA7A,U+1FA7B-1FA7F,U+1FA80-1FA82,U+1FA83-1FA8F,U+1FA90-1FA95,U+1FA96-1FFFD';
+    // We can accomplish this with the unicodeRange property of our FontFace. We just
+    // need to list EVERY SINGLE EMOJI UNICODE RANGE to make it work. Fortunately someone
+    // has done this already: https://github.com/fraction/emoji-unicode-range
+    const emojiUnicodeRange = 'U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2604,U+260E,U+2611,U+2614-2615,U+2618,U+261D,U+2620,U+2622-2623,U+2626,U+262A,U+262E-262F,U+2638-263A,U+2640,U+2642,U+2648-2653,U+265F-2660,U+2663,U+2665-2666,U+2668,U+267B,U+267E-267F,U+2692-2697,U+2699,U+269B-269C,U+26A0-26A1,U+26AA-26AB,U+26B0-26B1,U+26BD-26BE,U+26C4-26C5,U+26C8,U+26CE,U+26CF,U+26D1,U+26D3-26D4,U+26E9-26EA,U+26F0-26F5,U+26F7-26FA,U+26FD,U+2702,U+2705,U+2708-2709,U+270A-270B,U+270C-270D,U+270F,U+2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2764,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F004,U+1F0CF,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201-1F202,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F321,U+1F324-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F396-1F397,U+1F399-1F39B,U+1F39E-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F3-1F3F5,U+1F3F7,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD,U+1F4FF,U+1F500-1F53D,U+1F549-1F54A,U+1F54B-1F54E,U+1F550-1F567,U+1F56F-1F570,U+1F573-1F579,U+1F57A,U+1F587,U+1F58A-1F58D,U+1F590,U+1F595-1F596,U+1F5A4,U+1F5A5,U+1F5A8,U+1F5B1-1F5B2,U+1F5BC,U+1F5C2-1F5C4,U+1F5D1-1F5D3,U+1F5DC-1F5DE,U+1F5E1,U+1F5E3,U+1F5E8,U+1F5EF,U+1F5F3,U+1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CB-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6E0-1F6E5,U+1F6E9,U+1F6EB-1F6EC,U+1F6F0,U+1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+231A-231B,U+23E9-23EC,U+23F0,U+23F3,U+25FD-25FE,U+2614-2615,U+2648-2653,U+267F,U+2693,U+26A1,U+26AA-26AB,U+26BD-26BE,U+26C4-26C5,U+26CE,U+26D4,U+26EA,U+26F2-26F3,U+26F5,U+26FA,U+26FD,U+2705,U+270A-270B,U+2728,U+274C,U+274E,U+2753-2755,U+2757,U+2795-2797,U+27B0,U+27BF,U+2B1B-2B1C,U+2B50,U+2B55,U+1F004,U+1F0CF,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201,U+1F21A,U+1F22F,U+1F232-1F236,U+1F238-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F32D-1F32F,U+1F330-1F335,U+1F337-1F37C,U+1F37E-1F37F,U+1F380-1F393,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CF-1F3D3,U+1F3E0-1F3F0,U+1F3F4,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F440,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FF,U+1F500-1F53D,U+1F54B-1F54E,U+1F550-1F567,U+1F57A,U+1F595-1F596,U+1F5A4,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CC,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6EB-1F6EC,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+1F3FB-1F3FF,U+261D,U+26F9,U+270A-270B,U+270C-270D,U+1F385,U+1F3C2-1F3C4,U+1F3C7,U+1F3CA,U+1F3CB-1F3CC,U+1F442-1F443,U+1F446-1F450,U+1F466-1F478,U+1F47C,U+1F481-1F483,U+1F485-1F487,U+1F48F,U+1F491,U+1F4AA,U+1F574-1F575,U+1F57A,U+1F590,U+1F595-1F596,U+1F645-1F647,U+1F64B-1F64F,U+1F6A3,U+1F6B4-1F6B6,U+1F6C0,U+1F6CC,U+1F90F,U+1F918,U+1F919-1F91E,U+1F91F,U+1F926,U+1F930,U+1F931-1F932,U+1F933-1F939,U+1F93C-1F93E,U+1F9B5-1F9B6,U+1F9B8-1F9B9,U+1F9BB,U+1F9CD-1F9CF,U+1F9D1-1F9DD,U+0023,U+002A,U+0030-0039,U+200D,U+20E3,U+FE0F,U+1F1E6-1F1FF,U+1F3FB-1F3FF,U+1F9B0-1F9B3,U+E0020-E007F,U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+2388,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2605,U+2607-2612,U+2614-2615,U+2616-2617,U+2618,U+2619,U+261A-266F,U+2670-2671,U+2672-267D,U+267E-267F,U+2680-2685,U+2690-2691,U+2692-269C,U+269D,U+269E-269F,U+26A0-26A1,U+26A2-26B1,U+26B2,U+26B3-26BC,U+26BD-26BF,U+26C0-26C3,U+26C4-26CD,U+26CE,U+26CF-26E1,U+26E2,U+26E3,U+26E4-26E7,U+26E8-26FF,U+2700,U+2701-2704,U+2705,U+2708-2709,U+270A-270B,U+270C-2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2767,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F000-1F02B,U+1F02C-1F02F,U+1F030-1F093,U+1F094-1F09F,U+1F0A0-1F0AE,U+1F0AF-1F0B0,U+1F0B1-1F0BE,U+1F0BF,U+1F0C0,U+1F0C1-1F0CF,U+1F0D0,U+1F0D1-1F0DF,U+1F0E0-1F0F5,U+1F0F6-1F0FF,U+1F10D-1F10F,U+1F12F,U+1F16C,U+1F16D-1F16F,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1AD-1F1E5,U+1F201-1F202,U+1F203-1F20F,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F23C-1F23F,U+1F249-1F24F,U+1F250-1F251,U+1F252-1F25F,U+1F260-1F265,U+1F266-1F2FF,U+1F300-1F320,U+1F321-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F394-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F1-1F3F7,U+1F3F8-1F3FA,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD-1F4FE,U+1F4FF,U+1F500-1F53D,U+1F546-1F54A,U+1F54B-1F54F,U+1F550-1F567,U+1F568-1F579,U+1F57A,U+1F57B-1F5A3,U+1F5A4,U+1F5A5-1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6C6-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D3-1F6D4,U+1F6D5,U+1F6D6-1F6DF,U+1F6E0-1F6EC,U+1F6ED-1F6EF,U+1F6F0-1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F6FB-1F6FF,U+1F774-1F77F,U+1F7D5-1F7D8,U+1F7D9-1F7DF,U+1F7E0-1F7EB,U+1F7EC-1F7FF,U+1F80C-1F80F,U+1F848-1F84F,U+1F85A-1F85F,U+1F888-1F88F,U+1F8AE-1F8FF,U+1F90C,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F972,U+1F973-1F976,U+1F977-1F979,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A3-1F9A4,U+1F9A5-1F9AA,U+1F9AB-1F9AD,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CB-1F9CC,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA00-1FA53,U+1FA54-1FA5F,U+1FA60-1FA6D,U+1FA6E-1FA6F,U+1FA70-1FA73,U+1FA74-1FA77,U+1FA78-1FA7A,U+1FA7B-1FA7F,U+1FA80-1FA82,U+1FA83-1FA8F,U+1FA90-1FA95,U+1FA96-1FFFD';
 
-        // And then we can use that range with our font when we load it.
-        const emojiOnlyFont = new FontFace(emojiFontName, 'url(fonts/NotoEmoji-Regular.ttf)', {
-          unicodeRange: emojiUnicodeRange,
-        });
-        emojiOnlyFont.load().then(() => {
-            document.fonts.add(emojiOnlyFont);
-        });
-        // We then set our fallback font as part of the font family we use in the canvas.
-        // This order matters, latter fonts will use the unicodeRange to override earlier fonts.
-        this.fontName = `Sans-serif, ${emojiFontName}`
+    // And then we can use that range with our font when we load it.
+    const emojiOnlyFont = new FontFace(emojiFontName, 'url(fonts/NotoEmoji-Regular.ttf)', {
+      unicodeRange: emojiUnicodeRange,
+    });
+    emojiOnlyFont.load().then(() => {
+      document.fonts.add(emojiOnlyFont);
+    });
+    // We then set our fallback font as part of the font family we use in the canvas.
+    // This order matters, latter fonts will use the unicodeRange to override earlier fonts.
+    this.fontName = `Sans-serif, ${emojiFontName}`
+  }
+
+  // Some storage fields and utility properties
+  private fontName: string;
+  private configModalHandle: bootstrap.Modal;
+
+  get printers(): readonly WebLabel.LabelPrinterUsb[] {
+    return this.manager.devices;
+  }
+
+  // Track which printer is currently selected for operations
+  private _activePrinter = 0;
+  get activePrinter(): WebLabel.LabelPrinterUsb | undefined {
+    return this._activePrinter < 0 || this._activePrinter > this.printers.length
+      ? undefined
+      : this.printers[this._activePrinter];
+  }
+  set activePrinterIndex(printerIdx: number) {
+    this._activePrinter = printerIdx;
+    this.redrawTextCanvas();
+  }
+
+  /** Initialize the app */
+  public async init() {
+    this.redrawPrinterButtons();
+    this.redrawTextCanvas();
+  }
+
+  /** Display the configuration for a printer. */
+  public showConfigModal(printer: WebLabel.LabelPrinterUsb, printerIdx: number) {
+    if (printer == undefined) {
+      return;
+    }
+    const config = printer.printerOptions;
+
+    // Translate the available speeds to options to be selected
+    const speedSelect = this.configModal.querySelector('#modalSpeed')! as HTMLSelectElement;
+    speedSelect.innerHTML = '';
+    const speedTable = printer.printerOptions.speedTable.table;
+    for (const [key] of speedTable) {
+      // Skip utility values, so long as there's more than the defaults.
+      // Mobile printers *only* support auto, for example.
+      if ((speedTable.size > 3)
+        && (key === WebLabel.PrintSpeed.ipsAuto
+          || key === WebLabel.PrintSpeed.ipsPrinterMax
+          || key === WebLabel.PrintSpeed.ipsPrinterMin
+        )) {
+        continue;
+      }
+      const opt = document.createElement('option');
+      opt.value = key.toString();
+      opt.innerHTML = WebLabel.PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
+      speedSelect.appendChild(opt);
+    }
+    speedSelect.value = config.speed.printSpeed.toString();
+
+    const mediaSelect = this.configModal.querySelector('#modalMediaType')! as HTMLSelectElement;
+    switch (config.mediaGapDetectMode) {
+      case WebLabel.MediaMediaGapDetectionMode.continuous:
+        mediaSelect.value = "continuous";
+        break;
+      default:
+      case WebLabel.MediaMediaGapDetectionMode.webSensing:
+        mediaSelect.value = "gap";
+        break;
+      case WebLabel.MediaMediaGapDetectionMode.markSensing:
+        mediaSelect.value = "mark";
+        break;
     }
 
-    // Some storage fields and utility properties
-    private fontName: string;
-    private configModalHandle: bootstrap.Modal;
+    (this.configModal.querySelector('#modalPrinterIndex')     as HTMLInputElement)!.value = config.serialNumber;
+    (this.configModal.querySelector('#modalPrinterIndexText') as HTMLSelectElement)!.textContent = printerIdx.toString();
+    (this.configModal.querySelector('#modalLabelWidth')       as HTMLSelectElement)!.value = config.mediaWidthInches.toString();
+    (this.configModal.querySelector('#modalLabelHeight')      as HTMLSelectElement)!.value = config.mediaLengthInches.toString();
+    (this.configModal.querySelector('#modalDarkness')         as HTMLSelectElement)!.value = config.darknessPercent.toString();
+    (this.configModal.querySelector('#modalLabelOffsetLeft')  as HTMLSelectElement)!.value = config.mediaPrintOriginOffsetDots.left.toString();
+    (this.configModal.querySelector('#modalLabelOffsetTop')   as HTMLSelectElement)!.value = config.mediaPrintOriginOffsetDots.top.toString();
+    this.configModalHandle.show();
+  }
 
-    get printers() {
-        return this.manager.devices;
-    }
+  /** Erase and re-draw the list of printer buttons in the UI. */
+  private redrawPrinterButtons() {
+    this.btnContainer.innerHTML = '';
+    this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
+  }
 
-    // Track which printer is currently selected for operations
-    private _activePrinter = 0;
-    get activePrinter(): WebLabel.LabelPrinterUsb | undefined {
-        return this._activePrinter < 0 || this._activePrinter > this.printers.length
-            ? undefined
-            : this.printers[this._activePrinter];
-    }
-    set activePrinterIndex(printerIdx: number) {
-        this._activePrinter = printerIdx;
-        this.redrawTextCanvas();
-    }
+  /** Highlight only the currently selected printer. */
+  private redrawPrinterButtonHighlights() {
+    this.printers.forEach((printer, idx) => {
+      const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
+      const element = document.getElementById(`printer_${idx}`)!;
+      element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
+    });
+  }
 
-    /** Initialize the app */
-    public async init() {
-        this.redrawPrinterButtons();
-        this.redrawTextCanvas();
-    }
+  /** Add a printer's button UI to the list of printers. */
+  private drawPrinterButton(printer: WebLabel.LabelPrinterUsb, idx: number) {
+    const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
 
-    /** Display the configuration for a printer. */
-    public showConfigModal(printer: WebLabel.LabelPrinterUsb, printerIdx: number) {
-        if (printer == undefined) {
-            return;
-        }
-        const config = printer.printerOptions;
-
-        // Translate the available speeds to options to be selected
-        const speedSelect = this.configModal.querySelector('#modalSpeed')! as HTMLSelectElement;
-        speedSelect.innerHTML = '';
-        const speedTable = printer.printerOptions.speedTable.table;
-        for (const [key] of speedTable) {
-            // Skip utility values, so long as there's more than the defaults.
-            // Mobile printers *only* support auto, for example.
-            if ((speedTable.size > 3)
-                && (key === WebLabel.PrintSpeed.ipsAuto
-                    || key === WebLabel.PrintSpeed.ipsPrinterMax
-                    || key === WebLabel.PrintSpeed.ipsPrinterMin
-            )) {
-                continue;
-            }
-            const opt = document.createElement('option');
-            opt.value = key.toString();
-            opt.innerHTML = WebLabel.PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
-            speedSelect.appendChild(opt);
-        }
-        speedSelect.value = config.speed.printSpeed.toString();
-
-        const mediaSelect = this.configModal.querySelector('#modalMediaType')! as HTMLSelectElement;
-        switch (config.mediaGapDetectMode) {
-            case WebLabel.MediaMediaGapDetectionMode.continuous:
-                mediaSelect.value = "continuous";
-                break;
-            default:
-            case WebLabel.MediaMediaGapDetectionMode.webSensing:
-                mediaSelect.value = "gap";
-                break;
-            case WebLabel.MediaMediaGapDetectionMode.markSensing:
-                mediaSelect.value = "mark";
-                break;
-        }
-
-        (this.configModal.querySelector('#modalPrinterIndex') as HTMLInputElement)!.value            = config.serialNumber;
-        (this.configModal.querySelector('#modalPrinterIndexText') as HTMLSelectElement)!.textContent = printerIdx.toString();
-        (this.configModal.querySelector('#modalLabelWidth') as HTMLSelectElement)!.value             = config.mediaWidthInches.toString();
-        (this.configModal.querySelector('#modalLabelHeight') as HTMLSelectElement)!.value            = config.mediaLengthInches.toString();
-        (this.configModal.querySelector('#modalDarkness') as HTMLSelectElement)!.value               = config.darknessPercent.toString();
-        (this.configModal.querySelector('#modalLabelOffsetLeft') as HTMLSelectElement)!.value        = config.mediaPrintOriginOffsetDots.left.toString();
-        (this.configModal.querySelector('#modalLabelOffsetTop') as HTMLSelectElement)!.value         = config.mediaPrintOriginOffsetDots.top.toString();
-        this.configModalHandle.show();
-    }
-
-    /** Erase and re-draw the list of printer buttons in the UI. */
-    private redrawPrinterButtons() {
-        this.btnContainer.innerHTML = '';
-        this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
-    }
-
-    /** Highlight only the currently selected printer. */
-    private redrawPrinterButtonHighlights() {
-        this.printers.forEach((printer, idx) => {
-          const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
-            const element = document.getElementById(`printer_${idx}`)!;
-            element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
-        });
-    }
-
-    /** Add a printer's button UI to the list of printers. */
-    private drawPrinterButton(printer: WebLabel.LabelPrinterUsb, idx: number) {
-        const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
-
-        // Generate a new label printer button for the given printer.
-        const element = document.createElement("div");
-        element.innerHTML = `
+    // Generate a new label printer button for the given printer.
+    const element = document.createElement("div");
+    element.innerHTML = `
     <li id="printer_${idx}" data-printer-idx="${idx}"
         class="list-group-item d-flex flex-row justify-content-between sligh-items-start"
         style="background: linear-gradient(to right, ${highlight}, ${highlight}, grey, grey);">
@@ -303,201 +303,201 @@ class BasicLabelDesignerApp {
             </div>
         </div>
     </li>`;
-        // And slap it into the button container.
-        this.btnContainer.appendChild(element);
+    // And slap it into the button container.
+    this.btnContainer.appendChild(element);
 
-        // Then wire up the button events so they work.
-        document.getElementById(`printto_${idx}`)!
-            .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                const doc = this.addCanvasImageToLabelDoc(printer.getLabelDocument());
-                await printer.sendDocument(doc);
-            });
-        document.getElementById(`printer_${idx}`)!
-            .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                if (this._activePrinter === printerIdx) {
-                    // Don't refresh anything if we already have this printer selected..
-                    return;
-                }
-                this.activePrinterIndex = printerIdx;
-                this.redrawPrinterButtonHighlights();
-                this.redrawTextCanvas();
-            });
-        document.getElementById(`printtest_${idx}`)!
-            .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                const doc = WebLabel.ReadyToPrintDocuments.printTestLabelDocument(
-                    printer.printerOptions.mediaWidthDots);
-                await printer.sendDocument(doc);
-            });
-        document.getElementById(`feedlabel_${idx}`)!
-            .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                const doc = WebLabel.ReadyToPrintDocuments.feedLabelDocument;
-                await printer.sendDocument(doc);
-            });
-        document.getElementById(`printconfig_${idx}`)!
-            .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                const doc = WebLabel.ReadyToPrintDocuments.printConfigDocument;
-                await printer.sendDocument(doc);
-            });
-        document.getElementById(`configprinter_${idx}`)!
-            .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                this.showConfigModal(printer, printerIdx);
-            });
-    }
-
-    /** Redraw the text canvas size according to the printer. */
-    private redrawTextCanvas() {
-        const printer = this.activePrinter;
-        if (printer === undefined) {
-            this.labelForm.classList.add('d-none');
-            this.labelFormInstructions.classList.remove('d-none');
-            return;
-        } else {
-            this.labelForm.classList.remove('d-none');
-            this.labelFormInstructions.classList.add('d-none');
-        }
-
-        // Resize the canvas to match the label size.
-        const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-        // Add a small margin as printer alignment is not exact.
-        canvas.width = printer.printerOptions.mediaWidthDots - 2;
-        canvas.height = printer.printerOptions.mediaLengthDots - 2;
-
-        const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-        textarea.value = "Enter your label text here!";
-        this.renderTextForm();
-    }
-
-    /** Render the text form to the canvas */
-    private renderTextForm() {
-        const printer = this.activePrinter;
-        if (printer === undefined) {
-            return;
-        }
-
-        const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-        const fontsizer = this.labelForm.querySelector('#previewFontSize') as HTMLInputElement;
-        const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-        const pageContext = canvas.getContext('2d')!;
-        pageContext.clearRect(0, 0, canvas.width, canvas.height);
-
-        const fontSize = Math.trunc(parseFloat(fontsizer.value));
-
-        // We'd like the preview image to be as close as possible to what the printer will
-        // actually print. To do this we don't draw text to the page's canvas directly,
-        // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
-        // then render *that* back to the page's canvas. This is a more accurate picture of
-        // what the label will end up looking like.
-
-        // A more complex app could do this more gracefully!
-        const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d')!;
-        offscreenContext.font = `${fontSize}pt ${this.fontName}`;
-        offscreenContext.fillStyle = "#000000";
-
-        // fillText doesn't do newlines, do that manually
-        textarea.value.split('\n').forEach((l, i) => {
-            offscreenContext.fillText(l, 5, (i * fontSize + 2) + fontSize);
-        })
-
-        // Now into the monochrome bitmap.
-        const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
-        const monoImg = WebLabel.BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
-        // And finally back onto the page.
-        pageContext.putImageData(monoImg.toImageData(), 0, 0);
-    }
-
-    /** Render the canvas to a document for printing */
-    private addCanvasImageToLabelDoc(builder: WebLabel.ILabelDocumentBuilder): WebLabel.IDocument {
-        const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-        const imgData = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
-
-        // One of the benefits of this library is being able to render images to a canvas element
-        // and sending that canvas directly to a label. This allows your webpage to generate complex
-        // images and fonts (like emoji!) that EPL/ZPL can't support.
-        return builder
-            .addImageFromImageData(imgData)
-            .addPrintCmd()
-            .finalize();
-    }
-
-    /** Send the contents of the config form as a config label to the printer. */
-    private async updatePrinterConfig(e: SubmitEvent) {
+    // Then wire up the button events so they work.
+    document.getElementById(`printto_${idx}`)!
+      .addEventListener('click', async (e) => {
         e.preventDefault();
-
-        // Figure out the right printer
-        const formElement = this.configModal.querySelector('form')!;
-        const form = formElement.elements as ConfigModalForm;
-        const printerIdx = parseInt((formElement.querySelector('#modalPrinterIndexText') as HTMLFormElement).innerText);
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
         const printer = this.printers[printerIdx];
-        if (printer === undefined) {
-            return;
-        }
-
-        form.modalSubmit.setAttribute("disabled", "");
-        form.modalCancel.setAttribute("disabled", "");
-
-        // Pull the values out of the form.
-        const darkness         = parseInt(form.modalDarkness.value) as WebLabel.DarknessPercent;
-        const rawSpeed         = parseInt(form.modalSpeed.value) as WebLabel.PrintSpeed;
-        const mediaWidthInches = parseFloat(form.modalLabelWidth.value);
-        const autosense        = form.modalWithAutosense.checked;
-
-        const mediaLengthInches = parseFloat(form.modalLabelHeight.value);
-        const offsetLeft        = parseInt(form.modalLabelOffsetLeft.value);
-        const offsetTop =         parseInt(form.modalLabelOffsetTop.value);
-
-        // Construct the config document with the values from the form
-        const configDoc = printer.getConfigDocument();
-
-        // Form mode should be set first for other elements to work right.
-        switch (form.modalMediaType.value) {
-            case "continuous":
-                configDoc.setLabelMediaToContinuous(mediaLengthInches);
-                break;
-            case "mark":
-                // TODO: Make a form for black line sensing.
-                configDoc.setLabelMediaToMarkSense(mediaLengthInches, 16, 0);
-                break;
-            default:
-            case "gap":
-                // TODO: Make a form for label gap size.
-                configDoc.setLabelMediaToWebGapSense(mediaLengthInches, 16);
-                break;
-        }
-
-        configDoc
-            .setPrintDirection()
-            .setLabelPrintOriginOffsetCommand(offsetLeft, offsetTop)
-            .setPrintSpeed(rawSpeed)
-            .setDarknessConfig(darkness)
-            .setLabelDimensions(mediaWidthInches);
-        const doc = autosense
-            ? configDoc.autosenseLabelLength()
-            : configDoc.finalize();
-        // And send the whole shebang to the printer!
+        const doc = this.addCanvasImageToLabelDoc(printer.getLabelDocument());
         await printer.sendDocument(doc);
-
-        form.modalSubmit.removeAttribute("disabled");
-        form.modalCancel.removeAttribute("disabled");
+      });
+    document.getElementById(`printer_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        if (this._activePrinter === printerIdx) {
+          // Don't refresh anything if we already have this printer selected..
+          return;
+        }
         this.activePrinterIndex = printerIdx;
-        this.configModalHandle.hide();
+        this.redrawPrinterButtonHighlights();
+        this.redrawTextCanvas();
+      });
+    document.getElementById(`printtest_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = WebLabel.ReadyToPrintDocuments.printTestLabelDocument(
+          printer.printerOptions.mediaWidthDots);
+        await printer.sendDocument(doc);
+      });
+    document.getElementById(`feedlabel_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = WebLabel.ReadyToPrintDocuments.feedLabelDocument;
+        await printer.sendDocument(doc);
+      });
+    document.getElementById(`printconfig_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = WebLabel.ReadyToPrintDocuments.printConfigDocument;
+        await printer.sendDocument(doc);
+      });
+    document.getElementById(`configprinter_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        this.showConfigModal(printer, printerIdx);
+      });
+  }
+
+  /** Redraw the text canvas size according to the printer. */
+  private redrawTextCanvas() {
+    const printer = this.activePrinter;
+    if (printer === undefined) {
+      this.labelForm.classList.add('d-none');
+      this.labelFormInstructions.classList.remove('d-none');
+      return;
+    } else {
+      this.labelForm.classList.remove('d-none');
+      this.labelFormInstructions.classList.add('d-none');
     }
+
+    // Resize the canvas to match the label size.
+    const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+    // Add a small margin as printer alignment is not exact.
+    canvas.width = printer.printerOptions.mediaWidthDots - 2;
+    canvas.height = printer.printerOptions.mediaLengthDots - 2;
+
+    const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+    textarea.value = "Enter your label text here!";
+    this.renderTextForm();
+  }
+
+  /** Render the text form to the canvas */
+  private renderTextForm() {
+    const printer = this.activePrinter;
+    if (printer === undefined) {
+      return;
+    }
+
+    const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+    const fontsizer = this.labelForm.querySelector('#previewFontSize') as HTMLInputElement;
+    const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+    const pageContext = canvas.getContext('2d')!;
+    pageContext.clearRect(0, 0, canvas.width, canvas.height);
+
+    const fontSize = Math.trunc(parseFloat(fontsizer.value));
+
+    // We'd like the preview image to be as close as possible to what the printer will
+    // actually print. To do this we don't draw text to the page's canvas directly,
+    // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
+    // then render *that* back to the page's canvas. This is a more accurate picture of
+    // what the label will end up looking like.
+
+    // A more complex app could do this more gracefully!
+    const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d')!;
+    offscreenContext.font = `${fontSize}pt ${this.fontName}`;
+    offscreenContext.fillStyle = "#000000";
+
+    // fillText doesn't do newlines, do that manually
+    textarea.value.split('\n').forEach((l, i) => {
+      offscreenContext.fillText(l, 5, (i * fontSize + 2) + fontSize);
+    })
+
+    // Now into the monochrome bitmap.
+    const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
+    const monoImg = WebLabel.BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
+    // And finally back onto the page.
+    pageContext.putImageData(monoImg.toImageData(), 0, 0);
+  }
+
+  /** Render the canvas to a document for printing */
+  private addCanvasImageToLabelDoc(builder: WebLabel.ILabelDocumentBuilder): WebLabel.IDocument {
+    const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+    const imgData = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
+
+    // One of the benefits of this library is being able to render images to a canvas element
+    // and sending that canvas directly to a label. This allows your webpage to generate complex
+    // images and fonts (like emoji!) that EPL/ZPL can't support.
+    return builder
+      .addImageFromImageData(imgData)
+      .addPrintCmd()
+      .finalize();
+  }
+
+  /** Send the contents of the config form as a config label to the printer. */
+  private async updatePrinterConfig(e: SubmitEvent) {
+    e.preventDefault();
+
+    // Figure out the right printer
+    const formElement = this.configModal.querySelector('form')!;
+    const form = formElement.elements as ConfigModalForm;
+    const printerIdx = parseInt((formElement.querySelector('#modalPrinterIndexText') as HTMLFormElement).innerText);
+    const printer = this.printers[printerIdx];
+    if (printer === undefined) {
+      return;
+    }
+
+    form.modalSubmit.setAttribute("disabled", "");
+    form.modalCancel.setAttribute("disabled", "");
+
+    // Pull the values out of the form.
+    const darkness = parseInt(form.modalDarkness.value) as WebLabel.DarknessPercent;
+    const rawSpeed = parseInt(form.modalSpeed.value) as WebLabel.PrintSpeed;
+    const mediaWidthInches = parseFloat(form.modalLabelWidth.value);
+    const autosense = form.modalWithAutosense.checked;
+
+    const mediaLengthInches = parseFloat(form.modalLabelHeight.value);
+    const offsetLeft = parseInt(form.modalLabelOffsetLeft.value);
+    const offsetTop = parseInt(form.modalLabelOffsetTop.value);
+
+    // Construct the config document with the values from the form
+    const configDoc = printer.getConfigDocument();
+
+    // Form mode should be set first for other elements to work right.
+    switch (form.modalMediaType.value) {
+      case "continuous":
+        configDoc.setLabelMediaToContinuous(mediaLengthInches);
+        break;
+      case "mark":
+        // TODO: Make a form for black line sensing.
+        configDoc.setLabelMediaToMarkSense(mediaLengthInches, 16, 0);
+        break;
+      default:
+      case "gap":
+        // TODO: Make a form for label gap size.
+        configDoc.setLabelMediaToWebGapSense(mediaLengthInches, 16);
+        break;
+    }
+
+    configDoc
+      .setPrintDirection()
+      .setLabelPrintOriginOffsetCommand(offsetLeft, offsetTop)
+      .setPrintSpeed(rawSpeed)
+      .setDarknessConfig(darkness)
+      .setLabelDimensions(mediaWidthInches);
+    const doc = autosense
+      ? configDoc.autosenseLabelLength()
+      : configDoc.finalize();
+    // And send the whole shebang to the printer!
+    await printer.sendDocument(doc);
+
+    form.modalSubmit.removeAttribute("disabled");
+    form.modalCancel.removeAttribute("disabled");
+    this.activePrinterIndex = printerIdx;
+    this.configModalHandle.hide();
+  }
 }
 
 // With the app class defined we can run it.

--- a/demo/test_index.ts
+++ b/demo/test_index.ts
@@ -1,6 +1,6 @@
 import * as WebLabel from '../src/index.js';
-import bootstrap from 'bootstrap';
 import * as WebDevices from 'web-device-mux';
+import bootstrap from 'bootstrap';
 // This file exists to test the index.html's typescript. Unfortunately there isn't
 // a good way to configure Visual Studio Code to, well, treat it as typescript.
 ////////////////////////////////////////////////////////////////////////////////
@@ -42,24 +42,24 @@ refreshPrinterBtn.addEventListener('click', async () => printerMgr.forceReconnec
 
 // Next we wire up some events on the UsbDeviceManager itself.
 printerMgr.addEventListener('connectedDevice', ({ detail }) => {
-    const printer = detail.device;
-    console.log('New printer is a', printer.printerModel);
-    const config = printer.printerOptions;
-    console.log('Printer darkness is', config.darknessPercent, 'percent');
-    console.log('Printer speed is', WebLabel.PrintSpeed[config.speed.printSpeed]);
-    console.log(
-        'Label is',
-        config.mediaWidthInches,
-        'in wide and',
-        config.mediaLengthInches,
-        'in long');
-    console.log('Printer media mode is', WebLabel.MediaMediaGapDetectionMode[config.mediaGapDetectMode]);
+  const printer = detail.device;
+  console.log('New printer is a', printer.printerModel);
+  const config = printer.printerOptions;
+  console.log('Printer darkness is', config.darknessPercent, 'percent');
+  console.log('Printer speed is', WebLabel.PrintSpeed[config.speed.printSpeed]);
+  console.log(
+    'Label is',
+    config.mediaWidthInches,
+    'in wide and',
+    config.mediaLengthInches,
+    'in long');
+  console.log('Printer media mode is', WebLabel.MediaMediaGapDetectionMode[config.mediaGapDetectMode]);
 });
 
 // There's also an event that will tell you when a printer disconnects.
 printerMgr.addEventListener('disconnectedDevice', ({ detail }) => {
-    const printer = detail.device;
-    console.log('Lost printer', printer.printerModel, 'serial', printer.printerOptions.serialNumber);
+  const printer = detail.device;
+  console.log('Lost printer', printer.printerModel, 'serial', printer.printerOptions.serialNumber);
 });
 
 // When the browser first loaded the page any previously connected printers would have caused
@@ -76,153 +76,153 @@ printerMgr.addEventListener('disconnectedDevice', ({ detail }) => {
 
 // First we create an interface to describe our settings form.
 interface ConfigModalForm extends HTMLCollection {
-    modalCancel         : HTMLButtonElement
-    modalDarkness       : HTMLSelectElement
-    modalLabelHeight    : HTMLInputElement
-    modalLabelOffsetLeft: HTMLInputElement
-    modalLabelOffsetTop : HTMLInputElement
-    modalLabelWidth     : HTMLInputElement
-    modalMediaType      : HTMLSelectElement
-    modalSpeed          : HTMLSelectElement
-    modalSubmit         : HTMLButtonElement
-    modalWithAutosense  : HTMLInputElement
+  modalCancel         : HTMLButtonElement
+  modalDarkness       : HTMLSelectElement
+  modalLabelHeight    : HTMLInputElement
+  modalLabelOffsetLeft: HTMLInputElement
+  modalLabelOffsetTop : HTMLInputElement
+  modalLabelWidth     : HTMLInputElement
+  modalMediaType      : HTMLSelectElement
+  modalSpeed          : HTMLSelectElement
+  modalSubmit         : HTMLButtonElement
+  modalWithAutosense  : HTMLInputElement
 }
 
 // The app's logic is wrapped in a class just for ease of reading.
 class BasicLabelDesignerApp {
-    constructor(
-        private manager: PrinterManager,
-        private btnContainer: HTMLElement,
-        private labelForm: HTMLElement,
-        private labelFormInstructions: HTMLElement,
-        private configModal: HTMLElement
-    ) {
-        // Based on the containers, map the various listeners.
-        this.configModalHandle = new bootstrap.Modal(this.configModal);
-        this.configModal
-            .querySelector('form')!
-            .addEventListener('submit', this.updatePrinterConfig.bind(this));
-        this.labelForm.addEventListener('blur', this.renderTextForm.bind(this));
-        this.labelForm.addEventListener('keyup', this.renderTextForm.bind(this));
+  constructor(
+    private manager: PrinterManager,
+    private btnContainer: HTMLElement,
+    private labelForm: HTMLElement,
+    private labelFormInstructions: HTMLElement,
+    private configModal: HTMLElement
+  ) {
+    // Based on the containers, map the various listeners.
+    this.configModalHandle = new bootstrap.Modal(this.configModal);
+    this.configModal
+      .querySelector('form')!
+      .addEventListener('submit', this.updatePrinterConfig.bind(this));
+    this.labelForm.addEventListener('blur', this.renderTextForm.bind(this));
+    this.labelForm.addEventListener('keyup', this.renderTextForm.bind(this));
 
-        // Add a second set of event listeners for printer connect and disconnect to redraw
-        // the printer list when it changes.
-        this.manager.addEventListener('connectedDevice', () => {
-            this.activePrinterIndex = -1;
-            this.redrawPrinterButtons();
-        });
-        this.manager.addEventListener('disconnectedDevice', () => {
-            this.activePrinterIndex = -1;
-            this.redrawPrinterButtons();
-        });
+    // Add a second set of event listeners for printer connect and disconnect to redraw
+    // the printer list when it changes.
+    this.manager.addEventListener('connectedDevice', () => {
+      this.activePrinterIndex = -1;
+      this.redrawPrinterButtons();
+    });
+    this.manager.addEventListener('disconnectedDevice', () => {
+      this.activePrinterIndex = -1;
+      this.redrawPrinterButtons();
+    });
 
-        // Here's a nice font with a great set of emoji that work well for monochrome printing.
-        // The text font is fairly basic though, so we would like to use only the emoji out
-        // of this font and use a basic sans-serif font for regular text.
-        // https://fonts.google.com/noto/specimen/Noto+Emoji
-        const emojiFontName = 'noto-emoji';
+    // Here's a nice font with a great set of emoji that work well for monochrome printing.
+    // The text font is fairly basic though, so we would like to use only the emoji out
+    // of this font and use a basic sans-serif font for regular text.
+    // https://fonts.google.com/noto/specimen/Noto+Emoji
+    const emojiFontName = 'noto-emoji';
 
-        // We can accomplish this with the unicodeRange property of our FontFace. We just
-        // need to list EVERY SINGLE EMOJI UNICODE RANGE to make it work. Fortunately someone
-        // has done this already: https://github.com/fraction/emoji-unicode-range
-        const emojiUnicodeRange = 'U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2604,U+260E,U+2611,U+2614-2615,U+2618,U+261D,U+2620,U+2622-2623,U+2626,U+262A,U+262E-262F,U+2638-263A,U+2640,U+2642,U+2648-2653,U+265F-2660,U+2663,U+2665-2666,U+2668,U+267B,U+267E-267F,U+2692-2697,U+2699,U+269B-269C,U+26A0-26A1,U+26AA-26AB,U+26B0-26B1,U+26BD-26BE,U+26C4-26C5,U+26C8,U+26CE,U+26CF,U+26D1,U+26D3-26D4,U+26E9-26EA,U+26F0-26F5,U+26F7-26FA,U+26FD,U+2702,U+2705,U+2708-2709,U+270A-270B,U+270C-270D,U+270F,U+2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2764,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F004,U+1F0CF,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201-1F202,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F321,U+1F324-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F396-1F397,U+1F399-1F39B,U+1F39E-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F3-1F3F5,U+1F3F7,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD,U+1F4FF,U+1F500-1F53D,U+1F549-1F54A,U+1F54B-1F54E,U+1F550-1F567,U+1F56F-1F570,U+1F573-1F579,U+1F57A,U+1F587,U+1F58A-1F58D,U+1F590,U+1F595-1F596,U+1F5A4,U+1F5A5,U+1F5A8,U+1F5B1-1F5B2,U+1F5BC,U+1F5C2-1F5C4,U+1F5D1-1F5D3,U+1F5DC-1F5DE,U+1F5E1,U+1F5E3,U+1F5E8,U+1F5EF,U+1F5F3,U+1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CB-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6E0-1F6E5,U+1F6E9,U+1F6EB-1F6EC,U+1F6F0,U+1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+231A-231B,U+23E9-23EC,U+23F0,U+23F3,U+25FD-25FE,U+2614-2615,U+2648-2653,U+267F,U+2693,U+26A1,U+26AA-26AB,U+26BD-26BE,U+26C4-26C5,U+26CE,U+26D4,U+26EA,U+26F2-26F3,U+26F5,U+26FA,U+26FD,U+2705,U+270A-270B,U+2728,U+274C,U+274E,U+2753-2755,U+2757,U+2795-2797,U+27B0,U+27BF,U+2B1B-2B1C,U+2B50,U+2B55,U+1F004,U+1F0CF,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201,U+1F21A,U+1F22F,U+1F232-1F236,U+1F238-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F32D-1F32F,U+1F330-1F335,U+1F337-1F37C,U+1F37E-1F37F,U+1F380-1F393,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CF-1F3D3,U+1F3E0-1F3F0,U+1F3F4,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F440,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FF,U+1F500-1F53D,U+1F54B-1F54E,U+1F550-1F567,U+1F57A,U+1F595-1F596,U+1F5A4,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CC,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6EB-1F6EC,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+1F3FB-1F3FF,U+261D,U+26F9,U+270A-270B,U+270C-270D,U+1F385,U+1F3C2-1F3C4,U+1F3C7,U+1F3CA,U+1F3CB-1F3CC,U+1F442-1F443,U+1F446-1F450,U+1F466-1F478,U+1F47C,U+1F481-1F483,U+1F485-1F487,U+1F48F,U+1F491,U+1F4AA,U+1F574-1F575,U+1F57A,U+1F590,U+1F595-1F596,U+1F645-1F647,U+1F64B-1F64F,U+1F6A3,U+1F6B4-1F6B6,U+1F6C0,U+1F6CC,U+1F90F,U+1F918,U+1F919-1F91E,U+1F91F,U+1F926,U+1F930,U+1F931-1F932,U+1F933-1F939,U+1F93C-1F93E,U+1F9B5-1F9B6,U+1F9B8-1F9B9,U+1F9BB,U+1F9CD-1F9CF,U+1F9D1-1F9DD,U+0023,U+002A,U+0030-0039,U+200D,U+20E3,U+FE0F,U+1F1E6-1F1FF,U+1F3FB-1F3FF,U+1F9B0-1F9B3,U+E0020-E007F,U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+2388,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2605,U+2607-2612,U+2614-2615,U+2616-2617,U+2618,U+2619,U+261A-266F,U+2670-2671,U+2672-267D,U+267E-267F,U+2680-2685,U+2690-2691,U+2692-269C,U+269D,U+269E-269F,U+26A0-26A1,U+26A2-26B1,U+26B2,U+26B3-26BC,U+26BD-26BF,U+26C0-26C3,U+26C4-26CD,U+26CE,U+26CF-26E1,U+26E2,U+26E3,U+26E4-26E7,U+26E8-26FF,U+2700,U+2701-2704,U+2705,U+2708-2709,U+270A-270B,U+270C-2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2767,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F000-1F02B,U+1F02C-1F02F,U+1F030-1F093,U+1F094-1F09F,U+1F0A0-1F0AE,U+1F0AF-1F0B0,U+1F0B1-1F0BE,U+1F0BF,U+1F0C0,U+1F0C1-1F0CF,U+1F0D0,U+1F0D1-1F0DF,U+1F0E0-1F0F5,U+1F0F6-1F0FF,U+1F10D-1F10F,U+1F12F,U+1F16C,U+1F16D-1F16F,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1AD-1F1E5,U+1F201-1F202,U+1F203-1F20F,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F23C-1F23F,U+1F249-1F24F,U+1F250-1F251,U+1F252-1F25F,U+1F260-1F265,U+1F266-1F2FF,U+1F300-1F320,U+1F321-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F394-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F1-1F3F7,U+1F3F8-1F3FA,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD-1F4FE,U+1F4FF,U+1F500-1F53D,U+1F546-1F54A,U+1F54B-1F54F,U+1F550-1F567,U+1F568-1F579,U+1F57A,U+1F57B-1F5A3,U+1F5A4,U+1F5A5-1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6C6-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D3-1F6D4,U+1F6D5,U+1F6D6-1F6DF,U+1F6E0-1F6EC,U+1F6ED-1F6EF,U+1F6F0-1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F6FB-1F6FF,U+1F774-1F77F,U+1F7D5-1F7D8,U+1F7D9-1F7DF,U+1F7E0-1F7EB,U+1F7EC-1F7FF,U+1F80C-1F80F,U+1F848-1F84F,U+1F85A-1F85F,U+1F888-1F88F,U+1F8AE-1F8FF,U+1F90C,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F972,U+1F973-1F976,U+1F977-1F979,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A3-1F9A4,U+1F9A5-1F9AA,U+1F9AB-1F9AD,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CB-1F9CC,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA00-1FA53,U+1FA54-1FA5F,U+1FA60-1FA6D,U+1FA6E-1FA6F,U+1FA70-1FA73,U+1FA74-1FA77,U+1FA78-1FA7A,U+1FA7B-1FA7F,U+1FA80-1FA82,U+1FA83-1FA8F,U+1FA90-1FA95,U+1FA96-1FFFD';
+    // We can accomplish this with the unicodeRange property of our FontFace. We just
+    // need to list EVERY SINGLE EMOJI UNICODE RANGE to make it work. Fortunately someone
+    // has done this already: https://github.com/fraction/emoji-unicode-range
+    const emojiUnicodeRange = 'U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2604,U+260E,U+2611,U+2614-2615,U+2618,U+261D,U+2620,U+2622-2623,U+2626,U+262A,U+262E-262F,U+2638-263A,U+2640,U+2642,U+2648-2653,U+265F-2660,U+2663,U+2665-2666,U+2668,U+267B,U+267E-267F,U+2692-2697,U+2699,U+269B-269C,U+26A0-26A1,U+26AA-26AB,U+26B0-26B1,U+26BD-26BE,U+26C4-26C5,U+26C8,U+26CE,U+26CF,U+26D1,U+26D3-26D4,U+26E9-26EA,U+26F0-26F5,U+26F7-26FA,U+26FD,U+2702,U+2705,U+2708-2709,U+270A-270B,U+270C-270D,U+270F,U+2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2764,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F004,U+1F0CF,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201-1F202,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F321,U+1F324-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F396-1F397,U+1F399-1F39B,U+1F39E-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F3-1F3F5,U+1F3F7,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD,U+1F4FF,U+1F500-1F53D,U+1F549-1F54A,U+1F54B-1F54E,U+1F550-1F567,U+1F56F-1F570,U+1F573-1F579,U+1F57A,U+1F587,U+1F58A-1F58D,U+1F590,U+1F595-1F596,U+1F5A4,U+1F5A5,U+1F5A8,U+1F5B1-1F5B2,U+1F5BC,U+1F5C2-1F5C4,U+1F5D1-1F5D3,U+1F5DC-1F5DE,U+1F5E1,U+1F5E3,U+1F5E8,U+1F5EF,U+1F5F3,U+1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CB-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6E0-1F6E5,U+1F6E9,U+1F6EB-1F6EC,U+1F6F0,U+1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+231A-231B,U+23E9-23EC,U+23F0,U+23F3,U+25FD-25FE,U+2614-2615,U+2648-2653,U+267F,U+2693,U+26A1,U+26AA-26AB,U+26BD-26BE,U+26C4-26C5,U+26CE,U+26D4,U+26EA,U+26F2-26F3,U+26F5,U+26FA,U+26FD,U+2705,U+270A-270B,U+2728,U+274C,U+274E,U+2753-2755,U+2757,U+2795-2797,U+27B0,U+27BF,U+2B1B-2B1C,U+2B50,U+2B55,U+1F004,U+1F0CF,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201,U+1F21A,U+1F22F,U+1F232-1F236,U+1F238-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F32D-1F32F,U+1F330-1F335,U+1F337-1F37C,U+1F37E-1F37F,U+1F380-1F393,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CF-1F3D3,U+1F3E0-1F3F0,U+1F3F4,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F440,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FF,U+1F500-1F53D,U+1F54B-1F54E,U+1F550-1F567,U+1F57A,U+1F595-1F596,U+1F5A4,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CC,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6EB-1F6EC,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+1F3FB-1F3FF,U+261D,U+26F9,U+270A-270B,U+270C-270D,U+1F385,U+1F3C2-1F3C4,U+1F3C7,U+1F3CA,U+1F3CB-1F3CC,U+1F442-1F443,U+1F446-1F450,U+1F466-1F478,U+1F47C,U+1F481-1F483,U+1F485-1F487,U+1F48F,U+1F491,U+1F4AA,U+1F574-1F575,U+1F57A,U+1F590,U+1F595-1F596,U+1F645-1F647,U+1F64B-1F64F,U+1F6A3,U+1F6B4-1F6B6,U+1F6C0,U+1F6CC,U+1F90F,U+1F918,U+1F919-1F91E,U+1F91F,U+1F926,U+1F930,U+1F931-1F932,U+1F933-1F939,U+1F93C-1F93E,U+1F9B5-1F9B6,U+1F9B8-1F9B9,U+1F9BB,U+1F9CD-1F9CF,U+1F9D1-1F9DD,U+0023,U+002A,U+0030-0039,U+200D,U+20E3,U+FE0F,U+1F1E6-1F1FF,U+1F3FB-1F3FF,U+1F9B0-1F9B3,U+E0020-E007F,U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+2388,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2605,U+2607-2612,U+2614-2615,U+2616-2617,U+2618,U+2619,U+261A-266F,U+2670-2671,U+2672-267D,U+267E-267F,U+2680-2685,U+2690-2691,U+2692-269C,U+269D,U+269E-269F,U+26A0-26A1,U+26A2-26B1,U+26B2,U+26B3-26BC,U+26BD-26BF,U+26C0-26C3,U+26C4-26CD,U+26CE,U+26CF-26E1,U+26E2,U+26E3,U+26E4-26E7,U+26E8-26FF,U+2700,U+2701-2704,U+2705,U+2708-2709,U+270A-270B,U+270C-2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2767,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F000-1F02B,U+1F02C-1F02F,U+1F030-1F093,U+1F094-1F09F,U+1F0A0-1F0AE,U+1F0AF-1F0B0,U+1F0B1-1F0BE,U+1F0BF,U+1F0C0,U+1F0C1-1F0CF,U+1F0D0,U+1F0D1-1F0DF,U+1F0E0-1F0F5,U+1F0F6-1F0FF,U+1F10D-1F10F,U+1F12F,U+1F16C,U+1F16D-1F16F,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1AD-1F1E5,U+1F201-1F202,U+1F203-1F20F,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F23C-1F23F,U+1F249-1F24F,U+1F250-1F251,U+1F252-1F25F,U+1F260-1F265,U+1F266-1F2FF,U+1F300-1F320,U+1F321-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F394-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F1-1F3F7,U+1F3F8-1F3FA,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD-1F4FE,U+1F4FF,U+1F500-1F53D,U+1F546-1F54A,U+1F54B-1F54F,U+1F550-1F567,U+1F568-1F579,U+1F57A,U+1F57B-1F5A3,U+1F5A4,U+1F5A5-1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6C6-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D3-1F6D4,U+1F6D5,U+1F6D6-1F6DF,U+1F6E0-1F6EC,U+1F6ED-1F6EF,U+1F6F0-1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F6FB-1F6FF,U+1F774-1F77F,U+1F7D5-1F7D8,U+1F7D9-1F7DF,U+1F7E0-1F7EB,U+1F7EC-1F7FF,U+1F80C-1F80F,U+1F848-1F84F,U+1F85A-1F85F,U+1F888-1F88F,U+1F8AE-1F8FF,U+1F90C,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F972,U+1F973-1F976,U+1F977-1F979,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A3-1F9A4,U+1F9A5-1F9AA,U+1F9AB-1F9AD,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CB-1F9CC,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA00-1FA53,U+1FA54-1FA5F,U+1FA60-1FA6D,U+1FA6E-1FA6F,U+1FA70-1FA73,U+1FA74-1FA77,U+1FA78-1FA7A,U+1FA7B-1FA7F,U+1FA80-1FA82,U+1FA83-1FA8F,U+1FA90-1FA95,U+1FA96-1FFFD';
 
-        // And then we can use that range with our font when we load it.
-        const emojiOnlyFont = new FontFace(emojiFontName, 'url(fonts/NotoEmoji-Regular.ttf)', {
-          unicodeRange: emojiUnicodeRange,
-        });
-        emojiOnlyFont.load().then(() => {
-            document.fonts.add(emojiOnlyFont);
-        });
-        // We then set our fallback font as part of the font family we use in the canvas.
-        // This order matters, latter fonts will use the unicodeRange to override earlier fonts.
-        this.fontName = `Sans-serif, ${emojiFontName}`
+    // And then we can use that range with our font when we load it.
+    const emojiOnlyFont = new FontFace(emojiFontName, 'url(fonts/NotoEmoji-Regular.ttf)', {
+      unicodeRange: emojiUnicodeRange,
+    });
+    emojiOnlyFont.load().then(() => {
+      document.fonts.add(emojiOnlyFont);
+    });
+    // We then set our fallback font as part of the font family we use in the canvas.
+    // This order matters, latter fonts will use the unicodeRange to override earlier fonts.
+    this.fontName = `Sans-serif, ${emojiFontName}`
+  }
+
+  // Some storage fields and utility properties
+  private fontName: string;
+  private configModalHandle: bootstrap.Modal;
+
+  get printers(): readonly WebLabel.LabelPrinterUsb[] {
+    return this.manager.devices;
+  }
+
+  // Track which printer is currently selected for operations
+  private _activePrinter = 0;
+  get activePrinter(): WebLabel.LabelPrinterUsb | undefined {
+    return this._activePrinter < 0 || this._activePrinter > this.printers.length
+      ? undefined
+      : this.printers[this._activePrinter];
+  }
+  set activePrinterIndex(printerIdx: number) {
+    this._activePrinter = printerIdx;
+    this.redrawTextCanvas();
+  }
+
+  /** Initialize the app */
+  public async init() {
+    this.redrawPrinterButtons();
+    this.redrawTextCanvas();
+  }
+
+  /** Display the configuration for a printer. */
+  public showConfigModal(printer: WebLabel.LabelPrinterUsb, printerIdx: number) {
+    if (printer == undefined) {
+      return;
     }
+    const config = printer.printerOptions;
 
-    // Some storage fields and utility properties
-    private fontName: string;
-    private configModalHandle: bootstrap.Modal;
-
-    get printers() {
-        return this.manager.devices;
+    // Translate the available speeds to options to be selected
+    const speedSelect = this.configModal.querySelector('#modalSpeed')! as HTMLSelectElement;
+    speedSelect.innerHTML = '';
+    const speedTable = printer.printerOptions.speedTable.table;
+    for (const [key] of speedTable) {
+      // Skip utility values, so long as there's more than the defaults.
+      // Mobile printers *only* support auto, for example.
+      if ((speedTable.size > 3)
+        && (key === WebLabel.PrintSpeed.ipsAuto
+          || key === WebLabel.PrintSpeed.ipsPrinterMax
+          || key === WebLabel.PrintSpeed.ipsPrinterMin
+        )) {
+        continue;
+      }
+      const opt = document.createElement('option');
+      opt.value = key.toString();
+      opt.innerHTML = WebLabel.PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
+      speedSelect.appendChild(opt);
     }
+    speedSelect.value = config.speed.printSpeed.toString();
 
-    // Track which printer is currently selected for operations
-    private _activePrinter = 0;
-    get activePrinter(): WebLabel.LabelPrinterUsb | undefined {
-        return this._activePrinter < 0 || this._activePrinter > this.printers.length
-            ? undefined
-            : this.printers[this._activePrinter];
-    }
-    set activePrinterIndex(printerIdx: number) {
-        this._activePrinter = printerIdx;
-        this.redrawTextCanvas();
-    }
+    (this.configModal.querySelector('#modalPrinterIndex')     as HTMLInputElement)!.value = config.serialNumber;
+    (this.configModal.querySelector('#modalPrinterIndexText') as HTMLSelectElement)!.textContent = printerIdx.toString();
+    (this.configModal.querySelector('#modalLabelWidth')       as HTMLSelectElement)!.value = config.mediaWidthInches.toString();
+    (this.configModal.querySelector('#modalLabelHeight')      as HTMLSelectElement)!.value = config.mediaLengthInches.toString();
+    (this.configModal.querySelector('#modalDarkness')         as HTMLSelectElement)!.value = config.darknessPercent.toString();
+    this.configModalHandle.show();
+  }
 
-    /** Initialize the app */
-    public async init() {
-        this.redrawPrinterButtons();
-        this.redrawTextCanvas();
-    }
+  /** Erase and re-draw the list of printer buttons in the UI. */
+  private redrawPrinterButtons() {
+    this.btnContainer.innerHTML = '';
+    this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
+  }
 
-    /** Display the configuration for a printer. */
-    public showConfigModal(printer: WebLabel.LabelPrinterUsb, printerIdx: number) {
-        if (printer == undefined) {
-            return;
-        }
-        const config = printer.printerOptions;
+  /** Highlight only the currently selected printer. */
+  private redrawPrinterButtonHighlights() {
+    this.printers.forEach((printer, idx) => {
+      const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
+      const element = document.getElementById(`printer_${idx}`)!;
+      element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
+    });
+  }
 
-        // Translate the available speeds to options to be selected
-        const speedSelect = this.configModal.querySelector('#modalSpeed')! as HTMLSelectElement;
-        speedSelect.innerHTML = '';
-        const speedTable = printer.printerOptions.speedTable.table;
-        for (const [key] of speedTable) {
-            // Skip utility values, so long as there's more than the defaults.
-            // Mobile printers *only* support auto, for example.
-            if ((speedTable.size > 3)
-                && (key === WebLabel.PrintSpeed.ipsAuto
-                    || key === WebLabel.PrintSpeed.ipsPrinterMax
-                    || key === WebLabel.PrintSpeed.ipsPrinterMin
-            )) {
-                continue;
-            }
-            const opt = document.createElement('option');
-            opt.value = key.toString();
-            opt.innerHTML = WebLabel.PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
-            speedSelect.appendChild(opt);
-        }
-        speedSelect.value = config.speed.printSpeed.toString();
+  /** Add a printer's button UI to the list of printers. */
+  private drawPrinterButton(printer: WebLabel.LabelPrinterUsb, idx: number) {
+    const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
 
-        (this.configModal.querySelector('#modalPrinterIndex') as HTMLInputElement)!.value            = config.serialNumber;
-        (this.configModal.querySelector('#modalPrinterIndexText') as HTMLSelectElement)!.textContent = printerIdx.toString();
-        (this.configModal.querySelector('#modalLabelWidth') as HTMLSelectElement)!.value             = config.mediaWidthInches.toString();
-        (this.configModal.querySelector('#modalLabelHeight') as HTMLSelectElement)!.value            = config.mediaLengthInches.toString();
-        (this.configModal.querySelector('#modalDarkness') as HTMLSelectElement)!.value               = config.darknessPercent.toString();
-        this.configModalHandle.show();
-    }
-
-    /** Erase and re-draw the list of printer buttons in the UI. */
-    private redrawPrinterButtons() {
-        this.btnContainer.innerHTML = '';
-        this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
-    }
-
-    /** Highlight only the currently selected printer. */
-    private redrawPrinterButtonHighlights() {
-        this.printers.forEach((printer, idx) => {
-          const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
-            const element = document.getElementById(`printer_${idx}`)!;
-            element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
-        });
-    }
-
-    /** Add a printer's button UI to the list of printers. */
-    private drawPrinterButton(printer: WebLabel.LabelPrinterUsb, idx: number) {
-        const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
-
-        // Generate a new label printer button for the given printer.
-        const element = document.createElement("div");
-        element.innerHTML = `
+    // Generate a new label printer button for the given printer.
+    const element = document.createElement("div");
+    element.innerHTML = `
     <li id="printer_${idx}" data-printer-idx="${idx}"
         class="list-group-item d-flex flex-row justify-content-between sligh-items-start"
         style="background: linear-gradient(to right, ${highlight}, ${highlight}, grey, grey);">
@@ -258,180 +258,180 @@ class BasicLabelDesignerApp {
             </div>
         </div>
     </li>`;
-        // And slap it into the button container.
-        this.btnContainer.appendChild(element);
+    // And slap it into the button container.
+    this.btnContainer.appendChild(element);
 
-        // Then wire up the button events so they work.
-        document.getElementById(`printto_${idx}`)!
-            .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                const doc = this.addCanvasImageToLabelDoc(printer.getLabelDocument());
-                await printer.sendDocument(doc);
-            });
-        document.getElementById(`printer_${idx}`)!
-            .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                if (this._activePrinter === printerIdx) {
-                    // Don't refresh anything if we already have this printer selected..
-                    return;
-                }
-                this.activePrinterIndex = printerIdx;
-                this.redrawPrinterButtonHighlights();
-                this.redrawTextCanvas();
-            });
-        document.getElementById(`printtest_${idx}`)!
-            .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                const doc = WebLabel.ReadyToPrintDocuments.printTestLabelDocument(
-                    printer.printerOptions.mediaWidthDots);
-                await printer.sendDocument(doc);
-            });
-        document.getElementById(`feedlabel_${idx}`)!
-            .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                const doc = WebLabel.ReadyToPrintDocuments.feedLabelDocument;
-                await printer.sendDocument(doc);
-            });
-        document.getElementById(`printconfig_${idx}`)!
-            .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                const doc = WebLabel.ReadyToPrintDocuments.printConfigDocument;
-                await printer.sendDocument(doc);
-            });
-        document.getElementById(`configprinter_${idx}`)!
-            .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                this.showConfigModal(printer, printerIdx);
-            });
-    }
-
-    /** Redraw the text canvas size according to the printer. */
-    private redrawTextCanvas() {
-        const printer = this.activePrinter;
-        if (printer === undefined) {
-            this.labelForm.classList.add('d-none');
-            this.labelFormInstructions.classList.remove('d-none');
-            return;
-        } else {
-            this.labelForm.classList.remove('d-none');
-            this.labelFormInstructions.classList.add('d-none');
-        }
-
-        // Resize the canvas to match the label size.
-        const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-        // Add a small margin as printer alignment is not exact.
-        canvas.width = printer.printerOptions.mediaWidthDots - 2;
-        canvas.height = printer.printerOptions.mediaLengthDots - 2;
-
-        const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-        textarea.value = "Enter your label text here!";
-        this.renderTextForm();
-    }
-
-    /** Render the text form to the canvas */
-    private renderTextForm() {
-        const printer = this.activePrinter;
-        if (printer === undefined) {
-            return;
-        }
-
-        const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-        const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-        const pageContext = canvas.getContext('2d')!;
-        pageContext.clearRect(0, 0, canvas.width, canvas.height);
-
-        const fontSize = 30;
-
-        // We'd like the preview image to be as close as possible to what the printer will
-        // actually print. To do this we don't draw text to the page's canvas directly,
-        // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
-        // then render *that* back to the page's canvas. This is a more accurate picture of
-        // what the label will end up looking like.
-
-        // A more complex app could do this more gracefully!
-        const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d')!;
-        offscreenContext.font = `${fontSize}pt ${this.fontName}`;
-        offscreenContext.fillStyle = "#000000";
-
-        // fillText doesn't do newlines, do that manually
-        textarea.value.split('\n').forEach((l, i) => {
-            offscreenContext.fillText(l, 5, (i * fontSize + 2) + fontSize);
-        })
-
-        // Now into the monochrome bitmap.
-        const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
-        const monoImg = WebLabel.BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
-        // And finally back onto the page.
-        pageContext.putImageData(monoImg.toImageData(), 0, 0);
-    }
-
-    /** Render the canvas to a document for printing */
-    private addCanvasImageToLabelDoc(builder: WebLabel.ILabelDocumentBuilder): WebLabel.IDocument {
-        const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-        const imgData = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
-
-        // One of the benefits of this library is being able to render images to a canvas element
-        // and sending that canvas directly to a label. This allows your webpage to generate complex
-        // images and fonts (like emoji!) that EPL/ZPL can't support.
-        return builder
-            .addImageFromImageData(imgData)
-            .addPrintCmd()
-            .finalize();
-    }
-
-    /** Send the contents of the config form as a config label to the printer. */
-    private async updatePrinterConfig(e: SubmitEvent) {
+    // Then wire up the button events so they work.
+    document.getElementById(`printto_${idx}`)!
+      .addEventListener('click', async (e) => {
         e.preventDefault();
-
-        // Figure out the right printer
-        const formElement = this.configModal.querySelector('form')!;
-        const form = formElement.elements as ConfigModalForm;
-        const printerIdx = parseInt((formElement.querySelector('#modalPrinterIndexText') as HTMLFormElement).innerText);
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
         const printer = this.printers[printerIdx];
-        if (printer === undefined) {
-            return;
-        }
-
-        form.modalSubmit.setAttribute("disabled", "");
-        form.modalCancel.setAttribute("disabled", "");
-
-        // Pull the values out of the form.
-        const darkness         = parseInt(form.modalDarkness.value) as WebLabel.DarknessPercent;
-        const rawSpeed         = parseInt(form.modalSpeed.value) as WebLabel.PrintSpeed;
-        const mediaWidthInches = parseFloat(form.modalLabelWidth.value);
-        const autosense        = form.modalWithAutosense.checked;
-
-        // Construct the config document with the values from the form
-        const configDoc = printer.getConfigDocument();
-
-        configDoc
-            .setPrintDirection()
-            .setLabelHomeOffsetDots(0, 0)
-            .setPrintSpeed(rawSpeed)
-            .setDarknessConfig(darkness)
-            .setLabelDimensions(mediaWidthInches);
-        const doc = autosense
-            ? configDoc.autosenseLabelLength()
-            : configDoc.finalize();
-        // And send the whole shebang to the printer!
+        const doc = this.addCanvasImageToLabelDoc(printer.getLabelDocument());
         await printer.sendDocument(doc);
-
-        form.modalSubmit.removeAttribute("disabled");
-        form.modalCancel.removeAttribute("disabled");
+      });
+    document.getElementById(`printer_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        if (this._activePrinter === printerIdx) {
+          // Don't refresh anything if we already have this printer selected..
+          return;
+        }
         this.activePrinterIndex = printerIdx;
-        this.configModalHandle.hide();
+        this.redrawPrinterButtonHighlights();
+        this.redrawTextCanvas();
+      });
+    document.getElementById(`printtest_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = WebLabel.ReadyToPrintDocuments.printTestLabelDocument(
+          printer.printerOptions.mediaWidthDots);
+        await printer.sendDocument(doc);
+      });
+    document.getElementById(`feedlabel_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = WebLabel.ReadyToPrintDocuments.feedLabelDocument;
+        await printer.sendDocument(doc);
+      });
+    document.getElementById(`printconfig_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = WebLabel.ReadyToPrintDocuments.printConfigDocument;
+        await printer.sendDocument(doc);
+      });
+    document.getElementById(`configprinter_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        this.showConfigModal(printer, printerIdx);
+      });
+  }
+
+  /** Redraw the text canvas size according to the printer. */
+  private redrawTextCanvas() {
+    const printer = this.activePrinter;
+    if (printer === undefined) {
+      this.labelForm.classList.add('d-none');
+      this.labelFormInstructions.classList.remove('d-none');
+      return;
+    } else {
+      this.labelForm.classList.remove('d-none');
+      this.labelFormInstructions.classList.add('d-none');
     }
+
+    // Resize the canvas to match the label size.
+    const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+    // Add a small margin as printer alignment is not exact.
+    canvas.width = printer.printerOptions.mediaWidthDots - 2;
+    canvas.height = printer.printerOptions.mediaLengthDots - 2;
+
+    const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+    textarea.value = "Enter your label text here!";
+    this.renderTextForm();
+  }
+
+  /** Render the text form to the canvas */
+  private renderTextForm() {
+    const printer = this.activePrinter;
+    if (printer === undefined) {
+      return;
+    }
+
+    const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+    const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+    const pageContext = canvas.getContext('2d')!;
+    pageContext.clearRect(0, 0, canvas.width, canvas.height);
+
+    const fontSize = 30;
+
+    // We'd like the preview image to be as close as possible to what the printer will
+    // actually print. To do this we don't draw text to the page's canvas directly,
+    // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
+    // then render *that* back to the page's canvas. This is a more accurate picture of
+    // what the label will end up looking like.
+
+    // A more complex app could do this more gracefully!
+    const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d')!;
+    offscreenContext.font = `${fontSize}pt ${this.fontName}`;
+    offscreenContext.fillStyle = "#000000";
+
+    // fillText doesn't do newlines, do that manually
+    textarea.value.split('\n').forEach((l, i) => {
+      offscreenContext.fillText(l, 5, (i * fontSize + 2) + fontSize);
+    })
+
+    // Now into the monochrome bitmap.
+    const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
+    const monoImg = WebLabel.BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
+    // And finally back onto the page.
+    pageContext.putImageData(monoImg.toImageData(), 0, 0);
+  }
+
+  /** Render the canvas to a document for printing */
+  private addCanvasImageToLabelDoc(builder: WebLabel.ILabelDocumentBuilder): WebLabel.IDocument {
+    const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+    const imgData = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
+
+    // One of the benefits of this library is being able to render images to a canvas element
+    // and sending that canvas directly to a label. This allows your webpage to generate complex
+    // images and fonts (like emoji!) that EPL/ZPL can't support.
+    return builder
+      .addImageFromImageData(imgData)
+      .addPrintCmd()
+      .finalize();
+  }
+
+  /** Send the contents of the config form as a config label to the printer. */
+  private async updatePrinterConfig(e: SubmitEvent) {
+    e.preventDefault();
+
+    // Figure out the right printer
+    const formElement = this.configModal.querySelector('form')!;
+    const form = formElement.elements as ConfigModalForm;
+    const printerIdx = parseInt((formElement.querySelector('#modalPrinterIndexText') as HTMLFormElement).innerText);
+    const printer = this.printers[printerIdx];
+    if (printer === undefined) {
+      return;
+    }
+
+    form.modalSubmit.setAttribute("disabled", "");
+    form.modalCancel.setAttribute("disabled", "");
+
+    // Pull the values out of the form.
+    const darkness = parseInt(form.modalDarkness.value) as WebLabel.DarknessPercent;
+    const rawSpeed = parseInt(form.modalSpeed.value) as WebLabel.PrintSpeed;
+    const mediaWidthInches = parseFloat(form.modalLabelWidth.value);
+    const autosense = form.modalWithAutosense.checked;
+
+    // Construct the config document with the values from the form
+    const configDoc = printer.getConfigDocument();
+
+    configDoc
+      .setPrintDirection()
+      .setLabelHomeOffsetDots(0, 0)
+      .setPrintSpeed(rawSpeed)
+      .setDarknessConfig(darkness)
+      .setLabelDimensions(mediaWidthInches);
+    const doc = autosense
+      ? configDoc.autosenseLabelLength()
+      : configDoc.finalize();
+    // And send the whole shebang to the printer!
+    await printer.sendDocument(doc);
+
+    form.modalSubmit.removeAttribute("disabled");
+    form.modalCancel.removeAttribute("disabled");
+    this.activePrinterIndex = printerIdx;
+    this.configModalHandle.hide();
+  }
 }
 
 // With the app class defined we can run it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webzlp",
-  "version": "2.0.0-rc.3",
+  "version": "2.0.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webzlp",
-      "version": "2.0.0-rc.3",
+      "version": "2.0.0-rc.5",
       "license": "GPL-3.0-only",
       "dependencies": {
         "web-device-mux": "^0.4.1"
@@ -20,6 +20,7 @@
         "@vitest/coverage-v8": "^2.1.6",
         "eslint": "^9.9.0",
         "globals": "^15.9.0",
+        "happy-dom": "^15.11.7",
         "https-localhost": "^4.7.1",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.16.0",
@@ -1869,6 +1870,17 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1977,6 +1989,14 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2162,6 +2182,20 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/compare-versions": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
@@ -2300,6 +2334,35 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.1.0.tgz",
+      "integrity": "sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "rrweb-cssom": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -2322,6 +2385,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -2353,6 +2424,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -2914,6 +2996,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3089,6 +3187,29 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
     },
+    "node_modules/happy-dom": {
+      "version": "15.11.7",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.7.tgz",
+      "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.5.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3185,6 +3306,20 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3213,6 +3348,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-localhost": {
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/https-localhost/-/https-localhost-4.7.1.tgz",
@@ -3228,6 +3378,21 @@
       },
       "bin": {
         "serve": "index.js"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -3354,6 +3519,14 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3447,6 +3620,48 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -3769,6 +3984,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.16.tgz",
+      "integrity": "sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3880,6 +4103,20 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "entities": "^4.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -4221,6 +4458,14 @@
         "win32"
       ]
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4269,6 +4514,20 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -4656,6 +4915,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/test-exclude": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
@@ -4733,6 +5000,28 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.68",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.68.tgz",
+      "integrity": "sha512-JKF17jROiYkjJPT73hUTEiTp2OBCf+kAlB+1novk8i6Q6dWjHsgEjw9VLiipV4KTJavazXhY1QUXyQFSem2T7w==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tldts-core": "^6.1.68"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.68",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.68.tgz",
+      "integrity": "sha512-85TdlS/DLW/gVdf2oyyzqp3ocS30WxjaL4la85EArl9cHUR/nizifKAJPziWewSZjDZS71U517/i6ciUeqtB5Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4752,6 +5041,34 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+      "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6112,6 +6429,20 @@
       "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
       "dev": true
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wbuf": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
@@ -6125,6 +6456,69 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/web-device-mux/-/web-device-mux-0.4.1.tgz",
       "integrity": "sha512-usRRvLTObi9MXPAqpHnDFBjFXaEdW5yvIQQMwzsFKm2a69Q3ZZ5eDv4z0FDRPbjbZ0wayL/8KFa8a45PdypUrQ=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.0.tgz",
+      "integrity": "sha512-jlf/foYIKywAt3x/XWKZ/3rz8OSJPiWktjmk891alJUEjiVxKX9LEO92qH3hv4aJ0mN3MWPvGMCy8jQi95xK4w==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6253,6 +6647,48 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@vitest/coverage-v8": "^2.1.6",
     "eslint": "^9.9.0",
     "globals": "^15.9.0",
+    "happy-dom": "^15.11.7",
     "https-localhost": "^4.7.1",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.16.0",

--- a/src/Commands/Commands.ts
+++ b/src/Commands/Commands.ts
@@ -91,13 +91,12 @@ export type CommandType
   | "SetLabelToMarkMedia"
   | "SetPrintDirection"
   | "SetPrintSpeed"
+  | "SetBackfeedAfterTaken"
   // Document handling
   | "NewLabel"
   | "StartLabel"
   | "EndLabel"
   | "CutNow"
-  | "EnableFeedBackup"
-  | "SuppressFeedBackup"
   | "Print"
   // Content
   | "ClearImageBuffer"
@@ -167,18 +166,6 @@ export class CutNowCommand extends BasicCommand {
   constructor() { super(['actuatesCutter']); }
 }
 
-export class SuppressFeedBackupCommand extends BasicCommand {
-  name = 'Disable feed backup after printing label (be sure to re-enable!)';
-  type: CommandType = 'SuppressFeedBackup';
-  constructor() { super([]); }
-}
-
-export class EnableFeedBackupCommand extends BasicCommand {
-  name = 'Enable feed backup after printing label.';
-  type: CommandType = 'EnableFeedBackup';
-  constructor() { super([]); }
-}
-
 /** A command to clear the image buffer. */
 export class ClearImageBufferCommand extends BasicCommand {
   name = 'Clear image buffer';
@@ -220,6 +207,21 @@ export class SetDarknessCommand implements IPrinterCommand {
   ) {}
 
   effectFlags = new CommandEffectFlags(['altersConfig']);
+}
+
+export class SetBackfeedAfterTakenMode implements IPrinterCommand {
+  name = 'Set backfeed mode after label is taken';
+  type: CommandType = 'SetBackfeedAfterTaken';
+  toDisplay(): string {
+    if (this.mode === 'disabled') {
+      return 'Disable backfeed';
+    } else {
+      return `Set backfeed to ${this.mode}% after label cut/taken.`;
+    }
+  }
+  effectFlags = new CommandEffectFlags(['altersConfig']);
+
+  constructor(public readonly mode: Conf.BackfeedAfterTaken) { }
 }
 
 /** A command to set the direction a label prints, either upside down or not. */

--- a/src/Commands/Messages.ts
+++ b/src/Commands/Messages.ts
@@ -92,11 +92,9 @@ export type AwaitedCommand = {
 export interface ISettingUpdateMessage {
   messageType: 'SettingUpdateMessage';
 
-  printerHardware: Conf.IPrinterHardwareUpdate;
-  printerMedia: Conf.IPrinterMediaUpdate;
-
-  printerDistanceIn?: number;
-  headDistanceIn?: number;
+  printerHardware?: Conf.IPrinterHardwareUpdate;
+  printerMedia   ?: Conf.IPrinterMediaUpdate;
+  printerSettings?: Conf.IPrinterSettingsUpdate;
 }
 
 /** A status message sent by the printer. */

--- a/src/Commands/PrinterConfig.ts
+++ b/src/Commands/PrinterConfig.ts
@@ -9,26 +9,28 @@ export class PrinterConfig extends Conf.BasePrinterConfig {
 
   /** Update these options with newly transmitted settings. */
   public update(msg: ISettingUpdateMessage) {
-    this._model                      = msg.printerHardware.model        ?? this._model;
-    this._manufacturer               = msg.printerHardware.manufacturer ?? this._manufacturer;
-    this._serial                     = msg.printerHardware.serialNumber ?? this._serial;
-    this._dpi                        = msg.printerHardware.dpi ?? this._dpi;
-    this._speedTable                 = msg.printerHardware.speedTable ?? this._speedTable;
-    this._maxMediaDarkness           = msg.printerHardware.maxMediaDarkness ?? this._maxMediaDarkness;
-    this._firmware                   = msg.printerHardware.firmware ?? this._firmware;
-    this._maxMediaLengthDots         = msg.printerHardware.maxMediaLengthDots ?? this._maxMediaLengthDots;
-    this._maxMediaWidthDots          = msg.printerHardware.maxMediaWidthDots ?? this._maxMediaWidthDots;
+    this._model                      = msg.printerHardware?.model              ?? this._model;
+    this._manufacturer               = msg.printerHardware?.manufacturer       ?? this._manufacturer;
+    this._serial                     = msg.printerHardware?.serialNumber       ?? this._serial;
+    this._dpi                        = msg.printerHardware?.dpi                ?? this._dpi;
+    this._speedTable                 = msg.printerHardware?.speedTable         ?? this._speedTable;
+    this._maxMediaDarkness           = msg.printerHardware?.maxMediaDarkness   ?? this._maxMediaDarkness;
+    this._firmware                   = msg.printerHardware?.firmware           ?? this._firmware;
+    this._maxMediaLengthDots         = msg.printerHardware?.maxMediaLengthDots ?? this._maxMediaLengthDots;
+    this._maxMediaWidthDots          = msg.printerHardware?.maxMediaWidthDots  ?? this._maxMediaWidthDots;
 
-    this._speed                      = msg.printerMedia.speed ?? this._speed;
-    this._darkness                   = msg.printerMedia.darknessPercent ?? this._darkness;
-    this._thermalPrintMode           = msg.printerMedia.thermalPrintMode ?? this._thermalPrintMode;
-    this._mediaPrintMode             = msg.printerMedia.mediaPrintMode ?? this._mediaPrintMode;
-    this._printOrientation           = msg.printerMedia.printOrientation ?? this._printOrientation;
-    this._mediaGapDetectMode         = msg.printerMedia.mediaGapDetectMode ?? this._mediaGapDetectMode;
-    this._mediaPrintOriginOffsetDots = msg.printerMedia.mediaPrintOriginOffsetDots ?? this._mediaPrintOriginOffsetDots;
-    this._mediaGapDots               = msg.printerMedia.mediaGapDots ?? this._mediaGapDots;
-    this._mediaLineOffsetDots        = msg.printerMedia.mediaLineOffsetDots ?? this._mediaLineOffsetDots;
-    this._mediaWidthDots             = msg.printerMedia.mediaWidthDots ?? this._mediaWidthDots;
-    this._mediaLengthDots            = msg.printerMedia.mediaLengthDots ?? this._mediaLengthDots;
+    this._speed                      = msg.printerMedia?.speed                      ?? this._speed;
+    this._darkness                   = msg.printerMedia?.darknessPercent            ?? this._darkness;
+    this._thermalPrintMode           = msg.printerMedia?.thermalPrintMode           ?? this._thermalPrintMode;
+    this._mediaPrintMode             = msg.printerMedia?.mediaPrintMode             ?? this._mediaPrintMode;
+    this._printOrientation           = msg.printerMedia?.printOrientation           ?? this._printOrientation;
+    this._mediaGapDetectMode         = msg.printerMedia?.mediaGapDetectMode         ?? this._mediaGapDetectMode;
+    this._mediaPrintOriginOffsetDots = msg.printerMedia?.mediaPrintOriginOffsetDots ?? this._mediaPrintOriginOffsetDots;
+    this._mediaGapDots               = msg.printerMedia?.mediaGapDots               ?? this._mediaGapDots;
+    this._mediaLineOffsetDots        = msg.printerMedia?.mediaLineOffsetDots        ?? this._mediaLineOffsetDots;
+    this._mediaWidthDots             = msg.printerMedia?.mediaWidthDots             ?? this._mediaWidthDots;
+    this._mediaLengthDots            = msg.printerMedia?.mediaLengthDots            ?? this._mediaLengthDots;
+
+    this._backfeedAfterTaken = msg.printerSettings?.backfeedAfterTaken ?? this._backfeedAfterTaken;
   }
 }

--- a/src/Configs/BasePrinterConfig.ts
+++ b/src/Configs/BasePrinterConfig.ts
@@ -1,7 +1,7 @@
-import { MediaMediaGapDetectionMode, MediaPrintMode, PrintOrientation, PrintSpeed, PrintSpeedSettings, SpeedTable, ThermalPrintMode, type Coordinate, type DarknessPercent, type IPrinterHardware } from "./ConfigurationTypes.js";
+import { MediaMediaGapDetectionMode, MediaPrintMode, PrintOrientation, PrintSpeed, PrintSpeedSettings, SpeedTable, ThermalPrintMode, type Coordinate, type DarknessPercent, type IPrinterHardware, type IPrinterMedia } from "./ConfigurationTypes.js";
 
-/** Configured options for a label printer */
-export abstract class BasePrinterConfig implements IPrinterHardware {
+/** Configured options for a printer */
+export abstract class BasePrinterConfig implements IPrinterHardware, IPrinterMedia {
 
   // Read-only printer config info
   protected _serial = 'no_serial_nm';
@@ -18,8 +18,6 @@ export abstract class BasePrinterConfig implements IPrinterHardware {
 
   protected _firmware = '';
   get firmware() { return this._firmware; }
-
-  public labelDimensionRoundingStep = 0.25;
 
   protected _speed = new PrintSpeedSettings(PrintSpeed.unknown);
   get speed() { return this._speed; }
@@ -38,6 +36,8 @@ export abstract class BasePrinterConfig implements IPrinterHardware {
 
   protected _mediaPrintMode = MediaPrintMode.tearOff;
   get mediaPrintMode() { return this._mediaPrintMode; }
+
+  public mediaDimensionRoundingStep = 0.25;
 
   protected _printOrientation = PrintOrientation.normal;
   get printOrientation() { return this._printOrientation; }

--- a/src/Configs/BasePrinterConfig.ts
+++ b/src/Configs/BasePrinterConfig.ts
@@ -1,7 +1,7 @@
-import { MediaMediaGapDetectionMode, MediaPrintMode, PrintOrientation, PrintSpeed, PrintSpeedSettings, SpeedTable, ThermalPrintMode, type Coordinate, type DarknessPercent, type IPrinterHardware, type IPrinterMedia } from "./ConfigurationTypes.js";
+import { MediaMediaGapDetectionMode, MediaPrintMode, PrintOrientation, PrintSpeed, PrintSpeedSettings, SpeedTable, ThermalPrintMode, type BackfeedAfterTaken, type Coordinate, type DarknessPercent, type IPrinterHardware, type IPrinterMedia, type IPrinterSettings } from "./ConfigurationTypes.js";
 
 /** Configured options for a printer */
-export abstract class BasePrinterConfig implements IPrinterHardware, IPrinterMedia {
+export abstract class BasePrinterConfig implements IPrinterHardware, IPrinterSettings, IPrinterMedia {
 
   // Read-only printer config info
   protected _serial = 'no_serial_nm';
@@ -27,6 +27,9 @@ export abstract class BasePrinterConfig implements IPrinterHardware, IPrinterMed
 
   protected _darkness: DarknessPercent = 50;
   get darknessPercent() { return this._darkness; }
+
+  protected _backfeedAfterTaken: BackfeedAfterTaken = '90';
+  get backfeedAfterTaken() { return this._backfeedAfterTaken; }
 
   protected _maxMediaDarkness = 15;
   get maxMediaDarkness() { return this._maxMediaDarkness; }

--- a/src/Configs/ConfigurationTypes.ts
+++ b/src/Configs/ConfigurationTypes.ts
@@ -98,6 +98,21 @@ export enum MediaPrintMode {
   kiosk
 }
 
+/** Percentage to backfeed after taking/cutting label, vs before printing the next. */
+export type BackfeedAfterTaken
+  = 'Disabled'
+  | '0'
+  | '10'
+  | '20'
+  | '30'
+  | '40'
+  | '50'
+  | '60'
+  | '70'
+  | '80'
+  | '90'
+  | '100';
+
 /** Class for representing a printer's relationship between speeds and raw values */
 export class SpeedTable {
   // Speed is determined by what the printer supports
@@ -233,6 +248,16 @@ export interface IPrinterHardwareUpdate {
   maxMediaDarkness?: number,
   serialNumber?: string;
   speedTable?: SpeedTable;
+}
+
+/** Settings for printer behavior */
+export interface IPrinterSettings {
+  /** What percentage of backfeed happens after cutting/taking label, vs before printing. */
+  readonly backfeedAfterTaken: BackfeedAfterTaken;
+}
+
+export interface IPrinterSettingsUpdate {
+  backfeedAfterTaken?: BackfeedAfterTaken;
 }
 
 /** Printer options related to the media media being printed */

--- a/src/Configs/ConfigurationTypes.ts
+++ b/src/Configs/ConfigurationTypes.ts
@@ -100,7 +100,7 @@ export enum MediaPrintMode {
 
 /** Percentage to backfeed after taking/cutting label, vs before printing the next. */
 export type BackfeedAfterTaken
-  = 'Disabled'
+  = 'disabled'
   | '0'
   | '10'
   | '20'

--- a/src/Configs/ConfigurationTypes.ts
+++ b/src/Configs/ConfigurationTypes.ts
@@ -11,7 +11,7 @@ export interface Coordinate {
   top: number;
 }
 
-/** The orientation of a label as it comes out of the printer. */
+/** The orientation of a media as it comes out of the printer. */
 export enum PrintOrientation {
   /** Right-side up when the printer faces the user. */
   normal,
@@ -60,13 +60,13 @@ export enum ThermalPrintMode {
   transfer
 }
 
-/** Describes the way the labels are marked for the printer to detect separate labels. */
+/** Describes the way the medias are marked for the printer to detect separate medias. */
 export enum MediaMediaGapDetectionMode {
-  /** Media is one continuous label with no gaps. Used with cutters usually. */
+  /** Media is one continuous media with no gaps. Used with cutters usually. */
   continuous,
-  /** Media is opaque with gaps between labels that can be sensed by the printer. */
+  /** Media is opaque with gaps between medias that can be sensed by the printer. */
   webSensing,
-  /** Media has black marks indicating label spacing. */
+  /** Media has black marks indicating media spacing. */
   markSensing,
   /** Autodetect during calibration. G-series printers only. */
   autoDuringCalibration,
@@ -76,25 +76,25 @@ export enum MediaMediaGapDetectionMode {
 
 /** Printing behavior  */
 export enum MediaPrintMode {
-  /** Label advances so web is over tear bar, to be torn manually. */
+  /** Media advances so web is over tear bar, to be torn manually. */
   tearOff,
-  /** Label advances over Label Taken sensor. Printing pauses until label is removed. */
+  /** Media advances over Media Taken sensor. Printing pauses until media is removed. */
   peel,
-  /** Peel mode, but each label is fed to pre-peel a small portion. Helps some media types. ZPL only.*/
+  /** Peel mode, but each media is fed to pre-peel a small portion. Helps some media types. ZPL only.*/
   peelWithPrePeel,
-  /** Peel mode, but printer waits for button tap between labels. */
+  /** Peel mode, but printer waits for button tap between medias. */
   peelWithButtonTap,
-  /** Label advances until web is over cutter. */
+  /** Media advances until web is over cutter. */
   cutter,
   /** Cutter, but cut operation waits for separate command. ZPL only. */
   cutterWaitForCommand,
-  /** Label and liner are rewound on an external device. No backfeed motion. ZPL only. */
+  /** Media and liner are rewound on an external device. No backfeed motion. ZPL only. */
   rewind,
-  /** Label advances far enough for applicator device to grab. Printers with applicator ports only. */
+  /** Media advances far enough for applicator device to grab. Printers with applicator ports only. */
   applicator,
-  /** Removes backfeed between RFID labels, improving throughput. RFID printers only. */
+  /** Removes backfeed between RFID medias, improving throughput. RFID printers only. */
   rfid,
-  /** Label is moved into a presentation position. ZPL only.*/
+  /** Media is moved into a presentation position. ZPL only.*/
   kiosk
 }
 
@@ -189,7 +189,7 @@ export class PrintSpeedSettings {
 
   /** Speed during printing media. */
   printSpeed: PrintSpeed;
-  /** Speed during feeding a blank label. ZPL only, same as media speed for EPL. */
+  /** Speed during feeding a blank media. ZPL only, same as media speed for EPL. */
   slewSpeed: PrintSpeed;
 }
 
@@ -235,40 +235,40 @@ export interface IPrinterHardwareUpdate {
   speedTable?: SpeedTable;
 }
 
-/** Printer options related to the label media being printed */
+/** Printer options related to the media media being printed */
 export interface IPrinterMedia {
   /** How dark to print. 0 is blank, 99 is max darkness */
   darknessPercent: DarknessPercent;
-  /** Mode the printer uses to detect separate labels when printing. */
-  labelGapDetectMode: MediaMediaGapDetectionMode;
+  /** Mode the printer uses to detect separate medias when printing. */
+  mediaGapDetectMode: MediaMediaGapDetectionMode;
   /**
-   * The gap / mark length between labels. Mandatory for markSensing black line mode.
+   * The gap / mark length between medias. Mandatory for markSensing black line mode.
    * Media with webSensing gaps can use AutoSense to get this value.
    */
-  get labelGapInches(): number;
-  /** Label gap in dots */
-  labelGapDots: number;
-  /** The offset in inches from the normal location of the label gap or black line. Can be negative. */
-  get labelLineOffsetInches(): number;
-  /** The offset in dots from the normal location of the label gap or black line. Can be negative. */
-  labelLineOffsetDots: number;
-  /** The length of the label media, in inches. */
-  get labelLengthInches(): number;
-  /** The length of the label media, in dots. */
-  labelLengthDots: number;
-  /** The width of the label media, in inches. */
-  get labelWidthInches(): number;
-  /** The width of the label media, in dots. */
-  labelWidthDots: number;
+  get mediaGapInches(): number;
+  /** Media web gap in dots */
+  mediaGapDots: number;
+  /** The offset in inches from the normal location of the media gap or black line. Can be negative. */
+  get mediaLineOffsetInches(): number;
+  /** The offset in dots from the normal location of the media gap or black line. Can be negative. */
+  mediaLineOffsetDots: number;
+  /** The length of the media media, in inches. */
+  get mediaLengthInches(): number;
+  /** The length of the media media, in dots. */
+  mediaLengthDots: number;
+  /** The width of the media media, in inches. */
+  get mediaWidthInches(): number;
+  /** The width of the media media, in dots. */
+  mediaWidthDots: number;
 
   /** The offset of the printable area, from the top-left corner. */
-  labelPrintOriginOffsetDots: Coordinate;
+  mediaPrintOriginOffsetDots: Coordinate;
 
   /**
-   * Value to use for rounding read-from-config label sizes.
+   * Value to use for rounding read-from-config media sizes.
    *
-   * When reading the config from a printer the label width and length may be
-   * variable. When you set the label width to 4 inches it's translated into
+   * When reading the config from a printer the media width and length may be
+   * variable. When you set the media width to 4 inches it's translated into
    * dots, and then the printer adds a calculated offset to that. This offset
    * is unique per printer (so far as I have observed) and introduces noise.
    * This value rounds the returned value to the nearest fraction of an inch.
@@ -276,18 +276,18 @@ export interface IPrinterMedia {
    * For example, with a rounding step of 0.25 (the default) if the printer
    * returns a width 4.113 it will be rounded to 4.0
    */
-  labelDimensionRoundingStep: number;
+  mediaDimensionRoundingStep: number;
 
-  /** Label print speed settings */
+  /** Media print speed settings */
   speed: PrintSpeedSettings;
 
-  /** The label media thermal print mode. */
+  /** The media thermal print mode. */
   thermalPrintMode: ThermalPrintMode;
 
   /** The behavior of media after form printing. */
   mediaPrintMode: MediaPrintMode;
 
-  /** Whether the label prints right-side-up or upside-down. */
+  /** Whether the media prints right-side-up or upside-down. */
   printOrientation: PrintOrientation;
 }
 
@@ -299,7 +299,7 @@ export interface IPrinterMediaUpdate {
   mediaLengthDots?: number;
   mediaWidthDots?: number;
   mediaPrintOriginOffsetDots?: Coordinate;
-  labelDimensionRoundingStep?: number;
+  mediaDimensionRoundingStep?: number;
   thermalPrintMode?: ThermalPrintMode;
   mediaPrintMode?: MediaPrintMode;
   printOrientation?: PrintOrientation;

--- a/src/Documents/ConfigDocument.ts
+++ b/src/Documents/ConfigDocument.ts
@@ -106,6 +106,10 @@ export class ConfigDocumentBuilder
   autosenseLabelLength() {
     return this.andThen(new Cmds.AutosenseLabelDimensionsCommand()).finalize();
   }
+  
+  setBackfeedAfterTakenMode(mode: Conf.BackfeedAfterTaken) {
+    return this.andThen(new Cmds.SetBackfeedAfterTakenMode(mode));
+  }
 
   setLabelDimensions(widthInInches: number, lengthInInches?: number, gapLengthInInches?: number) {
     this._doSave = true;
@@ -272,6 +276,9 @@ export interface IPrinterLabelConfigBuilder {
 
   /** Run the autosense operation to get label length. Must be last command. */
   autosenseLabelLength(): IDocument;
+
+  /** Set the backfeed behavior after cut/take of label. */
+  setBackfeedAfterTakenMode(mode: Conf.BackfeedAfterTaken): IConfigDocumentBuilder;
 
   /** Sets the media type to continuous (gapless) media. */
   setLabelMediaToContinuous(labelLengthInDots: number): IConfigDocumentBuilder;

--- a/src/Documents/LabelDocument.ts
+++ b/src/Documents/LabelDocument.ts
@@ -46,14 +46,6 @@ export class LabelDocumentBuilder
     return this.andThen(new Cmds.EndLabel(), new Cmds.StartLabel());
   }
 
-  suppressFeedBackupForLabel(): ILabelDocumentBuilder {
-    return this.andThen(new Cmds.SuppressFeedBackupCommand());
-  }
-
-  reenableFeedBackup(): ILabelDocumentBuilder {
-    return this.andThen(new Cmds.EnableFeedBackupCommand());
-  }
-
   ///////////////////// OFFSET AND SPACING
 
   setOffset(horizontal: number, vertical?: number): ILabelDocumentBuilder {
@@ -146,12 +138,6 @@ export interface ILabelActionCommandBuilder {
 
   /** Begin a new label to be sent as a single batch. */
   startNewLabel(): ILabelDocumentBuilder;
-
-  /** Disable feed backup for this label. Be sure to re-enable at the end of the batch. */
-  suppressFeedBackupForLabel(): ILabelDocumentBuilder;
-
-  /** Re-enable feed backup for this and future labels. */
-  reenableFeedBackup(): ILabelDocumentBuilder;
 }
 
 export interface ILabelPositionCommandBuilder {

--- a/src/Languages/Epl/CmdConfigurationInquiry.test.ts
+++ b/src/Languages/Epl/CmdConfigurationInquiry.test.ts
@@ -72,7 +72,7 @@ Cover: T=137, C=147
               "thermalPrintMode": 0,
             },
             "printerSettings": {
-              "backfeedAfterTaken": "90",
+              "backfeedAfterTaken": "100",
             },
           },
         ]
@@ -174,6 +174,75 @@ Cover: T=118, C=129
             "messageType": "SettingUpdateMessage",
             "printerHardware": {
               "dpi": 203,
+              "firmware": "V4.70.1A",
+              "manufacturer": "Zebra Corporation",
+              "maxMediaDarkness": 15,
+              "maxMediaLengthDots": 2223,
+              "maxMediaWidthDots": 832,
+              "model": "LP2844",
+              "serialNumber": "42A000000000",
+              "speedTable": SpeedTable {
+                "speedTable": Map {
+                  3 => 1,
+                  4 => 2,
+                  5 => 3,
+                  7 => 4,
+                  1 => 1,
+                  1000 => 4,
+                  0 => 3,
+                },
+              },
+            },
+            "printerMedia": {
+              "darknessPercent": 67,
+              "mediaGapDetectMode": 1,
+              "mediaGapDots": 25,
+              "mediaLengthDots": 913,
+              "mediaPrintOriginOffsetDots": {
+                "left": 8,
+                "top": 0,
+              },
+              "mediaWidthDots": 812,
+              "printOrientation": 1,
+              "speed": PrintSpeedSettings {
+                "printSpeed": 7,
+                "slewSpeed": 7,
+              },
+              "thermalPrintMode": 0,
+            },
+            "printerSettings": {
+              "backfeedAfterTaken": "100",
+            },
+          },
+        ]
+      `);
+    });
+
+    it('Real config 4', () => {
+      const real_config_4 = `
+UKQ1935HLU       V4.70.1A
+S/N: 42A000000000
+Serial port:96,N,8,1
+Page Mode
+Image buffer size:0245K
+Fmem used: 0 (bytes)
+Gmem used: 0
+Emem used: 29600
+Available: 100959
+I8,A,001 rY JF WN
+S4 D11 R104,0 ZB UN
+q616 Q56,169
+Option:d,S,Ff
+oEv,w,x,y,z
+12 21 30
+Cover: T=120, C=141`;
+      const result = parseConfigResponse(real_config_4, undefined!);
+      expect(result.messages).toMatchInlineSnapshot(`
+        [
+          {
+            "messageType": "SettingUpdateMessage",
+            "printerHardware": {
+              "dpi": 203,
               "firmware": "V4.45",
               "manufacturer": "Zebra Corporation",
               "maxMediaDarkness": 15,
@@ -210,32 +279,30 @@ Cover: T=118, C=129
               "thermalPrintMode": 0,
             },
             "printerSettings": {
-              "backfeedAfterTaken": "90",
+              "backfeedAfterTaken": "100",
             },
           },
         ]
       `);
     });
 
-    it('Real config 4', () => {
-      const real_config_4 = `
-UKQ1935HLU       V4.70.1A
-S/N: 42A000000000
+    it('Real config 5', () => {
+      const real_config_5 = `
+UKQ1935H U  UPS V4.51
+S/N: 64A060601536
 Serial port:96,N,8,1
-Page Mode
 Image buffer size:0245K
 Fmem used: 0 (bytes)
-Gmem used: 0
-Emem used: 29600
-Available: 100959
+Gmem used: 7443
+Emem used: 9732
+Available: 113384
 I8,A,001 rY JF WN
-S4 D11 R104,0 ZB UN
-q616 Q56,169
-Option:d,S,Ff
-oEv,w,x,y,z
-12 21 30
-Cover: T=120, C=141`;
-      const result = parseConfigResponse(real_config_4, undefined!);
+S4 D08 R008,000 ZB UN
+q816 Q56,189+4
+Option:d,S
+oUs,t,u
+09 14 20 `;
+      const result = parseConfigResponse(real_config_5, undefined!);
       expect(result.messages).toMatchInlineSnapshot(`
         [
           {
@@ -279,74 +346,7 @@ Cover: T=120, C=141`;
               "thermalPrintMode": 0,
             },
             "printerSettings": {
-              "backfeedAfterTaken": "90",
-            },
-          },
-        ]
-      `);
-    });
-
-    it('Real config 5', () => {
-      const real_config_5 = `
-UKQ1935H U  UPS V4.51
-S/N: 64A060601536
-Serial port:96,N,8,1
-Image buffer size:0245K
-Fmem used: 0 (bytes)
-Gmem used: 7443
-Emem used: 9732
-Available: 113384
-I8,A,001 rY JF WN
-S4 D08 R008,000 ZB UN
-q816 Q56,189+4
-Option:d,S
-oUs,t,u
-09 14 20 `;
-      const result = parseConfigResponse(real_config_5, undefined!);
-      expect(result.messages).toMatchInlineSnapshot(`
-        [
-          {
-            "messageType": "SettingUpdateMessage",
-            "printerHardware": {
-              "dpi": 203,
-              "firmware": "V4.51",
-              "manufacturer": "Zebra Corporation",
-              "maxMediaDarkness": 15,
-              "maxMediaLengthDots": 2223,
-              "maxMediaWidthDots": 832,
-              "model": "LP2844",
-              "serialNumber": "64A060601536",
-              "speedTable": SpeedTable {
-                "speedTable": Map {
-                  3 => 1,
-                  4 => 2,
-                  5 => 3,
-                  7 => 4,
-                  1 => 1,
-                  1000 => 4,
-                  0 => 3,
-                },
-              },
-            },
-            "printerMedia": {
-              "darknessPercent": 54,
-              "mediaGapDetectMode": 1,
-              "mediaGapDots": 189,
-              "mediaLengthDots": 50,
-              "mediaPrintOriginOffsetDots": {
-                "left": 8,
-                "top": 0,
-              },
-              "mediaWidthDots": 812,
-              "printOrientation": 0,
-              "speed": PrintSpeedSettings {
-                "printSpeed": 7,
-                "slewSpeed": 7,
-              },
-              "thermalPrintMode": 0,
-            },
-            "printerSettings": {
-              "backfeedAfterTaken": "90",
+              "backfeedAfterTaken": "100",
             },
           },
         ]

--- a/src/Languages/Epl/CmdConfigurationInquiry.test.ts
+++ b/src/Languages/Epl/CmdConfigurationInquiry.test.ts
@@ -71,6 +71,9 @@ Cover: T=137, C=147
               },
               "thermalPrintMode": 0,
             },
+            "printerSettings": {
+              "backfeedAfterTaken": "90",
+            },
           },
         ]
       `);
@@ -138,6 +141,9 @@ Cover: T=144, C=167
               },
               "thermalPrintMode": 0,
             },
+            "printerSettings": {
+              "backfeedAfterTaken": "90",
+            },
           },
         ]
       `);
@@ -165,9 +171,7 @@ Cover: T=118, C=129
       expect(result.messages).toMatchInlineSnapshot(`
         [
           {
-            "headDistanceIn": 249392,
             "messageType": "SettingUpdateMessage",
-            "printerDistanceIn": 249392,
             "printerHardware": {
               "dpi": 203,
               "firmware": "V4.45",
@@ -204,6 +208,9 @@ Cover: T=118, C=129
                 "slewSpeed": 7,
               },
               "thermalPrintMode": 0,
+            },
+            "printerSettings": {
+              "backfeedAfterTaken": "90",
             },
           },
         ]
@@ -271,6 +278,9 @@ Cover: T=120, C=141`;
               },
               "thermalPrintMode": 0,
             },
+            "printerSettings": {
+              "backfeedAfterTaken": "90",
+            },
           },
         ]
       `);
@@ -334,6 +344,9 @@ oUs,t,u
                 "slewSpeed": 7,
               },
               "thermalPrintMode": 0,
+            },
+            "printerSettings": {
+              "backfeedAfterTaken": "90",
             },
           },
         ]

--- a/src/Languages/Epl/CmdConfigurationInquiry.test.ts
+++ b/src/Languages/Epl/CmdConfigurationInquiry.test.ts
@@ -82,7 +82,7 @@ Cover: T=137, C=147
     it('Read config 2', () => {
       const real_config_2 = `
 UKQ1935HLU       V4.70.1A
-S/N: 42A000000000
+S/N: 42A000000022
 Serial port:96,N,8,1
 Page Mode
 Image buffer size:0507K
@@ -111,76 +111,7 @@ Cover: T=144, C=167
               "maxMediaLengthDots": 2223,
               "maxMediaWidthDots": 832,
               "model": "LP2844",
-              "serialNumber": "42A000000000",
-              "speedTable": SpeedTable {
-                "speedTable": Map {
-                  3 => 1,
-                  4 => 2,
-                  5 => 3,
-                  7 => 4,
-                  1 => 1,
-                  1000 => 4,
-                  0 => 3,
-                },
-              },
-            },
-            "printerMedia": {
-              "darknessPercent": 67,
-              "mediaGapDetectMode": 1,
-              "mediaGapDots": 25,
-              "mediaLengthDots": 913,
-              "mediaPrintOriginOffsetDots": {
-                "left": 8,
-                "top": 0,
-              },
-              "mediaWidthDots": 812,
-              "printOrientation": 1,
-              "speed": PrintSpeedSettings {
-                "printSpeed": 7,
-                "slewSpeed": 7,
-              },
-              "thermalPrintMode": 0,
-            },
-            "printerSettings": {
-              "backfeedAfterTaken": "90",
-            },
-          },
-        ]
-      `);
-    });
-
-    it('Read config 3', () => {
-      const real_config_3 = `
-UKQ1935HMU  FDX V4.45
-HEAD    usage =     249,392"
-PRINTER usage =     249,392"
-Serial port:96,N,8,1
-Image buffer size:0225K
-Fmem used: 0 (bytes)
-Gmem used: 0
-Emem used: 0
-Available: 130559
-I8,A,001 rY JF WY
-S4 D10 R000,000 ZT UN
-q832 Q934,24
-Option:D
-13 18 24
-Cover: T=118, C=129
-`;
-      const result = parseConfigResponse(real_config_3, undefined!);
-      expect(result.messages).toMatchInlineSnapshot(`
-        [
-          {
-            "messageType": "SettingUpdateMessage",
-            "printerHardware": {
-              "dpi": 203,
-              "firmware": "V4.70.1A",
-              "manufacturer": "Zebra Corporation",
-              "maxMediaDarkness": 15,
-              "maxMediaLengthDots": 2223,
-              "maxMediaWidthDots": 832,
-              "model": "LP2844",
-              "serialNumber": "42A000000000",
+              "serialNumber": "42A000000022",
               "speedTable": SpeedTable {
                 "speedTable": Map {
                   3 => 1,
@@ -218,25 +149,25 @@ Cover: T=118, C=129
       `);
     });
 
-    it('Real config 4', () => {
-      const real_config_4 = `
-UKQ1935HLU       V4.70.1A
-S/N: 42A000000000
+    it('Read config 3', () => {
+      const real_config_3 = `
+UKQ1935HMU  FDX V4.45
+HEAD    usage =     249,392"
+PRINTER usage =     249,392"
 Serial port:96,N,8,1
-Page Mode
-Image buffer size:0245K
+Image buffer size:0225K
 Fmem used: 0 (bytes)
 Gmem used: 0
-Emem used: 29600
-Available: 100959
-I8,A,001 rY JF WN
-S4 D11 R104,0 ZB UN
-q616 Q56,169
-Option:d,S,Ff
-oEv,w,x,y,z
-12 21 30
-Cover: T=120, C=141`;
-      const result = parseConfigResponse(real_config_4, undefined!);
+Emem used: 0
+Available: 130559
+I8,A,001 rY JF WY
+S4 D10 R000,000 ZT UN
+q832 Q934,24
+Option:D
+13 18 24
+Cover: T=118, C=129
+`;
+      const result = parseConfigResponse(real_config_3, undefined!);
       expect(result.messages).toMatchInlineSnapshot(`
         [
           {
@@ -286,6 +217,75 @@ Cover: T=120, C=141`;
       `);
     });
 
+    it('Real config 4', () => {
+      const real_config_4 = `
+UKQ1935HLU       V4.70.1A
+S/N: 42A000000044
+Serial port:96,N,8,1
+Page Mode
+Image buffer size:0245K
+Fmem used: 0 (bytes)
+Gmem used: 0
+Emem used: 29600
+Available: 100959
+I8,A,001 rY JF WN
+S4 D11 R104,0 ZB UN
+q616 Q56,169
+Option:d,S,Ff
+oEv,w,x,y,z
+12 21 30
+Cover: T=120, C=141`;
+      const result = parseConfigResponse(real_config_4, undefined!);
+      expect(result.messages).toMatchInlineSnapshot(`
+        [
+          {
+            "messageType": "SettingUpdateMessage",
+            "printerHardware": {
+              "dpi": 203,
+              "firmware": "V4.70.1A",
+              "manufacturer": "Zebra Corporation",
+              "maxMediaDarkness": 15,
+              "maxMediaLengthDots": 2223,
+              "maxMediaWidthDots": 832,
+              "model": "LP2844",
+              "serialNumber": "42A000000044",
+              "speedTable": SpeedTable {
+                "speedTable": Map {
+                  3 => 1,
+                  4 => 2,
+                  5 => 3,
+                  7 => 4,
+                  1 => 1,
+                  1000 => 4,
+                  0 => 3,
+                },
+              },
+            },
+            "printerMedia": {
+              "darknessPercent": 74,
+              "mediaGapDetectMode": 1,
+              "mediaGapDots": 169,
+              "mediaLengthDots": 50,
+              "mediaPrintOriginOffsetDots": {
+                "left": 104,
+                "top": 0,
+              },
+              "mediaWidthDots": 609,
+              "printOrientation": 0,
+              "speed": PrintSpeedSettings {
+                "printSpeed": 7,
+                "slewSpeed": 7,
+              },
+              "thermalPrintMode": 0,
+            },
+            "printerSettings": {
+              "backfeedAfterTaken": "100",
+            },
+          },
+        ]
+      `);
+    });
+
     it('Real config 5', () => {
       const real_config_5 = `
 UKQ1935H U  UPS V4.51
@@ -309,13 +309,13 @@ oUs,t,u
             "messageType": "SettingUpdateMessage",
             "printerHardware": {
               "dpi": 203,
-              "firmware": "V4.70.1A",
+              "firmware": "V4.51",
               "manufacturer": "Zebra Corporation",
               "maxMediaDarkness": 15,
               "maxMediaLengthDots": 2223,
               "maxMediaWidthDots": 832,
               "model": "LP2844",
-              "serialNumber": "42A000000000",
+              "serialNumber": "64A060601536",
               "speedTable": SpeedTable {
                 "speedTable": Map {
                   3 => 1,
@@ -329,15 +329,15 @@ oUs,t,u
               },
             },
             "printerMedia": {
-              "darknessPercent": 74,
+              "darknessPercent": 54,
               "mediaGapDetectMode": 1,
-              "mediaGapDots": 169,
+              "mediaGapDots": 189,
               "mediaLengthDots": 50,
               "mediaPrintOriginOffsetDots": {
-                "left": 104,
+                "left": 8,
                 "top": 0,
               },
-              "mediaWidthDots": 609,
+              "mediaWidthDots": 812,
               "printOrientation": 0,
               "speed": PrintSpeedSettings {
                 "printSpeed": 7,

--- a/src/Languages/Epl/CmdConfigurationInquiry.ts
+++ b/src/Languages/Epl/CmdConfigurationInquiry.ts
@@ -269,12 +269,12 @@ function updateSettingsLines(settingLine: string, msg: Cmds.ISettingUpdateMessag
     //lineJ.at(1); // rY - Double buffering (ignored, always on)
     switch(lineJ.at(2)) {
       case 'JF':
-        msg.printerSettings.backfeedAfterTaken = '90';
+        msg.printerSettings.backfeedAfterTaken = '100';
         break;
         // TODO: Is supporting JC actually important?
       case 'JC':
       case 'JB':
-        msg.printerSettings.backfeedAfterTaken = 'Disabled';
+        msg.printerSettings.backfeedAfterTaken = 'disabled';
         break;
     } // JF - Top of form backup
 

--- a/src/Languages/Epl/EplPrinterCommandSet.ts
+++ b/src/Languages/Epl/EplPrinterCommandSet.ts
@@ -110,13 +110,8 @@ export class EplPrinterCommandSet extends Cmds.StringCommandSet {
         return this.setLabelToMarkMediaCommand(cmd as Cmds.SetLabelToMarkMediaCommand);
       case 'SetLabelToWebGapMedia':
         return this.setLabelToWebGapMediaCommand(cmd as Cmds.SetLabelToWebGapMediaCommand);
-
-      case 'SuppressFeedBackup':
-        // EPL uses an on/off style for form backup, it'll remain off until reenabled.
-        return 'JB' + '\r\n';
-      case 'EnableFeedBackup':
-        // Thus EPL needs an explicit command to re-enable.
-        return 'JF' + '\r\n';
+      case 'SetBackfeedAfterTaken':
+        return this.setBackfeedAfterTaken((cmd as Cmds.SetBackfeedAfterTakenMode).mode);
 
       case 'Offset':
         return this.applyOffset(cmd as Cmds.OffsetCommand, docState);
@@ -133,6 +128,19 @@ export class EplPrinterCommandSet extends Cmds.StringCommandSet {
 
       case 'Print':
         return this.printCommand(cmd as Cmds.PrintCommand);
+    }
+  }
+
+  private setBackfeedAfterTaken(
+    mode: Conf.BackfeedAfterTaken
+  ): string {
+    if (mode === 'disabled') {
+      // TODO: Does JC matter? It's only supported on 28X4
+      // Send JB first for universal support and JC after just in case?
+      return `JB\r\nJC\r\n`
+    } else {
+      // EPL doesn't support percentages so just turn it on.
+      return `JF` + '\r\n';
     }
   }
 

--- a/src/Languages/Zpl/CmdXmlQuery.test.ts
+++ b/src/Languages/Zpl/CmdXmlQuery.test.ts
@@ -1,0 +1,13 @@
+import { expect, describe, it } from 'vitest';
+import { ZD410_FULL_SNAPSHOT, ZD410_XML } from './test_files/index.test.js';
+import { CmdXmlQuery, parseCmdXmlQueryResponse } from './CmdXmlQuery.js';
+
+describe('parseCmdXmlQueryResponse', () => {
+  describe('Full', () => {
+    const cmd = new CmdXmlQuery('All');
+    it('Extracts the config', async () => {
+      const file = ZD410_XML();
+      await expect(parseCmdXmlQueryResponse(file, cmd)).toMatchFileSnapshot(ZD410_FULL_SNAPSHOT);
+    });
+  });
+});

--- a/src/Languages/Zpl/CmdXmlQuery.ts
+++ b/src/Languages/Zpl/CmdXmlQuery.ts
@@ -138,27 +138,34 @@ function docToUpdate(
   doc: Document
 ): Cmds.ISettingUpdateMessage {
 
-  // Start by pulling basic info
   const update: Cmds.ISettingUpdateMessage = {
-    messageType: 'SettingUpdateMessage',
-    printerHardware: {
-      model: getXmlText(doc, 'MODEL') ?? 'UNKNOWN_ZPL',
-      firmware: getXmlText(doc, 'FIRMWARE-VERSION'),
-      speedTable: getSpeedTable(doc),
-      // ZPL rounds, multiplying by 25 gets us to 'inches' in their book.
-      // 8 DPM == 200 DPI, for example.
-      dpi: parseInt(getXmlText(doc, 'DOTS-PER-MM') ?? '8') * 25
-    },
-    printerMedia: {
-      mediaGapDetectMode: getMediaType(doc),
-      mediaPrintMode: getPrintMode(doc),
-      printOrientation: getPrintOrientation(doc),
-      speed: getSpeed(doc),
-      thermalPrintMode: getThermalPrintMode(doc)
-    }
-  }
+    messageType: 'SettingUpdateMessage'
+  };
 
-  addDarkness(update, doc);
+  // Start by pulling basic info
+  update.printerHardware = {
+    model: getXmlText(doc, 'MODEL') ?? 'UNKNOWN_ZPL',
+    firmware: getXmlText(doc, 'FIRMWARE-VERSION'),
+    speedTable: getSpeedTable(doc),
+    // ZPL rounds, multiplying by 25 gets us to 'inches' in their book.
+    // 8 DPM == 200 DPI, for example.
+    dpi: parseInt(getXmlText(doc, 'DOTS-PER-MM') ?? '8') * 25
+  };
+  update.printerMedia = {
+    mediaGapDetectMode: getMediaType(doc),
+    mediaPrintMode: getPrintMode(doc),
+    printOrientation: getPrintOrientation(doc),
+    speed: getSpeed(doc),
+    thermalPrintMode: getThermalPrintMode(doc)
+  };
+  update.printerSettings = {};
+
+  const dark = getDarkness(doc);
+  update.printerHardware.maxMediaDarkness = dark.maxDarkness;
+  update.printerMedia.darknessPercent = dark.currentDarkness;
+
+  update.printerSettings.backfeedAfterTaken = getBackfeedMode(doc);
+
   addLabelSize(update, doc);
 
   // TODO: more hardware options:
@@ -221,16 +228,16 @@ function getThermalPrintMode(doc: Document) {
     : Conf.ThermalPrintMode.transfer;
 }
 
-function addDarkness(update: Cmds.ISettingUpdateMessage, doc: Document) {
+function getDarkness(doc: Document) {
   // Pull the max darkness by grabbing the 'MAX' attribute from the element.
   // It's pretty much always 30.
   const maxDarkness = parseInt(doc.getElementsByTagName('MEDIA-DARKNESS')
     .item(0)?.getAttribute('MAX')?.valueOf() ?? "30");
-  update.printerHardware.maxMediaDarkness = maxDarkness;
 
-  const currentDarkness = parseInt(getXmlCurrent(doc, 'MEDIA-DARKNESS') ?? '15');
-  const rawDarkness = Math.ceil(currentDarkness * (100 / maxDarkness));
-  update.printerMedia.darknessPercent = Math.max(0, Math.min(rawDarkness, 99)) as Conf.DarknessPercent;
+  const rawDarkness = parseInt(getXmlCurrent(doc, 'MEDIA-DARKNESS') ?? '15');
+  const parseDarkness = Math.ceil(rawDarkness * (100 / maxDarkness));
+  const currentDarkness = Math.max(0, Math.min(parseDarkness, 99)) as Conf.DarknessPercent;
+  return { maxDarkness, currentDarkness }
 }
 
 function getSpeedTable(doc: Document) {
@@ -261,6 +268,25 @@ function getSpeedTable(doc: Document) {
   );
 }
 
+const backfeedTable: Map<string, Conf.BackfeedAfterTaken> = new Map([
+  ['BEFORE', '0'],
+  ['10%', '10'],
+  ['20%', '20'],
+  ['30%', '30'],
+  ['40%', '40'],
+  ['50%', '50'],
+  ['60%', '60'],
+  ['70%', '70'],
+  ['80%', '80'],
+  ['DEFAULT', '90'],
+  ['AFTER', '100'],
+  ['OFF', 'Disabled'],
+]);
+
+function getBackfeedMode(doc: Document): Conf.BackfeedAfterTaken {
+  return backfeedTable.get(getXmlCurrent(doc, 'BACKFEED-PERCENT') ?? 'DEFAULT') ?? '90';
+}
+
 function getSpeed(doc: Document) {
   const printRate = parseInt(getXmlText(doc, 'PRINT-RATE') ?? '1');
   const slewRate = parseInt(getXmlText(doc, 'SLEW-RATE') ?? '1');
@@ -277,6 +303,9 @@ function getPrintOrientation(doc: Document) {
 }
 
 function addLabelSize(update: Cmds.ISettingUpdateMessage, doc: Document) {
+  update.printerMedia ??= {};
+  update.printerHardware ??= {};
+
   // ZPL printers may add or subtract a factory-set offset to label dimensions.
   // You tell it 200 dots wide it will store 204. No idea why. Round to a reasonable
   // step value to deal with this.

--- a/src/Languages/Zpl/CmdXmlQuery.ts
+++ b/src/Languages/Zpl/CmdXmlQuery.ts
@@ -280,7 +280,7 @@ const backfeedTable: Map<string, Conf.BackfeedAfterTaken> = new Map([
   ['80%', '80'],
   ['DEFAULT', '90'],
   ['AFTER', '100'],
-  ['OFF', 'Disabled'],
+  ['OFF', 'disabled'],
 ]);
 
 function getBackfeedMode(doc: Document): Conf.BackfeedAfterTaken {

--- a/src/Languages/Zpl/ZplPrinterCommandSet.ts
+++ b/src/Languages/Zpl/ZplPrinterCommandSet.ts
@@ -116,19 +116,14 @@ export class ZplPrinterCommandSet extends Cmds.StringCommandSet {
         return this.setLabelToMarkMediaCommand(cmd as Cmds.SetLabelToMarkMediaCommand);
       case 'SetLabelToWebGapMedia':
         return this.setLabelToWebGapMediaCommand(cmd as Cmds.SetLabelToWebGapMediaCommand);
+      case 'SetBackfeedAfterTaken':
+        return this.setBackfeedAfterTaken((cmd as Cmds.SetBackfeedAfterTakenMode).mode);
 
       case 'ClearImageBuffer':
         // Clear image buffer isn't a relevant command on ZPL printers.
         // Closest equivalent is the ~JP (pause and cancel) or ~JA (cancel all) but both
         // affect in-progress printing operations which is unlikely to be desired operation.
         // Translate as a no-op.
-        return this.noop;
-      case 'SuppressFeedBackup':
-        // ZPL needs this for every form printed.
-        return '^XB';
-      case 'EnableFeedBackup':
-        // ZPL doesn't have an enable, it just expects XB for every label
-        // that should not back up.
         return this.noop;
 
       case 'Offset':
@@ -197,6 +192,19 @@ export class ZplPrinterCommandSet extends Cmds.StringCommandSet {
   private setPrintDirectionCommand(upsideDown: boolean) {
     const dir = upsideDown ? 'I' : 'N';
     return `^PO${dir}`;
+  }
+
+  private setBackfeedAfterTaken(
+    mode: Conf.BackfeedAfterTaken
+  ) {
+    // ZPL has special names for some percentages because of course it does.
+    switch (mode) {
+      case 'disabled': return '~JSO';
+      case '100'     : return '~JSA';
+      case '90'      : return '~JSN';
+      case '0'       : return '~JSB';
+      default        : return `~JS${mode}`;
+    }
   }
 
   private setDarknessCommand(

--- a/src/Languages/Zpl/test_files/ZD410.ts.snap
+++ b/src/Languages/Zpl/test_files/ZD410.ts.snap
@@ -42,7 +42,7 @@
         "thermalPrintMode": 0,
       },
       "printerSettings": {
-        "backfeedAfterTaken": "Disabled",
+        "backfeedAfterTaken": "disabled",
       },
     },
   ],

--- a/src/Languages/Zpl/test_files/ZD410.ts.snap
+++ b/src/Languages/Zpl/test_files/ZD410.ts.snap
@@ -1,0 +1,50 @@
+{
+  "messageIncomplete": false,
+  "messageMatchedExpectedCommand": true,
+  "messages": [
+    {
+      "messageType": "SettingUpdateMessage",
+      "printerHardware": {
+        "dpi": 200,
+        "firmware": "V84.20.18Z",
+        "maxMediaDarkness": 30,
+        "maxMediaLengthDots": 7967,
+        "maxMediaWidthDots": 448,
+        "model": "ZD410",
+        "speedTable": SpeedTable {
+          "speedTable": Map {
+            0 => 0,
+            1 => 2,
+            1000 => 6,
+            4 => 2,
+            6 => 3,
+            8 => 4,
+            9 => 5,
+            10 => 6,
+          },
+        },
+      },
+      "printerMedia": {
+        "darknessPercent": 67,
+        "mediaGapDetectMode": 1,
+        "mediaLengthDots": 200,
+        "mediaPrintMode": 0,
+        "mediaPrintOriginOffsetDots": {
+          "left": 0,
+          "top": 0,
+        },
+        "mediaWidthDots": 400,
+        "printOrientation": 0,
+        "speed": PrintSpeedSettings {
+          "printSpeed": 10,
+          "slewSpeed": 10,
+        },
+        "thermalPrintMode": 0,
+      },
+      "printerSettings": {
+        "backfeedAfterTaken": "Disabled",
+      },
+    },
+  ],
+  "remainder": "",
+}

--- a/src/Languages/Zpl/test_files/ZD410.xml
+++ b/src/Languages/Zpl/test_files/ZD410.xml
@@ -1,0 +1,959 @@
+<?xml version='1.0'?>
+<ZEBRA-ELTRON-PERSONALITY>
+    <DEFINITIONS>
+        <MODEL>ZD410</MODEL>
+        <FIRMWARE-VERSION>V84.20.18Z</FIRMWARE-VERSION>
+        <LINK-OS-VERSION>6.0</LINK-OS-VERSION>
+        <XML-SCHEMA-VERSION>1.3</XML-SCHEMA-VERSION>
+        <PLUG-AND-PLAY-VALUE>MANUFACTURER:Zebra Technologies ;COMMAND SET:ZPL;MODEL:ZTC ZD410-203dpi
+            ZPL;CLASS:PRINTER;OPTIONS:XML;</PLUG-AND-PLAY-VALUE>
+        <ZBI>DISABLED</ZBI>
+        <DOTS-PER-MM>8</DOTS-PER-MM>
+        <DOTS-PER-DOTROW>448</DOTS-PER-DOTROW>
+        <PHYSICAL-MEMORY>
+            <TYPE ENUM='R, E, B, A'>R</TYPE>
+            <SIZE>8388608</SIZE>
+            <AVAILABLE>8365056</AVAILABLE>
+        </PHYSICAL-MEMORY>
+        <PHYSICAL-MEMORY>
+            <TYPE ENUM='R, E, B, A'>E</TYPE>
+            <SIZE>67108864</SIZE>
+            <AVAILABLE>66939392</AVAILABLE>
+        </PHYSICAL-MEMORY>
+        <OPTIONS>
+            <CUTTER BOOL='Y,N'>N</CUTTER>
+            <LINER-TAKEUP BOOL='Y,N'>N</LINER-TAKEUP>
+            <VALUE-PEEL-REWIND BOOL='Y,N'>N</VALUE-PEEL-REWIND>
+            <APPLICATOR BOOL='Y,N'>N</APPLICATOR>
+            <PEEL BOOL='Y,N'>N</PEEL>
+        </OPTIONS>
+        <WIRELESS-PRINTSERVER>
+            <PRODUCT-NAME>ZebraNet Wireless PS</PRODUCT-NAME>
+            <PRINTSERVER-FIRMWARE-VERSION>V84.20.18Z</PRINTSERVER-FIRMWARE-VERSION>
+            <PRODUCT-NUMBER>79071</PRODUCT-NUMBER>
+            <MFG-ID>H</MFG-ID>
+            <CARD-ID>H</CARD-ID>
+            <CARD-FIRMWARE>00.00.00</CARD-FIRMWARE>
+            <MAC-ADDRESS>00:00:00:00:00:00</MAC-ADDRESS>
+            <DATE-CODE>0161A</DATE-CODE>
+            <PRINTER-STATUS>Online</PRINTER-STATUS>
+            <CONNECTED-TO>ZTC ZD410-203dpi ,</CONNECTED-TO>
+            <BIDI-STATUS-ENABLED>Y</BIDI-STATUS-ENABLED>
+            <SYSTEM-UPTIME>00 days 00 hours 14 mins 01 secs</SYSTEM-UPTIME>
+        </WIRELESS-PRINTSERVER>
+    </DEFINITIONS>
+    <SAVED-SETTINGS>
+        <NAME>50J000000000</NAME>
+        <DESCRIPTION></DESCRIPTION>
+        <MEDIA-DARKNESS MIN='0.0' MAX='30.0'>
+            <CURRENT>20.0</CURRENT>
+            <STORED>20.0</STORED>
+            <DEFAULT>10.0</DEFAULT>
+        </MEDIA-DARKNESS>
+        <TEAR-OFF-POSITION MIN='-120' MAX='120'>
+            <CURRENT>0</CURRENT>
+            <STORED>0</STORED>
+            <DEFAULT>0</DEFAULT>
+        </TEAR-OFF-POSITION>
+        <PRINT-MODE>
+            <MODE
+                ENUM='REWIND, TEAR OFF, PEEL OFF, CUTTER, DELAYED CUT, APPLICATOR, LINERLESS-P, LINERLESS-R, LINERLESS-T, LINERLESS CUT, LINRLESS DLY CUT, '>
+                <CURRENT>TEAR OFF</CURRENT>
+                <STORED>TEAR OFF</STORED>
+                <DEFAULT>TEAR OFF</DEFAULT>
+            </MODE>
+        </PRINT-MODE>
+        <MEDIA-TRACKING ENUM='CONTINUOUS, NON-CONTINUOUS'>
+            <CURRENT>NON-CONTINUOUS</CURRENT>
+            <STORED>NON-CONTINUOUS</STORED>
+            <DEFAULT>NON-CONTINUOUS</DEFAULT>
+        </MEDIA-TRACKING>
+        <MEDIA-TYPE ENUM='DIRECT-THERMAL, THERMAL-TRANS.'>
+            <CURRENT>DIRECT-THERMAL</CURRENT>
+            <STORED>DIRECT-THERMAL</STORED>
+            <DEFAULT>DIRECT-THERMAL</DEFAULT>
+        </MEDIA-TYPE>
+        <PRINT-WIDTH MIN='2' MAX='448'>
+            <CURRENT>400</CURRENT>
+            <STORED>400</STORED>
+            <DEFAULT>448</DEFAULT>
+        </PRINT-WIDTH>
+        <EARLY-WARNING-MEDIA BOOL='Y,N'>
+            <CURRENT>N</CURRENT>
+            <STORED>N</STORED>
+            <DEFAULT>N</DEFAULT>
+        </EARLY-WARNING-MEDIA>
+        <LABELS-PER-ROLL MIN='100' MAX='9999'>
+            <CURRENT>900</CURRENT>
+            <STORED>900</STORED>
+            <DEFAULT>900</DEFAULT>
+        </LABELS-PER-ROLL>
+        <RIBBON-LENGTH
+            ENUM='100 M  328 FT, 150 M  492 FT, 200 M  656 FT, 250 M  820 FT, 300 M  984 FT, 350 M  1148 FT, 400 M  1312 FT, 450 M  1476 FT'>
+            <CURRENT>450 M 1476 FT</CURRENT>
+            <STORED>450 M 1476 FT</STORED>
+            <DEFAULT>450 M 1476 FT</DEFAULT>
+        </RIBBON-LENGTH>
+        <EARLY-WARNING-MAINTENANCE BOOL='Y,N'>
+            <CURRENT>N</CURRENT>
+            <STORED>N</STORED>
+            <DEFAULT>N</DEFAULT>
+        </EARLY-WARNING-MAINTENANCE>
+        <HEAD-CLEANING
+            ENUM='0 M  0 FT, 100 M  328 FT, 150 M  492 FT, 200 M  656 FT, 250 M  820 FT, 300 M  984 FT, 350 M  1148 FT, 400 M  1312 FT, 450 M  1476 FT'>
+            <CURRENT>450 M 1476 FT</CURRENT>
+            <STORED>450 M 1476 FT</STORED>
+            <DEFAULT>450 M 1476 FT</DEFAULT>
+        </HEAD-CLEANING>
+        <SERIAL-PORT1>
+            <BAUD ENUM='4800, 9600, 14400, 19200, 28800, 38400, 57600, 115200'>
+                <CURRENT>9600</CURRENT>
+                <STORED>9600</STORED>
+                <DEFAULT>9600</DEFAULT>
+            </BAUD>
+            <DATA-BITS ENUM='7 BITS, 8 BITS'>
+                <CURRENT>8 BITS</CURRENT>
+                <STORED>8 BITS</STORED>
+                <DEFAULT>8 BITS</DEFAULT>
+            </DATA-BITS>
+            <PARITY ENUM='NONE, ODD, EVEN'>
+                <CURRENT>NONE</CURRENT>
+                <STORED>NONE</STORED>
+                <DEFAULT>NONE</DEFAULT>
+            </PARITY>
+            <STOP-BITS ENUM='1 STOP BIT, 2 STOP BITS'>
+                <CURRENT>1 STOP BIT</CURRENT>
+                <STORED>1 STOP BIT</STORED>
+                <DEFAULT>1 STOP BIT</DEFAULT>
+            </STOP-BITS>
+            <HANDSHAKE ENUM='XON/XOFF, DSR/DTR, RTS/CTS, APL-I, DTR &amp; XON/XOFF'>
+                <CURRENT>XON/XOFF</CURRENT>
+                <STORED>XON/XOFF</STORED>
+                <DEFAULT>XON/XOFF</DEFAULT>
+            </HANDSHAKE>
+            <PROTOCOL ENUM='NONE, ZEBRA, ACK_NAK'>
+                <CURRENT>NONE</CURRENT>
+                <STORED>NONE</STORED>
+                <DEFAULT>NONE</DEFAULT>
+            </PROTOCOL>
+        </SERIAL-PORT1>
+        <ZNET-ID MIN='0' MAX='999'>
+            <CURRENT>0</CURRENT>
+            <STORED>0</STORED>
+            <DEFAULT>0</DEFAULT>
+        </ZNET-ID>
+        <PROTOCOL-1284-4 BOOL='Y,N'>
+            <CURRENT>N</CURRENT>
+            <STORED>N</STORED>
+            <DEFAULT>N</DEFAULT>
+        </PROTOCOL-1284-4>
+        <WARN-HEAD-COLD BOOL='Y,N'>
+            <CURRENT>N</CURRENT>
+            <STORED>N</STORED>
+            <DEFAULT>N</DEFAULT>
+        </WARN-HEAD-COLD>
+        <TILDE-DEFINE MIN='0' MAX='255'>
+            <CURRENT>126</CURRENT>
+            <STORED>126</STORED>
+            <DEFAULT>126</DEFAULT>
+        </TILDE-DEFINE>
+        <CARET-DEFINE MIN='0' MAX='255'>
+            <CURRENT>94</CURRENT>
+            <STORED>94</STORED>
+            <DEFAULT>94</DEFAULT>
+        </CARET-DEFINE>
+        <DELIM-DEFINE MIN='0' MAX='255'>
+            <CURRENT>44</CURRENT>
+            <STORED>44</STORED>
+            <DEFAULT>44</DEFAULT>
+        </DELIM-DEFINE>
+        <LABEL-DESCRIPTION-LANGUAGE ENUM='ZPL II, ZPL'>
+            <CURRENT>ZPL II</CURRENT>
+            <STORED>ZPL II</STORED>
+            <DEFAULT>ZPL II</DEFAULT>
+        </LABEL-DESCRIPTION-LANGUAGE>
+        <MEDIA-FEED>
+            <POWER-UP ENUM='FEED, CALIBRATION, LENGTH, SHORT CAL, QUICK CAL, NO MOTION'>
+                <CURRENT>NO MOTION</CURRENT>
+                <STORED>NO MOTION</STORED>
+                <DEFAULT>NO MOTION</DEFAULT>
+            </POWER-UP>
+            <HEAD-CLOSE ENUM='FEED, CALIBRATION, LENGTH, SHORT CAL, QUICK CAL, NO MOTION'>
+                <CURRENT>FEED</CURRENT>
+                <STORED>FEED</STORED>
+                <DEFAULT>FEED</DEFAULT>
+            </HEAD-CLOSE>
+        </MEDIA-FEED>
+        <BACKFEED-PERCENT ENUM='BEFORE, 10%, 20%, 30%, 40%, 50%, 60%, 70%, 80%, DEFAULT, AFTER, OFF'>
+            <CURRENT>OFF</CURRENT>
+            <STORED>OFF</STORED>
+            <DEFAULT>DEFAULT</DEFAULT>
+        </BACKFEED-PERCENT>
+        <LABEL-TOP MIN='-120' MAX='120'>
+            <CURRENT>0</CURRENT>
+            <STORED>0</STORED>
+            <DEFAULT>0</DEFAULT>
+        </LABEL-TOP>
+        <CALIBRATION-VALUES>
+            <CALIBRATED-LABEL-LENGTH MIN='0' MAX='7967'>
+                <CURRENT>214</CURRENT>
+                <STORED>214</STORED>
+                <DEFAULT>1225</DEFAULT>
+            </CALIBRATED-LABEL-LENGTH>
+            <WEB-SENSOR MIN='0' MAX='100'>
+                <CURRENT>36</CURRENT>
+                <STORED>36</STORED>
+                <DEFAULT>20</DEFAULT>
+            </WEB-SENSOR>
+            <MEDIA-SENSOR MIN='0' MAX='100'>
+                <CURRENT>96</CURRENT>
+                <STORED>96</STORED>
+                <DEFAULT>24</DEFAULT>
+            </MEDIA-SENSOR>
+            <RIBBON-SENSOR MIN='0' MAX='100'>
+                <CURRENT>75</CURRENT>
+                <STORED>75</STORED>
+                <DEFAULT>75</DEFAULT>
+            </RIBBON-SENSOR>
+            <MARK-SENSOR MIN='0' MAX='100'>
+                <CURRENT>50</CURRENT>
+                <STORED>50</STORED>
+                <DEFAULT>27</DEFAULT>
+            </MARK-SENSOR>
+            <MARK-MEDIA-SENSOR MIN='0' MAX='100'>
+                <CURRENT>4</CURRENT>
+                <STORED>4</STORED>
+                <DEFAULT>27</DEFAULT>
+            </MARK-MEDIA-SENSOR>
+            <TRANSMISSIVE-GAIN MIN='0' MAX='255'>
+                <CURRENT>35</CURRENT>
+                <STORED>35</STORED>
+                <DEFAULT>128</DEFAULT>
+            </TRANSMISSIVE-GAIN>
+            <TRANSMISSIVE-LED MIN='0' MAX='100'>
+                <CURRENT>22</CURRENT>
+                <STORED>22</STORED>
+                <DEFAULT>50</DEFAULT>
+            </TRANSMISSIVE-LED>
+            <RIBBON-GAIN MIN='0' MAX='255'>
+                <CURRENT>40</CURRENT>
+                <STORED>40</STORED>
+                <DEFAULT>40</DEFAULT>
+            </RIBBON-GAIN>
+            <MARK-GAIN MIN='0' MAX='255'>
+                <CURRENT>17</CURRENT>
+                <STORED>17</STORED>
+                <DEFAULT>128</DEFAULT>
+            </MARK-GAIN>
+        </CALIBRATION-VALUES>
+        <HALF-DENSITY BOOL='Y,N'>
+            <CURRENT>N</CURRENT>
+            <STORED>N</STORED>
+            <DEFAULT>N</DEFAULT>
+        </HALF-DENSITY>
+        <OPERATOR-LANGUAGE
+            ENUM='ENGLISH, SPANISH, FRENCH, GERMAN, ITALIAN, NORWEGIAN, PORTUGUESE, SWEDISH, DANISH, DUTCH, FINNISH, JAPAN, KOREAN, SIMP CHINESE, TRAD CHINESE, RUSSIAN, POLISH, CZECH, ROMANIAN'>
+            <CURRENT>ENGLISH</CURRENT>
+            <STORED>ENGLISH</STORED>
+            <DEFAULT>ENGLISH</DEFAULT>
+        </OPERATOR-LANGUAGE>
+        <MODE-PROTECTION>
+            <DISABLE-DARKNESS BOOL='Y,N'>
+                <CURRENT>N</CURRENT>
+                <STORED>N</STORED>
+                <DEFAULT>N</DEFAULT>
+            </DISABLE-DARKNESS>
+            <DISABLE-POSITION BOOL='Y,N'>
+                <CURRENT>N</CURRENT>
+                <STORED>N</STORED>
+                <DEFAULT>N</DEFAULT>
+            </DISABLE-POSITION>
+            <DISABLE-CALIBRATION BOOL='Y,N'>
+                <CURRENT>N</CURRENT>
+                <STORED>N</STORED>
+                <DEFAULT>N</DEFAULT>
+            </DISABLE-CALIBRATION>
+            <DISABLE-SAVE-CONFIGURATION BOOL='Y,N'>
+                <CURRENT>N</CURRENT>
+                <STORED>N</STORED>
+                <DEFAULT>N</DEFAULT>
+            </DISABLE-SAVE-CONFIGURATION>
+            <DISABLE-PAUSE-KEY BOOL='Y,N'>
+                <CURRENT>N</CURRENT>
+                <STORED>N</STORED>
+                <DEFAULT>N</DEFAULT>
+            </DISABLE-PAUSE-KEY>
+            <DISABLE-FEED-KEY BOOL='Y,N'>
+                <CURRENT>N</CURRENT>
+                <STORED>N</STORED>
+                <DEFAULT>N</DEFAULT>
+            </DISABLE-FEED-KEY>
+            <DISABLE-CANCEL-KEY BOOL='Y,N'>
+                <CURRENT>N</CURRENT>
+                <STORED>N</STORED>
+                <DEFAULT>N</DEFAULT>
+            </DISABLE-CANCEL-KEY>
+            <DISABLE-MENU BOOL='Y,N'>
+                <CURRENT>N</CURRENT>
+                <STORED>N</STORED>
+                <DEFAULT>N</DEFAULT>
+            </DISABLE-MENU>
+        </MODE-PROTECTION>
+        <MEMORY-ALIAS>
+            <DRIVE-A ENUM='R, E, B, A'>
+                <CURRENT>A</CURRENT>
+                <STORED>A</STORED>
+                <DEFAULT>A</DEFAULT>
+            </DRIVE-A>
+            <DRIVE-B ENUM='R, E, B, A'>
+                <CURRENT>B</CURRENT>
+                <STORED>B</STORED>
+                <DEFAULT>B</DEFAULT>
+            </DRIVE-B>
+            <DRIVE-E ENUM='R, E, B, A'>
+                <CURRENT>E</CURRENT>
+                <STORED>E</STORED>
+                <DEFAULT>E</DEFAULT>
+            </DRIVE-E>
+            <DRIVE-R ENUM='R, E, B, A'>
+                <CURRENT>R</CURRENT>
+                <STORED>R</STORED>
+                <DEFAULT>R</DEFAULT>
+            </DRIVE-R>
+        </MEMORY-ALIAS>
+        <PASSWORD MIN='0' MAX='9999'>
+            <CURRENT>0</CURRENT>
+            <STORED>0</STORED>
+            <DEFAULT>1234</DEFAULT>
+        </PASSWORD>
+        <MAX-LABEL-LENGTH MIN='0' MAX='7967'>
+            <CURRENT>3048</CURRENT>
+            <STORED>3048</STORED>
+            <DEFAULT>3048</DEFAULT>
+        </MAX-LABEL-LENGTH>
+        <VERIFIER-PORT ENUM='OFF, VER-RPRNT ERR, VER-THRUPUT'>
+            <CURRENT>OFF</CURRENT>
+            <STORED>OFF</STORED>
+            <DEFAULT>OFF</DEFAULT>
+        </VERIFIER-PORT>
+        <APPLICATOR-PORT ENUM='OFF, MODE 1, MODE 2, MODE 3, MODE 4'>
+            <CURRENT>OFF</CURRENT>
+            <STORED>OFF</STORED>
+            <DEFAULT>OFF</DEFAULT>
+        </APPLICATOR-PORT>
+        <START-PRINT-SIG ENUM='PULSE MODE, LEVEL MODE'>
+            <CURRENT>PULSE MODE</CURRENT>
+            <STORED>PULSE MODE</STORED>
+            <DEFAULT>PULSE MODE</DEFAULT>
+        </START-PRINT-SIG>
+        <RESYNCH-MODE ENUM='FEED MODE, ERROR MODE'>
+            <CURRENT>FEED MODE</CURRENT>
+            <STORED>FEED MODE</STORED>
+            <DEFAULT>FEED MODE</DEFAULT>
+        </RESYNCH-MODE>
+        <PRE-PEEL BOOL='Y,N'>
+            <CURRENT>N</CURRENT>
+            <STORED>N</STORED>
+            <DEFAULT>N</DEFAULT>
+        </PRE-PEEL>
+        <PRINTER-SLEEP>
+            <FORCE-OFF-MODE BOOL='Y,N'>
+                <CURRENT>N</CURRENT>
+                <STORED>N</STORED>
+                <DEFAULT>N</DEFAULT>
+            </FORCE-OFF-MODE>
+            <IDLE-TIME MIN='0' MAX='999999'>
+                <CURRENT>0</CURRENT>
+                <STORED>0</STORED>
+                <DEFAULT>0</DEFAULT>
+            </IDLE-TIME>
+        </PRINTER-SLEEP>
+        <UNSOLICITED-MESSAGES>
+            <CURRENT>
+                <MESSAGE>
+                    <CONDITION
+                        ENUM='ALL MESSAGES, PAPER OUT, RIBBON OUT, HEAD TOO HOT, HEAD COLD, HEAD OPEN, SUPPLY TOO HOT, RIBBON IN, REWIND, CUTTER JAMMED, PRINTER PAUSED, PQ JOB COMPLETED, LABEL READY, HEAD ELEMENT BAD, BASIC RUNTIME, BASIC FORCED, POWER ON, CLEAN PRINTHEAD, MEDIA LOW, RIBBON LOW, REPLACE HEAD, BATTERY LOW, RFID ERROR, MOTOR OVERTEMP, PRINTHEAD SHUTDOWN, COLD START, SGD SET, SHUTTING DOWN, RESTARTING, NO READER PRESENT, THERMISTOR FAULT, INVALID HEAD, COUNTRY CODE ERROR, MCR RESULT READY, PMCU DOWNLOAD, RIBBON AUTH ERROR, ODOMETER TRIGGERED, COUNTRY CODE, BATTERY MISSING, MEDIA CARTRIDGE, MEDIA CARTRIDGE LOAD FAILURE, MEDIA CARTRIDGE EJECT FAILURE, MEDIA CARTRIDGE FORCED EJECT, CLEANING MODE, CSR AVAILABLE'>
+                        COLD START</CONDITION>
+                    <DESTINATION
+                        ENUM='SERIAL, PARALLEL, E-MAIL, TCP, UDP, SNMP, USB, HTTP-POST, BLUETOOTH, SDK'>
+                        SNMP</DESTINATION>
+                    <SET BOOL='Y,N'>Y</SET>
+                    <CLEAR BOOL='Y,N'>N</CLEAR>
+                    <DESTINATION-DATA>255.255.255.255</DESTINATION-DATA>
+                    <PORT MIN='0' MAX='65535'>162</PORT>
+                    <SGD-NAME></SGD-NAME>
+                </MESSAGE>
+            </CURRENT>
+            <STORED>
+                <MESSAGE>
+                    <CONDITION
+                        ENUM='ALL MESSAGES, PAPER OUT, RIBBON OUT, HEAD TOO HOT, HEAD COLD, HEAD OPEN, SUPPLY TOO HOT, RIBBON IN, REWIND, CUTTER JAMMED, PRINTER PAUSED, PQ JOB COMPLETED, LABEL READY, HEAD ELEMENT BAD, BASIC RUNTIME, BASIC FORCED, POWER ON, CLEAN PRINTHEAD, MEDIA LOW, RIBBON LOW, REPLACE HEAD, BATTERY LOW, RFID ERROR, MOTOR OVERTEMP, PRINTHEAD SHUTDOWN, COLD START, SGD SET, SHUTTING DOWN, RESTARTING, NO READER PRESENT, THERMISTOR FAULT, INVALID HEAD, COUNTRY CODE ERROR, MCR RESULT READY, PMCU DOWNLOAD, RIBBON AUTH ERROR, ODOMETER TRIGGERED, COUNTRY CODE, BATTERY MISSING, MEDIA CARTRIDGE, MEDIA CARTRIDGE LOAD FAILURE, MEDIA CARTRIDGE EJECT FAILURE, MEDIA CARTRIDGE FORCED EJECT, CLEANING MODE, CSR AVAILABLE'>
+                        COLD START</CONDITION>
+                    <DESTINATION
+                        ENUM='SERIAL, PARALLEL, E-MAIL, TCP, UDP, SNMP, USB, HTTP-POST, BLUETOOTH, SDK'>
+                        SNMP</DESTINATION>
+                    <SET BOOL='Y,N'>Y</SET>
+                    <CLEAR BOOL='Y,N'>N</CLEAR>
+                    <DESTINATION-DATA>255.255.255.255</DESTINATION-DATA>
+                    <PORT MIN='0' MAX='65535'>162</PORT>
+                    <SGD-NAME></SGD-NAME>
+                </MESSAGE>
+            </STORED>
+        </UNSOLICITED-MESSAGES>
+        <WIRELESS-PRINTSERVER>
+            <WIRELESS-SETTINGS>
+                <ESSID>
+                    <CURRENT></CURRENT>
+                    <STORED></STORED>
+                    <DEFAULT></DEFAULT>
+                </ESSID>
+                <OPERATING-MODE ENUM='AD-HOC, INFRASTRUCTURE'>
+                    <CURRENT>INFRASTRUCTURE</CURRENT>
+                    <STORED>INFRASTRUCTURE</STORED>
+                    <DEFAULT>INFRASTRUCTURE</DEFAULT>
+                </OPERATING-MODE>
+                <PREAMBLE ENUM='LONG, SHORT'>
+                    <CURRENT>LONG</CURRENT>
+                    <STORED>LONG</STORED>
+                    <DEFAULT>LONG</DEFAULT>
+                </PREAMBLE>
+                <WLAN-PULSE-ENABLED BOOL='ON,OFF'>
+                    <CURRENT>ON</CURRENT>
+                    <STORED>ON</STORED>
+                    <DEFAULT>ON</DEFAULT>
+                </WLAN-PULSE-ENABLED>
+                <WLAN-PULSE-RATE MIN='5' MAX='300'>
+                    <CURRENT>15</CURRENT>
+                    <STORED>15</STORED>
+                    <DEFAULT>15</DEFAULT>
+                </WLAN-PULSE-RATE>
+                <WLAN-INTERNATIONAL-MODE ENUM='OFF, ON, AUTO'>
+                    <CURRENT>OFF</CURRENT>
+                    <STORED>OFF</STORED>
+                    <DEFAULT>OFF</DEFAULT>
+                </WLAN-INTERNATIONAL-MODE>
+                <WLAN-CHANNEL-MASK>
+                    <CURRENT>7FF</CURRENT>
+                    <STORED>7FF</STORED>
+                    <DEFAULT>7FF</DEFAULT>
+                </WLAN-CHANNEL-MASK>
+                <KERBEROS-USERNAME>
+                    <CURRENT></CURRENT>
+                    <STORED></STORED>
+                    <DEFAULT></DEFAULT>
+                </KERBEROS-USERNAME>
+                <KERBEROS-PASSWORD>
+                    <CURRENT>*****</CURRENT>
+                    <STORED>*****</STORED>
+                    <DEFAULT>*****</DEFAULT>
+                </KERBEROS-PASSWORD>
+                <KERBEROS-REALM>
+                    <CURRENT>kerberos</CURRENT>
+                    <STORED>kerberos</STORED>
+                    <DEFAULT>kerberos</DEFAULT>
+                </KERBEROS-REALM>
+                <KERBEROS-KDC>
+                    <CURRENT>krbtgt</CURRENT>
+                    <STORED>krbtgt</STORED>
+                    <DEFAULT>krbtgt</DEFAULT>
+                </KERBEROS-KDC>
+                <WLAN-USERNAME>
+                    <CURRENT></CURRENT>
+                    <STORED></STORED>
+                    <DEFAULT></DEFAULT>
+                </WLAN-USERNAME>
+                <WLAN-PASSWORD>
+                    <CURRENT>*****</CURRENT>
+                    <STORED>*****</STORED>
+                    <DEFAULT>*****</DEFAULT>
+                </WLAN-PASSWORD>
+                <WPA-PRE-SHARED-KEY>
+                    <CURRENT>*****</CURRENT>
+                    <STORED>*****</STORED>
+                    <DEFAULT>*****</DEFAULT>
+                </WPA-PRE-SHARED-KEY>
+                <WLAN-SECURITY
+                    ENUM='INVALID MODE, NONE, EAP-TLS, EAP-TTLS, EAP-FAST, PEAP, LEAP, WPA PSK, WPA EAP-TLS, WPA EAP-TTLS, WPA EAP-FAST, WPA PEAP, WPA LEAP'>
+                    <CURRENT>NONE</CURRENT>
+                    <STORED></STORED>
+                    <DEFAULT>NONE</DEFAULT>
+                </WLAN-SECURITY>
+                <PRIVATE-KEY>
+                    <CURRENT>*****</CURRENT>
+                    <STORED>*****</STORED>
+                    <DEFAULT>*****</DEFAULT>
+                </PRIVATE-KEY>
+                <REGION-CODE>
+                    <CURRENT>all</CURRENT>
+                    <STORED>all</STORED>
+                    <DEFAULT>all</DEFAULT>
+                </REGION-CODE>
+                <COUNTRY-CODE>
+                    <CURRENT>all</CURRENT>
+                    <STORED>all</STORED>
+                    <DEFAULT>all</DEFAULT>
+                </COUNTRY-CODE>
+            </WIRELESS-SETTINGS>
+        </WIRELESS-PRINTSERVER>
+        <CAPTURE>
+            <CHANNEL1>
+                <PORT ENUM='serial,usb,bt,parallel,off'>
+                    off</PORT>
+                <DELIMITER>
+<![CDATA[
+]]></DELIMITER>
+                <MAX-LENGTH>
+                    1000</MAX-LENGTH>
+                <COUNT>
+                    0</COUNT>
+                <DATA>
+                    <RAW>
+<![CDATA[]]></RAW>
+                    <MIME>
+<![CDATA[]]></MIME>
+                </DATA>
+            </CHANNEL1>
+        </CAPTURE>
+        <WEBLINK>
+            <ENABLE BOOL='Y,N'>N</ENABLE>
+            <PRINTER-RESET-REQUIRED BOOL='Y,N'>N</PRINTER-RESET-REQUIRED>
+            <LOGGING>
+                <MAX-ENTRIES>500</MAX-ENTRIES>
+            </LOGGING>
+            <IP>
+                <CONN1>
+                    <LOCATION><![CDATA[]]></LOCATION>
+                    <RETRY-INTERVAL>10</RETRY-INTERVAL>
+                    <PROXY><![CDATA[]]></PROXY>
+                    <MAXIMUM-SIMULTANEOUS-CONNECTIONS>10</MAXIMUM-SIMULTANEOUS-CONNECTIONS>
+                    <AUTHENTICATION>
+                        <ENTRIES><![CDATA[]]></ENTRIES>
+                    </AUTHENTICATION>
+                    <TEST>
+                        <LOCATION><![CDATA[http://www.zebra.com/apps/linktest]]></LOCATION>
+                        <TEST-ON>failure</TEST-ON>
+                        <RETRY-INTERVAL>900</RETRY-INTERVAL>
+                    </TEST>
+                </CONN1>
+                <CONN2>
+                    <LOCATION><![CDATA[]]></LOCATION>
+                    <RETRY-INTERVAL>10</RETRY-INTERVAL>
+                    <PROXY><![CDATA[]]></PROXY>
+                    <MAXIMUM-SIMULTANEOUS-CONNECTIONS>10</MAXIMUM-SIMULTANEOUS-CONNECTIONS>
+                    <AUTHENTICATION>
+                        <ENTRIES><![CDATA[]]></ENTRIES>
+                    </AUTHENTICATION>
+                    <TEST>
+                        <LOCATION><![CDATA[http://www.zebra.com/apps/linktest]]></LOCATION>
+                        <TEST-ON>failure</TEST-ON>
+                        <RETRY-INTERVAL>900</RETRY-INTERVAL>
+                    </TEST>
+                </CONN2>
+            </IP>
+        </WEBLINK>
+        <ALERTS>
+            <TRACKED_SETTINGS>
+                <ZBI-NOTIFIED>
+<![CDATA[]]></ZBI-NOTIFIED>
+                <LOG-TRACKED>
+<![CDATA[]]></LOG-TRACKED>
+                <MAX-LOG-ENTRIES>
+                    100</MAX-LOG-ENTRIES>
+            </TRACKED_SETTINGS>
+            <HTTP>
+                <PROXY>
+<![CDATA[]]></PROXY>
+                <LOG-MAX-ENTRIES>
+                    500</LOG-MAX-ENTRIES>
+                <AUTHENTICATION-ENTRIES>
+<![CDATA[]]></AUTHENTICATION-ENTRIES>
+            </HTTP>
+        </ALERTS>
+    </SAVED-SETTINGS>
+    <INTERFACES>
+        <NETWORK>
+            <ACTIVE-NETWORK-INTERFACE ENUM='Wireless, External Wired, UNKNOWN, Internal Wired'>
+                UNKNOWN</ACTIVE-NETWORK-INTERFACE>
+            <NETWORK-SETTINGS-DIRTY BOOL='Y,N'>N</NETWORK-SETTINGS-DIRTY>
+            <NETWORK-COMMON>
+                <PROTOCOLS>
+                    <TCP>
+                        <ENABLED BOOL='Y,N'>Y</ENABLED>
+                    </TCP>
+                    <FTP>
+                        <ENABLED BOOL='Y,N'>Y</ENABLED>
+                    </FTP>
+                    <LPD>
+                        <ENABLED BOOL='Y,N'>Y</ENABLED>
+                    </LPD>
+                    <MAIL>
+                        <PS_DOMAIN>ZBRPrintServer.com</PS_DOMAIN>
+                        <SMTP>
+                            <ENABLED BOOL='Y,N'>Y</ENABLED>
+                            <SMTP-SERVER-ADDRESS>0.0.0.0</SMTP-SERVER-ADDRESS>
+                        </SMTP>
+                        <POP3>
+                            <ENABLED BOOL='Y,N'>Y</ENABLED>
+                            <POP3-SERVER-ADDRESS>0.0.0.0</POP3-SERVER-ADDRESS>
+                            <USER-NAME></USER-NAME>
+                            <PASSWORD>*****</PASSWORD>
+                            <POLLING-INTERVAL>240</POLLING-INTERVAL>
+                        </POP3>
+                    </MAIL>
+                    <TELNET>
+                        <ENABLED BOOL='Y,N'>N</ENABLED>
+                    </TELNET>
+                    <UDP>
+                        <ENABLED BOOL='Y,N'>Y</ENABLED>
+                        <UDP-DISCOVERY-PORT>4201</UDP-DISCOVERY-PORT>
+                    </UDP>
+                    <HTTP>
+                        <ENABLED BOOL='Y,N'>Y</ENABLED>
+                        <HTTP-PORT>0</HTTP-PORT>
+                    </HTTP>
+                    <SNMP>
+                        <ENABLED BOOL='Y,N'>Y</ENABLED>
+                        <GET-COMMUNITY-NAME>public</GET-COMMUNITY-NAME>
+                        <SET-COMMUNITY-NAME>*****</SET-COMMUNITY-NAME>
+                        <TRAP-COMMUNITY-NAME>public</TRAP-COMMUNITY-NAME>
+                    </SNMP>
+                </PROTOCOLS>
+            </NETWORK-COMMON>
+            <NETWORK-INTERFACE-SPECIFIC>
+                <GENERAL>
+                    <MAC-ADDRESS>
+                        <INTERNAL-WIRED>00:07:4D:99:69:69</INTERNAL-WIRED>
+                        <WIRELESS>00:00:00:00:00:00</WIRELESS>
+                    </MAC-ADDRESS>
+                </GENERAL>
+                <TCP>
+                    <IP-ADDRESS>
+                        <INTERNAL-WIRED>0.0.0.0</INTERNAL-WIRED>
+                        <WIRELESS>0.0.0.0</WIRELESS>
+                    </IP-ADDRESS>
+                    <SUBNET-MASK>
+                        <INTERNAL-WIRED>255.255.255.0</INTERNAL-WIRED>
+                        <WIRELESS>255.255.255.0</WIRELESS>
+                    </SUBNET-MASK>
+                    <DEFAULT-GATEWAY>
+                        <INTERNAL-WIRED>0.0.0.0</INTERNAL-WIRED>
+                        <WIRELESS>0.0.0.0</WIRELESS>
+                    </DEFAULT-GATEWAY>
+                    <IP-PROTOCOL
+                        ENUM='ALL, GLEANING ONLY, RARP, BOOTP, DHCP, DHCP AND BOOTP, PERMANENT'>
+                        <INTERNAL-WIRED>ALL</INTERNAL-WIRED>
+                        <WIRELESS>ALL</WIRELESS>
+                    </IP-PROTOCOL>
+                    <DEFAULT-ADDRESS-ENABLED BOOL='YES,NO'>
+                        <INTERNAL-WIRED>YES</INTERNAL-WIRED>
+                        <WIRELESS>YES</WIRELESS>
+                    </DEFAULT-ADDRESS-ENABLED>
+                    <TIMEOUT-CHECKING-ENABLED BOOL='YES,NO'>
+                        <INTERNAL-WIRED>YES</INTERNAL-WIRED>
+                        <WIRELESS>YES</WIRELESS>
+                    </TIMEOUT-CHECKING-ENABLED>
+                    <TIMEOUT-CHECKING-VALUE>
+                        <INTERNAL-WIRED>300</INTERNAL-WIRED>
+                        <WIRELESS>300</WIRELESS>
+                    </TIMEOUT-CHECKING-VALUE>
+                    <ARP-INTERVAL>
+                        <INTERNAL-WIRED>0</INTERNAL-WIRED>
+                        <WIRELESS>0</WIRELESS>
+                    </ARP-INTERVAL>
+                    <BASE-RAW-PORT-NUMBER>
+                        <INTERNAL-WIRED>6101</INTERNAL-WIRED>
+                        <WIRELESS>6101</WIRELESS>
+                    </BASE-RAW-PORT-NUMBER>
+                    <BASE-RAW-PORT-NUMBER-ALTERNATE>
+                        <INTERNAL-WIRED>9100</INTERNAL-WIRED>
+                        <WIRELESS>9100</WIRELESS>
+                    </BASE-RAW-PORT-NUMBER-ALTERNATE>
+                    <BASE-JSON-CONFIG-PORT-NUMBER>
+                        <INTERNAL-WIRED>9200</INTERNAL-WIRED>
+                        <WIRELESS>9200</WIRELESS>
+                    </BASE-JSON-CONFIG-PORT-NUMBER>
+                    <WINS-ADDRESSING-PERMANENT BOOL='YES,NO'>
+                        <INTERNAL-WIRED>NO</INTERNAL-WIRED>
+                        <WIRELESS>NO</WIRELESS>
+                    </WINS-ADDRESSING-PERMANENT>
+                    <WINS-ADDRESS>
+                        <INTERNAL-WIRED>0.0.0.0</INTERNAL-WIRED>
+                        <WIRELESS>0.0.0.0</WIRELESS>
+                    </WINS-ADDRESS>
+                </TCP>
+                <DHCP-CLIENT-ID-SETTINGS>
+                    <ENABLED BOOL='YES,NO'>
+                        <INTERNAL-WIRED>NO</INTERNAL-WIRED>
+                        <WIRELESS>NO</WIRELESS>
+                    </ENABLED>
+                    <TYPE ENUM='STRING, MAC ADDRESS, HEX'>
+                        <INTERNAL-WIRED>MAC ADDRESS</INTERNAL-WIRED>
+                        <WIRELESS>MAC ADDRESS</WIRELESS>
+                    </TYPE>
+                    <PREFIX>
+                        <INTERNAL-WIRED></INTERNAL-WIRED>
+                        <WIRELESS></WIRELESS>
+                    </PREFIX>
+                    <SUFFIX>
+                        <INTERNAL-WIRED>00074D9D5A4F</INTERNAL-WIRED>
+                        <WIRELESS>000000000000</WIRELESS>
+                    </SUFFIX>
+                </DHCP-CLIENT-ID-SETTINGS>
+            </NETWORK-INTERFACE-SPECIFIC>
+        </NETWORK>
+        <BLUETOOTH>
+            <FIRMWARE>1.4.1.0</FIRMWARE>
+            <DATE>05/25/2016</DATE>
+            <DISCOVERABLE BOOL='Y,N'>N</DISCOVERABLE>
+            <RADIO-VERSION>4.0</RADIO-VERSION>
+            <ENABLED BOOL='Y,N'>Y</ENABLED>
+            <MAC-ADDRESS>50:51:A9:69:96:96</MAC-ADDRESS>
+            <FRIENDLY-NAME>50J193302798</FRIENDLY-NAME>
+            <CONNECTED BOOL='Y,N'>N</CONNECTED>
+            <MIN-SECURITY-MODE>1</MIN-SECURITY-MODE>
+            <CONN-SECURITY-MODE>nc</CONN-SECURITY-MODE>
+        </BLUETOOTH>
+    </INTERFACES>
+    <FORMAT-SETTINGS>
+        <CODE-VALIDATION BOOL='Y,N'>N</CODE-VALIDATION>
+        <REPRINT-AFTER-ERROR BOOL='Y,N'>Y</REPRINT-AFTER-ERROR>
+        <MODE-UNITS ENUM='DOTS, INCHES, MILLIMETERS'>DOTS</MODE-UNITS>
+        <LABEL-LENGTH MIN='0' MAX='7967'>214</LABEL-LENGTH>
+        <LABEL-REVERSE BOOL='Y,N'>N</LABEL-REVERSE>
+        <LABEL-SHIFT MIN='-9999' MAX='9999'>0</LABEL-SHIFT>
+        <LABEL-HOME>
+            <X-AXIS MIN='0' MAX='32000'>0</X-AXIS>
+            <Y-AXIS MIN='0' MAX='32000'>0</Y-AXIS>
+        </LABEL-HOME>
+        <RELATIVE-DARKNESS MIN='-30.0' MAX='30.0'>0.0</RELATIVE-DARKNESS>
+        <PRINT-RATE MIN='2.0' MAX='6.0'>6.0</PRINT-RATE>
+        <VOID-PRINT-RATE MIN='2' MAX='6'>6</VOID-PRINT-RATE>
+        <SLEW-RATE MIN='2.0' MAX='6.0'>6.0</SLEW-RATE>
+        <BACKFEED-RATE MIN='2.0' MAX='6.0'>6.0</BACKFEED-RATE>
+        <HEAD-TEST-INFO>
+            <MANUAL-RANGE BOOL='Y,N'>N</MANUAL-RANGE>
+            <FIRST-ELEMENT MIN='0' MAX='9999'>0</FIRST-ELEMENT>
+            <LAST-ELEMENT MIN='0' MAX='9999'>9999</LAST-ELEMENT>
+        </HEAD-TEST-INFO>
+        <DEFAULT-FONT>
+            <FONT-LETTER MIN='0' MAX='255'>65</FONT-LETTER>
+            <HEIGHT MIN='1' MAX='9999'>9</HEIGHT>
+            <WIDTH MIN='1' MAX='9999'>5</WIDTH>
+        </DEFAULT-FONT>
+        <DEFAULT-BARCODE>
+            <RATIO MIN='2.0' MAX='3.0'>3.0</RATIO>
+            <MODULE-WIDTH MIN='1' MAX='10'>2</MODULE-WIDTH>
+            <HEIGHT MIN='1' MAX='9999'>10</HEIGHT>
+        </DEFAULT-BARCODE>
+    </FORMAT-SETTINGS>
+    <STATUS>
+        <TOTAL-LABELS-IN-BATCH>0</TOTAL-LABELS-IN-BATCH>
+        <LABELS-REMAINING-IN-BATCH>0</LABELS-REMAINING-IN-BATCH>
+        <PRINTHEAD-TEMP>
+            <OVERTEMP-THRESHOLD>75</OVERTEMP-THRESHOLD>
+            <UNDERTEMP-THRESHOLD>5</UNDERTEMP-THRESHOLD>
+            <CURRENT>22</CURRENT>
+        </PRINTHEAD-TEMP>
+        <HEAD-ELEMENT-STATUS>
+            <FAILED BOOL='Y,N'>N</FAILED>
+        </HEAD-ELEMENT-STATUS>
+        <HEAD-OPEN BOOL='Y,N'>N</HEAD-OPEN>
+        <CONFIG-LOST-ERROR BOOL='Y,N'>N</CONFIG-LOST-ERROR>
+        <RAM-ALLOCATION-ERROR BOOL='Y,N'>N</RAM-ALLOCATION-ERROR>
+        <BITMAP-ALLOCATION-ERROR BOOL='Y,N'>N</BITMAP-ALLOCATION-ERROR>
+        <STORED-FORMAT-ERROR BOOL='Y,N'>N</STORED-FORMAT-ERROR>
+        <STORED-GRAPHIC-ERROR BOOL='Y,N'>N</STORED-GRAPHIC-ERROR>
+        <STORED-BITMAP-ERROR BOOL='Y,N'>N</STORED-BITMAP-ERROR>
+        <STORED-FONT-ERROR BOOL='Y,N'>N</STORED-FONT-ERROR>
+        <CACHE-MEMORY-ERROR BOOL='Y,N'>N</CACHE-MEMORY-ERROR>
+        <BASIC-FORCED-ERROR BOOL='Y,N'>N</BASIC-FORCED-ERROR>
+        <HEAD-UNDERTEMP-WARNING BOOL='Y,N'>N</HEAD-UNDERTEMP-WARNING>
+        <HEAD-OVERTEMP-ERROR BOOL='Y,N'>N</HEAD-OVERTEMP-ERROR>
+        <RIBBON-IN-WARNING BOOL='Y,N'>N</RIBBON-IN-WARNING>
+        <BUFFER-FULL-ERROR BOOL='Y,N'>N</BUFFER-FULL-ERROR>
+        <CLEAN-PRINTHEAD-WARNING BOOL='Y,N'>N</CLEAN-PRINTHEAD-WARNING>
+        <CUTTER-JAM-ERROR BOOL='Y,N'>N</CUTTER-JAM-ERROR>
+        <COVER-OPEN BOOL='Y,N'>N</COVER-OPEN>
+        <RIBBON-TENSION-ERROR BOOL='Y,N'>N</RIBBON-TENSION-ERROR>
+        <VERIFIER-ERROR BOOL='Y,N'>N</VERIFIER-ERROR>
+        <RIBBON-LOW-WARNING BOOL='Y,N'>N</RIBBON-LOW-WARNING>
+        <MEDIA-LOW-WARNING BOOL='Y,N'>N</MEDIA-LOW-WARNING>
+        <NUMBER-OF-FORMATS>1</NUMBER-OF-FORMATS>
+        <PARTIAL-FORMAT-IN-PROGRESS BOOL='Y,N'>N</PARTIAL-FORMAT-IN-PROGRESS>
+        <PAUSE BOOL='Y,N'>N</PAUSE>
+        <PAPER-OUT BOOL='Y,N'>N</PAPER-OUT>
+        <RIBBON-OUT BOOL='Y,N'>N</RIBBON-OUT>
+        <PRINTER-COUNTER>
+            <COUNTER1>
+                <INCHES>12480</INCHES>
+                <CENTIMETERS>31699</CENTIMETERS>
+                <LABELS>7308</LABELS>
+            </COUNTER1>
+            <COUNTER2>
+                <INCHES>12480</INCHES>
+                <CENTIMETERS>31699</CENTIMETERS>
+                <LABELS>7308</LABELS>
+            </COUNTER2>
+            <NON-RESET-COUNTER>
+                <INCHES>12492</INCHES>
+                <CENTIMETERS>31699</CENTIMETERS>
+                <LABELS>7308</LABELS>
+            </NON-RESET-COUNTER>
+        </PRINTER-COUNTER>
+        <MEDIA-REPLACED>0</MEDIA-REPLACED>
+        <RIBBON-REPLACED>0</RIBBON-REPLACED>
+        <HEAD-CLEANED>12480</HEAD-CLEANED>
+        <CLOCK>
+            <DATE>
+                20241210</DATE>
+            <TIME>
+                09:18:05</TIME>
+        </CLOCK>
+        <SENSOR-SELECT>TRANSMISSIVE</SENSOR-SELECT>
+    </STATUS>
+    <OBJECT-LIST>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='TTF' FORMAT='ZPL' SIZE='125904' PROTECTED='Y'>0</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='6839' PROTECTED='Y'>A</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='NRD' FORMAT='ZPL' SIZE='5178' PROTECTED='Y'>ALERTCFG</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>AZTEC</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='7746' PROTECTED='Y'>B</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='478' PROTECTED='Y'>BATTERY52</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='3730' PROTECTED='Y'>BATTERYCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='230454' PROTECTED='Y'>BLUEBCK</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='230454' PROTECTED='Y'>BLUEBCKDARK</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='480' PROTECTED='Y'>BLUETOOTH52</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='9367' PROTECTED='Y'>
+            BLUETOOTHCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='PCX' FORMAT='ZPL' SIZE='884' PROTECTED='Y'>BTSYMBOL</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>CODABAR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>CODABLK</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>CODE11</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>CODE128</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>CODE39</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>CODE49</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>CODE93</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='10648' PROTECTED='Y'>D</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='3183' PROTECTED='Y'>DISPLYQRCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='166' PROTECTED='Y'>
+            DOWN_ARROW_COLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='15691' PROTECTED='Y'>E12</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='47056' PROTECTED='Y'>E24</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='8520' PROTECTED='Y'>E6</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='10893' PROTECTED='Y'>E8</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>EAN-13</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>EAN-8</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='ZPL' FORMAT='ZPL' SIZE='3830' PROTECTED='Y'>ELEMENTOUT</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='17718' PROTECTED='Y'>EPL1</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='20918' PROTECTED='Y'>EPL2</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='24118' PROTECTED='Y'>EPL3</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='24118' PROTECTED='Y'>EPL300-1</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='30518' PROTECTED='Y'>EPL300-2</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='51318' PROTECTED='Y'>EPL300-3</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='72686' PROTECTED='Y'>EPL300-4</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='107958' PROTECTED='Y'>EPL300-5</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='32870' PROTECTED='Y'>EPL4</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='58038' PROTECTED='Y'>EPL5</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='8498' PROTECTED='Y'>EPL6</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='8928' PROTECTED='Y'>EPL7</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='13275' PROTECTED='Y'>F</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='ZPL' FORMAT='ZPL' SIZE='10420' PROTECTED='Y'>
+            FIRSTDOTLOCATION</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='49663' PROTECTED='Y'>G</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='5470' PROTECTED='Y'>GS</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='11536' PROTECTED='Y'>H12</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='30436' PROTECTED='Y'>H24</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='7247' PROTECTED='Y'>H6</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='7825' PROTECTED='Y'>H8</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='3900' PROTECTED='Y'>HOMEMENUCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>I2OF5</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>IDMATRIX</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='ZPL' FORMAT='ZPL' SIZE='9524' PROTECTED='Y'>
+            IMAGECOMPRESSION</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>IND2OF5</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='5331' PROTECTED='Y'>INDEXCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='400' PROTECTED='Y'>LANGUAGE</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='480' PROTECTED='Y'>LANGUAGE52</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='14652' PROTECTED='Y'>
+            LANGUAGECOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='10820' PROTECTED='Y'>LMU</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='11640' PROTECTED='Y'>LMV</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='11640' PROTECTED='Y'>LMW</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='11640' PROTECTED='Y'>LMX</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='23480' PROTECTED='Y'>LMY</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='14340' PROTECTED='Y'>LMZ</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>LOGMARS</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='PNG' FORMAT='ZPL' SIZE='20154' PROTECTED='Y'>LOGO</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>MAXICODE</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='TXT' FORMAT='ZPL' SIZE='45500' PROTECTED='Y'>MIB200</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>MICROPDF</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='5570' PROTECTED='Y'>MONOBD15</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>MSICODE</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='400' PROTECTED='Y'>NETWORK</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='480' PROTECTED='Y'>NETWORK52</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='37871' PROTECTED='Y'>NETWORKCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='566518' PROTECTED='Y'>NJ26WGL4</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='1081154' PROTECTED='Y'>NK26WGL4</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='2025530' PROTECTED='Y'>NS26WGL4</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='1351834' PROTECTED='Y'>NT26WGL4</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='58' PROTECTED='Y'>ONEDOT</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='116' PROTECTED='Y'>P</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='1304' PROTECTED='Y'>PASSWORD</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='1668' PROTECTED='Y'>PASSWORDCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>PDF417</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>PLANETCD</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>PLESSEY</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='400' PROTECTED='Y'>PORTS</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='480' PROTECTED='Y'>PORTS52</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='8371' PROTECTED='Y'>PORTSCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>POSTNET</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='116' PROTECTED='Y'>Q</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='3855' PROTECTED='Y'>QCKCNTDOCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='2704' PROTECTED='Y'>QCKCNTMKCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='230454' PROTECTED='Y'>QRBCKCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>QRCODE</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='116' PROTECTED='Y'>R</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='NRD' FORMAT='ZPL' SIZE='357267' PROTECTED='Y'>REGDB</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='NRD' FORMAT='ZPL' SIZE='3' PROTECTED='Y'>REPRINT</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='NRD' FORMAT='ZPL' SIZE='3' PROTECTED='Y'>RESETNET</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>RSS</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='116' PROTECTED='Y'>S</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>S2OF5</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='400' PROTECTED='Y'>SENSORS</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='480' PROTECTED='Y'>SENSORS52</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='12115' PROTECTED='Y'>SENSORSCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='400' PROTECTED='Y'>SETTINGS</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='480' PROTECTED='Y'>SETTINGS52</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='20825' PROTECTED='Y'>
+            SETTINGSCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='128' PROTECTED='Y'>
+            SIGNAL_STRENGTH_0_BAR_ICON</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='128' PROTECTED='Y'>
+            SIGNAL_STRENGTH_1_BAR_ICON</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='128' PROTECTED='Y'>
+            SIGNAL_STRENGTH_2_BAR_ICON</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='128' PROTECTED='Y'>
+            SIGNAL_STRENGTH_3_BAR_ICON</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='128' PROTECTED='Y'>
+            SIGNAL_STRENGTH_4_BAR_ICON</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='310' PROTECTED='Y'>
+            SPACE10COLORLONG</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='222' PROTECTED='Y'>SPACE20COLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='222' PROTECTED='Y'>SPACE23COLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='116' PROTECTED='Y'>T</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>TLC39</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='8168' PROTECTED='Y'>TOOLS-COLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='400' PROTECTED='Y'>TOOLS</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='480' PROTECTED='Y'>TOOLS52</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='WML' FORMAT='ZPL' SIZE='60088' PROTECTED='Y'>TOOLSCOLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='116' PROTECTED='Y'>U</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='SS' FORMAT='ZPL' SIZE='11596' PROTECTED='Y'>UIF</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>UPC-A</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>UPC-E</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BAR' FORMAT='ZPL' SIZE='0' PROTECTED='Y'>UPC-EAN</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='BMP' FORMAT='ZPL' SIZE='166' PROTECTED='Y'>UP_ARROW_COLOR</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='NRD' FORMAT='ZPL' SIZE='7' PROTECTED='Y'>USBCNFIG</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='SS' FORMAT='ZPL' SIZE='11588' PROTECTED='Y'>UTT</OBJECT>
+        <OBJECT MEMORY-LOCATION='Z:' TYPE='FNT' FORMAT='ZPL' SIZE='116' PROTECTED='Y'>V</OBJECT>
+        <OBJECT MEMORY-LOCATION='E:' TYPE='TTF' FORMAT='ZPL' SIZE='169188' PROTECTED='N'>TT0003M_</OBJECT>
+    </OBJECT-LIST>
+</ZEBRA-ELTRON-PERSONALITY>

--- a/src/Languages/Zpl/test_files/index.test.ts
+++ b/src/Languages/Zpl/test_files/index.test.ts
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import { expect, describe, it } from 'vitest';
+
+describe('Files exist', () => {
+  it('Files exist', () => {
+    expect(ZD410_XML()).not.toBeUndefined();
+  })
+})
+
+export const ZD410_XML = () => {
+  return fs.readFileSync('./src/Languages/Zpl/test_files/ZD410.xml', { encoding: 'utf-8'});
+}
+export const ZD410_FULL_SNAPSHOT = "./test_files/ZD410.ts.snap"

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -28,7 +28,7 @@ function promiseWithTimeout<T>(
   return Promise.race<T>([promise, timeout]);
 }
 
-/** Type alias for a Label Printer the communicates over USB. */
+/** Type alias for a Label Printer that communicates over USB. */
 export type LabelPrinterUsb = LabelPrinter<Uint8Array>;
 
 /** A class for working with a label printer. */
@@ -103,7 +103,12 @@ export class LabelPrinter<TChannelType extends Conf.MessageArrayLike> extends Ev
     deviceCommunicationOptions: Mux.IDeviceCommunicationOptions = { debug: false },
     printerOptions?: Cmds.PrinterConfig,
   ) {
-    const p = new LabelPrinter(channel, channelMessageTransformer, channelType, deviceCommunicationOptions, printerOptions);
+    const p = new LabelPrinter(
+      channel,
+      channelMessageTransformer,
+      channelType,
+      deviceCommunicationOptions,
+      printerOptions);
     await p.setup();
     return p;
   }
@@ -331,7 +336,7 @@ export class LabelPrinter<TChannelType extends Conf.MessageArrayLike> extends Ev
     this.logResultIfDebug(() => {
       const debugMsg = Cmds.asString(transaction.commands);
       return `Transaction being sent to printer:\n${debugMsg}\n--end of transaction--`;
-    })
+    });
 
     // TODO: Better type guards??
     let sendCmds: TChannelType;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,10 +16,19 @@ export default defineConfig({
   define: {
     'import.meta.vitest': 'undefined',
   },
-  plugins: [dts(), eslint({
-    failOnError: false
-  })],
+  plugins: [
+    dts({
+      exclude: [
+        '**/node_modules',
+        '**/*.test.ts'
+      ]
+    }),
+    eslint({
+      failOnError: false
+    })
+  ],
   test: {
+    environment: 'happy-dom',
     includeSource: ['src/**/*.{js,ts}'],
     coverage: {
       enabled: true,


### PR DESCRIPTION
This PR mostly rejiggers the backfeed setting to actually set properly. Previously it only was meant to work for ZPL's 'suppress backfeed once' on a per-label basis.

This also expands the settings page to be more flexible for additional settings in the near future.