### PR TITLE
Improved message handling, better command handler layout

### DIFF
--- a/demo/advanced.html
+++ b/demo/advanced.html
@@ -186,22 +186,29 @@
               // Printers themselves also have events, let's show an alert on errors.
               const printer = detail.device;
               printer.addEventListener('reportedError', ({ detail: msg }) => {
-                // Error messages may indicate no error, we can ignore those.
-                if (msg.errors.has(WebLabel.ErrorState.NoError)) { return; }
+                const alertId = `alert-printererror-${printer.printerSerial}`;
+                // Hide any existing alerts for this printer
+                const existingAlerts = document.getElementById('printerAlertSpace')?.querySelectorAll(`.${alertId}`) ?? [];
+                existingAlerts.forEach((a: Element) => bootstrap.Alert.getInstance(a)?.close());
+
+                // Error messages are also status messages, such as indicating no problem.
+                if (msg.errors.size === 0 || msg.errors.has(WebLabel.ErrorState.NoError)) { return; }
 
                 const alertWrapper = document.createElement('div');
+                alertWrapper.classList.add("alert", "alert-warning", "alert-dismissible", "fade", "show", alertId);
+                alertWrapper.id = alertId;
+                alertWrapper.role = "alert";
                 alertWrapper.innerHTML = `
-                  <div class="alert alert-warning alert-dismissible fade show alert-printererror" role="alert">
-                      <h4>Printer <strong>${printer.printerSerial}</strong> has an error</h4>
-                      <p>${JSON.stringify(msg, null, 2)}</p>
-                      <hr>
-                      <p>Fix the issue, then dismiss this alert to check the status again.</p>
-                      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                  </div>`
+                  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                  <h4>Printer <strong>${printer.printerSerial}</strong> has an error</h4>
+                  <p><ul>${Array.from(msg.errors).map(e => `<li>${e}`)}</ul></p>
+                  <hr>
+                  <p>Fix the issue, then dismiss this alert to check the status again.</p>`;
                 document.getElementById('printerAlertSpace')?.appendChild(alertWrapper);
+                new bootstrap.Alert(alertWrapper);
 
                 // and even go one layer deeper!
-                alertWrapper.firstElementChild!.addEventListener('closed.bs.alert', () => {
+                alertWrapper.addEventListener('closed.bs.alert', () => {
                   printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
                 });
               });

--- a/demo/test_advanced.ts
+++ b/demo/test_advanced.ts
@@ -121,22 +121,29 @@ class BasicLabelDesignerApp {
       // Printers themselves also have events, let's show an alert on errors.
       const printer = detail.device;
       printer.addEventListener('reportedError', ({ detail: msg }) => {
-        // Error messages may indicate no error, we can ignore those.
-        if (msg.errors.has(WebLabel.ErrorState.NoError)) { return; }
+        const alertId = `alert-printererror-${printer.printerSerial}`;
+        // Hide any existing alerts for this printer
+        const existingAlerts = document.getElementById('printerAlertSpace')?.querySelectorAll(`.${alertId}`) ?? [];
+        existingAlerts.forEach((a: Element) => bootstrap.Alert.getInstance(a)?.close());
+
+        // Error messages are also status messages, such as indicating no problem.
+        if (msg.errors.size === 0 || msg.errors.has(WebLabel.ErrorState.NoError)) { return; }
 
         const alertWrapper = document.createElement('div');
+        alertWrapper.classList.add("alert", "alert-warning", "alert-dismissible", "fade", "show", alertId);
+        alertWrapper.id = alertId;
+        alertWrapper.role = "alert";
         alertWrapper.innerHTML = `
-          <div class="alert alert-warning alert-dismissible fade show alert-printererror" role="alert">
-              <h4>Printer <strong>${printer.printerSerial}</strong> has an error</h4>
-              <p>${JSON.stringify(msg, null, 2)}</p>
-              <hr>
-              <p>Fix the issue, then dismiss this alert to check the status again.</p>
-              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-          </div>`
+          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+          <h4>Printer <strong>${printer.printerSerial}</strong> has an error</h4>
+          <p><ul>${Array.from(msg.errors).map(e => `<li>${e}`)}</ul></p>
+          <hr>
+          <p>Fix the issue, then dismiss this alert to check the status again.</p>`;
         document.getElementById('printerAlertSpace')?.appendChild(alertWrapper);
+        new bootstrap.Alert(alertWrapper);
 
         // and even go one layer deeper!
-        alertWrapper.firstElementChild!.addEventListener('closed.bs.alert', () => {
+        alertWrapper.addEventListener('closed.bs.alert', () => {
           printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
         });
       });

--- a/src/Commands/BasicCommands.ts
+++ b/src/Commands/BasicCommands.ts
@@ -1,0 +1,339 @@
+import * as Util from '../Util/index.js';
+import * as Conf from '../Configs/index.js';
+import { BasicCommand, CommandEffectFlags, NoEffect, type CommandTypeBasic, type IPrinterBasicCommand } from './Commands.js';
+
+export class StartLabel extends BasicCommand {
+  name = 'Explicitly start a new label.';
+  type = 'StartLabel' as const;
+  constructor() { super([]); }
+}
+
+export class EndLabel extends BasicCommand {
+  name = 'Explicitly end a label.';
+  type: CommandTypeBasic = 'EndLabel';
+  constructor() { super([]); }
+}
+
+export class PrintCommand implements IPrinterBasicCommand {
+  name = 'Print label';
+  type: CommandTypeBasic = 'Print';
+  toDisplay(): string {
+    return `Print ${this.labelCount} copies of label`;
+  }
+
+  constructor(
+    public readonly labelCount = 1,
+    public readonly additionalDuplicateOfEach = 1
+  ) {
+    // TODO: If someone complains that this is lower than what ZPL allows
+    // figure out a way to support the 99,999,999 supported.
+    // Who needs to print > 65 thousand labels at once??? I want to know.
+    this.labelCount = Util.clampToRange(labelCount, 0, 65534);
+    this.additionalDuplicateOfEach = Util.clampToRange(additionalDuplicateOfEach, 0, 65534);
+  }
+
+  effectFlags = new CommandEffectFlags(['feedsPaper']);
+}
+
+export class NoOp extends BasicCommand {
+  name = 'No operation placeholder';
+  type: CommandTypeBasic = 'NoOp';
+  constructor() { super(); }
+}
+
+export class GetStatusCommand extends BasicCommand {
+  name = 'Get the immediate printer status';
+  type: CommandTypeBasic = 'GetStatus';
+  constructor() { super(['waitsForResponse']); }
+}
+
+export class CutNowCommand extends BasicCommand {
+  name = 'Cycle the media cutter now';
+  type: CommandTypeBasic = 'CutNow';
+  constructor() { super(['actuatesCutter']); }
+}
+
+/** A command to clear the image buffer. */
+export class ClearImageBufferCommand extends BasicCommand {
+  name = 'Clear image buffer';
+  type: CommandTypeBasic = 'ClearImageBuffer';
+  constructor() { super([]); }
+}
+
+/** A command to have the printer send its configuration back over serial. */
+export class QueryConfigurationCommand extends BasicCommand {
+  name = 'Query for printer config';
+  type: CommandTypeBasic = 'QueryConfiguration';
+  constructor() { super(['waitsForResponse']); }
+}
+
+/** A command to have the printer print its configuration labels. */
+export class PrintConfigurationCommand extends BasicCommand {
+  get name() { return "Print printer's config onto labels"; }
+  type: CommandTypeBasic = 'PrintConfiguration';
+  constructor() { super([]); }
+}
+
+/** A command to store the current configuration as the stored configuration. */
+export class SaveCurrentConfigurationCommand extends BasicCommand {
+  name = 'Store the current configuration as the saved configuration.';
+  type: CommandTypeBasic = 'SaveCurrentConfiguration';
+  constructor() { super([]); }
+}
+
+/** A command to set the darkness the printer prints at. */
+export class SetDarknessCommand implements IPrinterBasicCommand {
+  name = 'Set darkness';
+  type: CommandTypeBasic = 'SetDarkness';
+  toDisplay(): string {
+    return `Set darkness to ${this.darknessPercent}%`;
+  }
+
+  constructor(
+    public readonly darknessPercent: Conf.DarknessPercent
+  ) {}
+
+  effectFlags = new CommandEffectFlags(['altersConfig']);
+}
+
+export class SetBackfeedAfterTakenMode implements IPrinterBasicCommand {
+  name = 'Set backfeed mode after label is taken';
+  type: CommandTypeBasic = 'SetBackfeedAfterTaken';
+  toDisplay(): string {
+    if (this.mode === 'disabled') {
+      return 'Disable backfeed';
+    } else {
+      return `Set backfeed to ${this.mode}% after label cut/taken.`;
+    }
+  }
+  effectFlags = new CommandEffectFlags(['altersConfig']);
+
+  constructor(public readonly mode: Conf.BackfeedAfterTaken) { }
+}
+
+/** A command to set the direction a label prints, either upside down or not. */
+export class SetPrintDirectionCommand implements IPrinterBasicCommand {
+  name = 'Set print direction';
+  type: CommandTypeBasic = 'SetPrintDirection';
+  toDisplay(): string {
+    return `Print labels ${this.upsideDown ? 'upside-down' : 'right-side up'}`;
+  }
+  effectFlags = new CommandEffectFlags(['altersConfig']);
+
+  constructor(public readonly upsideDown: boolean) { }
+}
+
+/** A command to set the print speed a printer prints at. Support varies per printer. */
+export class SetPrintSpeedCommand implements IPrinterBasicCommand {
+  name = 'Set print speed';
+  type: CommandTypeBasic = 'SetPrintSpeed';
+  toDisplay(): string {
+    return `Set print speed to ${Conf.PrintSpeed[this.speed]} (inches per second).`;
+  }
+  effectFlags = new CommandEffectFlags(['altersConfig']);
+
+  constructor(
+    public readonly speed: Conf.PrintSpeed,
+    public readonly mediaSlewSpeed: Conf.PrintSpeed,
+  ) { }
+}
+
+/** A command to set the label dimensions of this label. */
+export class SetLabelDimensionsCommand implements IPrinterBasicCommand {
+  name = 'Set label dimensions';
+  type: CommandTypeBasic = 'SetLabelDimensions';
+  toDisplay(): string {
+    let str = `Set label size to ${this.widthInDots} wide`;
+    if (this.lengthInDots) {
+      str += ` x ${this.lengthInDots} high`;
+    }
+    if (this.gapLengthInDots) {
+      str += ` with a gap length of ${this.gapLengthInDots}`;
+    }
+    str += ' (in dots).';
+    return str;
+  }
+
+  get setsLength() {
+    return this.lengthInDots !== undefined && this.gapLengthInDots !== undefined;
+  }
+
+  // TODO: Black line mode for EPL?
+  constructor(
+    public readonly widthInDots: number,
+    public readonly lengthInDots?: number,
+    public readonly gapLengthInDots?: number) { }
+
+  effectFlags = new CommandEffectFlags(['altersConfig']);
+}
+
+export class SetLabelHomeCommand implements IPrinterBasicCommand {
+  name = 'Sets the label home (origin) offset';
+  type: CommandTypeBasic = 'SetLabelHome';
+  toDisplay(): string {
+    return `Set the label home (origin) to ${this.offset.left},${this.offset.top} from the top-left.`;
+  }
+  effectFlags = new CommandEffectFlags(['altersConfig']);
+
+  constructor(public offset: Conf.Coordinate) { }
+}
+
+/** Command class to set the print offset from the top-left of the label. */
+export class SetLabelPrintOriginOffsetCommand implements IPrinterBasicCommand {
+  name = 'Sets the print offset from the top left corner.';
+  type: CommandTypeBasic = 'SetLabelPrintOriginOffset';
+  toDisplay(): string {
+    return `Sets the print offset to ${this.offset.left} in and ${this.offset.top} down from the top-left.`;
+  }
+  effectFlags = new CommandEffectFlags(['altersConfig']);
+
+  constructor(public offset: Conf.Coordinate) { }
+}
+
+/** A command to set the media tracking type to continuous media. */
+export class SetMediaToContinuousMediaCommand implements IPrinterBasicCommand {
+  name = 'Sets the media tracking type to continuous media.';
+  type: CommandTypeBasic = 'SetMediaToContinuousMedia';
+  toDisplay(): string { return this.name; }
+  effectFlags = new CommandEffectFlags(['altersConfig']);
+
+  constructor(
+    public mediaLengthInDots: number,
+    public formGapInDots: number
+  ) { }
+}
+
+/** A command to set the media tracking type to web gap detection. */
+export class SetMediaToWebGapMediaCommand implements IPrinterBasicCommand {
+  name = 'Sets the media tracking type to web gap detection.';
+  type: CommandTypeBasic = 'SetMediaToWebGapMedia';
+  toDisplay(): string { return this.name; }
+  effectFlags = new CommandEffectFlags(['altersConfig']);
+
+  constructor(
+    public mediaLengthInDots: number,
+    public mediaGapInDots: number,
+    public mediaGapOffsetInDots: number = 0,
+  ) { }
+}
+
+/** A command to set the media tracking type to black mark detection. */
+export class SetMediaToMarkMediaCommand implements IPrinterBasicCommand {
+  name = 'Sets the media tracking type to black mark detection.';
+  type: CommandTypeBasic = 'SetMediaToMarkMedia';
+  toDisplay(): string { return this.name; }
+  effectFlags = new CommandEffectFlags(['altersConfig']);
+
+  constructor(
+    public mediaLengthInDots: number,
+    public blackLineThicknessInDots: number,
+    public blackLineOffset: number = 0
+  ) { }
+}
+
+/** Command to cause the printer to auto-sense the media length. */
+export class AutosenseMediaDimensionsCommand extends BasicCommand {
+  get name() { return 'Auto-sense the media length by feeding several labels.'; }
+  type: CommandTypeBasic = 'AutosenseMediaDimensions';
+  constructor() { super (['altersConfig', 'feedsPaperIgnoringPeeler', 'feedsPaper'])}
+  override toDisplay(): string { return this.name; }
+}
+
+/** Command class to modify an offset. */
+export class OffsetCommand implements IPrinterBasicCommand {
+  name = 'Modify offset';
+  type: CommandTypeBasic = 'Offset';
+  toDisplay(): string {
+    let str = `Set offset to ${this.horizontal} from the left`;
+    if (this.vertical) {
+      str += ` and ${this.vertical} from the top`;
+    }
+    str += this.absolute ? `of the label.` : ` of the current offset.`;
+    return str;
+  }
+  effectFlags = NoEffect;
+
+  constructor(
+    public readonly horizontal: number,
+    public readonly vertical?: number,
+    public readonly absolute = false
+  ) {
+    this.horizontal = Math.floor(horizontal);
+    this.vertical = vertical !== undefined ? Math.floor(vertical) : undefined;
+    this.absolute = absolute;
+  }
+}
+
+/** Command class to force a printer to reset. */
+export class RebootPrinterCommand extends BasicCommand {
+  get name() { return 'Simulate a power-cycle for the printer. This should be the final command.'; }
+  type: CommandTypeBasic = 'RebootPrinter';
+  constructor() { super(['lossOfConnection']); }
+}
+
+/** Command class to draw an image into the image buffer for immediate print. */
+export class AddImageCommand implements IPrinterBasicCommand {
+  name = 'Add image to label';
+  type: CommandTypeBasic = 'AddImage';
+  toDisplay(): string {
+    return `Adds a ${this.bitmap.width} wide x ${this.bitmap.height} high image.`;
+  }
+  effectFlags = NoEffect;
+
+  constructor(
+    public bitmap: Util.BitmapGRF,
+    public imageConversionOptions: Util.ImageConversionOptions
+  ) { }
+}
+
+/** List of colors to draw elements with */
+export enum DrawColor {
+  /** Draw in black */
+  black,
+  /** Draw in white */
+  white
+}
+
+/** Command class to draw a straight line. */
+export class AddLineCommand implements IPrinterBasicCommand {
+  name = 'Add perpendicular line to label';
+  type: CommandTypeBasic = 'AddLine';
+  toDisplay(): string {
+    return `Add a ${DrawColor[this.color]} line ${this.widthInDots} wide by ${this.heightInDots} high.`;
+  }
+  effectFlags = NoEffect;
+
+  constructor(
+    public readonly widthInDots: number,
+    public readonly heightInDots: number,
+    public readonly color: DrawColor
+  ) { }
+}
+
+/** Command to draw a box on a label */
+export class AddBoxCommand implements IPrinterBasicCommand {
+  name = 'Add a box to label';
+  type: CommandTypeBasic = 'AddBox';
+  toDisplay(): string {
+    return `Add a box ${this.widthInDots} wide by ${this.heightInDots} high.`;
+  }
+  effectFlags = NoEffect;
+
+  constructor(
+    public readonly widthInDots: number,
+    public readonly heightInDots: number,
+    public readonly thickness: number
+  ) { }
+}
+
+/** Sending a raw instruction to the printer. */
+export class Raw implements IPrinterBasicCommand {
+  name = 'Sends a raw set of commands directly to the printer unmodified.';
+  type: CommandTypeBasic = 'Raw';
+  toDisplay(): string { return this.name; }
+
+  constructor(
+    public readonly rawDocument: string,
+    public readonly effectFlags: CommandEffectFlags
+  ) { }
+}

--- a/src/Commands/BasicCommands.ts
+++ b/src/Commands/BasicCommands.ts
@@ -35,6 +35,12 @@ export class PrintCommand implements IPrinterBasicCommand {
   effectFlags = new CommandEffectFlags(['feedsPaper']);
 }
 
+export class IdentifyDeviceCommand extends BasicCommand {
+  name = 'Identify device';
+  type: CommandTypeBasic = 'Identify';
+  constructor() { super(); }
+}
+
 export class NoOp extends BasicCommand {
   name = 'No operation placeholder';
   type: CommandTypeBasic = 'NoOp';

--- a/src/Commands/Commands.ts
+++ b/src/Commands/Commands.ts
@@ -86,9 +86,9 @@ export type CommandType
   | "SetLabelDimensions"
   | "SetLabelHome"
   | "SetLabelPrintOriginOffset"
-  | "SetLabelToContinuousMedia"
-  | "SetLabelToWebGapMedia"
-  | "SetLabelToMarkMedia"
+  | "SetMediaToContinuousMedia"
+  | "SetMediaToWebGapMedia"
+  | "SetMediaToMarkMedia"
   | "SetPrintDirection"
   | "SetPrintSpeed"
   | "SetBackfeedAfterTaken"
@@ -303,43 +303,44 @@ export class SetLabelPrintOriginOffsetCommand implements IPrinterCommand {
   constructor(public offset: Conf.Coordinate) { }
 }
 
-/** A command class to set the media handling mode to continuous media. */
-export class SetLabelToContinuousMediaCommand implements IPrinterCommand {
-  name = 'Sets the media handling mode to continuous media.';
-  type: CommandType = 'SetLabelToContinuousMedia';
-  toDisplay(): string {
-    return this.name;
-  }
-  effectFlags = new CommandEffectFlags(['altersConfig']);
-
-  constructor(public labelLengthInDots: number, public labelGapInDots = 0) { }
-}
-
-/** A command class to set the media handling mode to web gap detection. */
-export class SetLabelToWebGapMediaCommand implements IPrinterCommand {
-  name = 'Sets the media handling mode to web gap detection.';
-  type: CommandType = 'SetLabelToWebGapMedia';
-  toDisplay(): string {
-    return this.name;
-  }
-  effectFlags = new CommandEffectFlags(['altersConfig']);
-
-  constructor(public labelLengthInDots: number, public labelGapInDots: number) { }
-}
-
-/** A command class to set the media handling mode to black mark detection. */
-export class SetLabelToMarkMediaCommand implements IPrinterCommand {
-  name = 'Sets the media handling mode to black mark detection.';
-  type: CommandType = 'SetLabelToMarkMedia';
-  toDisplay(): string {
-    return this.name;
-  }
+/** A command to set the media tracking type to continuous media. */
+export class SetMediaToContinuousMediaCommand implements IPrinterCommand {
+  name = 'Sets the media tracking type to continuous media.';
+  type: CommandType = 'SetMediaToContinuousMedia';
+  toDisplay(): string { return this.name; }
   effectFlags = new CommandEffectFlags(['altersConfig']);
 
   constructor(
-    public labelLengthInDots: number,
+    public mediaLengthInDots: number,
+    public formGapInDots: number
+  ) { }
+}
+
+/** A command to set the media tracking type to web gap detection. */
+export class SetMediaToWebGapMediaCommand implements IPrinterCommand {
+  name = 'Sets the media tracking type to web gap detection.';
+  type: CommandType = 'SetMediaToWebGapMedia';
+  toDisplay(): string { return this.name; }
+  effectFlags = new CommandEffectFlags(['altersConfig']);
+
+  constructor(
+    public mediaLengthInDots: number,
+    public mediaGapInDots: number,
+    public mediaGapOffsetInDots: number = 0,
+  ) { }
+}
+
+/** A command to set the media tracking type to black mark detection. */
+export class SetMediaToMarkMediaCommand implements IPrinterCommand {
+  name = 'Sets the media tracking type to black mark detection.';
+  type: CommandType = 'SetMediaToMarkMedia';
+  toDisplay(): string { return this.name; }
+  effectFlags = new CommandEffectFlags(['altersConfig']);
+
+  constructor(
+    public mediaLengthInDots: number,
     public blackLineThicknessInDots: number,
-    public blackLineOffset: number
+    public blackLineOffset: number = 0
   ) { }
 }
 

--- a/src/Commands/Commands.ts
+++ b/src/Commands/Commands.ts
@@ -1,4 +1,3 @@
-import * as Util from '../Util/index.js';
 import * as Conf from '../Configs/index.js';
 
 export type PrinterCommandEffectTypes
@@ -22,33 +21,32 @@ export const NoEffect = new CommandEffectFlags();
 export const AwaitsEffect = new CommandEffectFlags(['waitsForResponse']);
 
 /** A command that can be sent to a printer. */
-export interface IPrinterCommand {
+export type IPrinterCommand = IPrinterCommandBase & (IPrinterBasicCommand | IPrinterExtendedCommand)
+
+interface IPrinterCommandBase {
   /** Get the display name of this command. */
   readonly name: string;
-  /** Get the command type of this command. */
-  readonly type: CommandType;
   /** Any effects this command may cause the printer to undergo. */
   readonly effectFlags: CommandEffectFlags;
-
   /** Get the human-readable output of this command. */
   toDisplay(): string;
 }
 
-/** A custom command beyond the standard command set, with command-language-specific behavior. */
-export interface IPrinterExtendedCommand extends IPrinterCommand {
-  /** The unique identifier for this command. */
-  get typeExtended(): symbol;
-
-  /** Gets the command languages this extended command can apply to. */
-  get commandLanguageApplicability(): Conf.PrinterCommandLanguage;
+export type CommandTypeBasic = Exclude<CommandType, 'CustomCommand'>;
+/** A basic printer command, common to all printer languages. */
+export interface IPrinterBasicCommand extends IPrinterCommandBase {
+  /** Get the command type of this command. */
+  readonly type: CommandTypeBasic;
 }
 
-/** List of colors to draw elements with */
-export enum DrawColor {
-  /** Draw in black */
-  black,
-  /** Draw in white */
-  white
+/** A custom command beyond the standard command set, with language-specific behavior. */
+export interface IPrinterExtendedCommand extends IPrinterCommandBase {
+  /** Get the command type of this command. */
+  readonly type: Extract<CommandType, 'CustomCommand'>;
+  /** The unique identifier for this command. */
+  readonly typeExtended: symbol;
+  /** Gets the command languages this extended command can apply to. */
+  readonly commandLanguageApplicability: Conf.PrinterCommandLanguage;
 }
 
 /** Behavior to take for commands that belong inside or outside of a form. */
@@ -66,379 +64,63 @@ export enum CommandReorderBehavior {
   throwError,
 }
 
-/** Union type of all possible commands that must be handled by command sets. */
-export type CommandType
+export const basicCommandTypes = [
   // Users/PCLs may supply printer commands. This uses a different lookup table.
-  = "CustomCommand"
+  "CustomCommand",
   // General printer commands
-  | "Identify"
-  | "RebootPrinter"
-  | "Raw"
-  | "NoOp"
+  "Identify",
+  "RebootPrinter",
+  "Raw",
+  "NoOp",
   // Status commands
-  | "GetStatus"
-  | "PrintConfiguration"
-  | "QueryConfiguration"
+  "GetStatus",
+  "PrintConfiguration",
+  "QueryConfiguration",
   // Configuration commands
-  | "SaveCurrentConfiguration"
-  | "AutosenseMediaDimensions"
-  | "SetDarkness"
-  | "SetLabelDimensions"
-  | "SetLabelHome"
-  | "SetLabelPrintOriginOffset"
-  | "SetMediaToContinuousMedia"
-  | "SetMediaToWebGapMedia"
-  | "SetMediaToMarkMedia"
-  | "SetPrintDirection"
-  | "SetPrintSpeed"
-  | "SetBackfeedAfterTaken"
+  "SaveCurrentConfiguration",
+  "AutosenseMediaDimensions",
+  "SetDarkness",
+  "SetLabelDimensions",
+  "SetLabelHome",
+  "SetLabelPrintOriginOffset",
+  "SetMediaToContinuousMedia",
+  "SetMediaToWebGapMedia",
+  "SetMediaToMarkMedia",
+  "SetPrintDirection",
+  "SetPrintSpeed",
+  "SetBackfeedAfterTaken",
   // Document handling
-  | "NewLabel"
-  | "StartLabel"
-  | "EndLabel"
-  | "CutNow"
-  | "Print"
+  "NewLabel",
+  "StartLabel",
+  "EndLabel",
+  "CutNow",
+  "Print",
   // Content
-  | "ClearImageBuffer"
-  | "AddBox"
-  | "AddImage"
-  | "AddLine"
-  | "Offset"
+  "ClearImageBuffer",
+  "AddBox",
+  "AddImage",
+  "AddLine",
+  "Offset",
+] as const;
+/** Union type of all possible commands that must be handled by command sets. */
+export type CommandType = typeof basicCommandTypes[number];
 
-abstract class BasicCommand implements IPrinterCommand {
+/**A regular command or an extended command type. */
+export type CommandAnyType = CommandType | symbol;
+export function getCommandAnyType(cmd: IPrinterCommand | IPrinterExtendedCommand): CommandAnyType {
+  if (cmd.type === 'CustomCommand') {
+    return cmd.typeExtended;
+  } else {
+    return cmd.type;
+  }
+}
+
+export abstract class BasicCommand implements IPrinterBasicCommand {
   abstract name: string;
-  abstract type: CommandType;
+  abstract type: CommandTypeBasic;
   effectFlags: CommandEffectFlags;
   toDisplay() { return this.name; }
   constructor(effects: PrinterCommandEffectTypes[] = []) {
     this.effectFlags = new CommandEffectFlags(effects);
   }
-}
-
-export class StartLabel extends BasicCommand {
-  name = 'Explicitly start a new label.';
-  type: CommandType = 'StartLabel';
-  constructor() { super([]); }
-}
-
-export class EndLabel extends BasicCommand {
-  name = 'Explicitly end a label.';
-  type: CommandType = 'EndLabel';
-  constructor() { super([]); }
-}
-
-export class PrintCommand implements IPrinterCommand {
-  name = 'Print label';
-  type: CommandType = 'Print';
-  toDisplay(): string {
-    return `Print ${this.labelCount} copies of label`;
-  }
-
-  constructor(
-    public readonly labelCount = 1,
-    public readonly additionalDuplicateOfEach = 1
-  ) {
-    // TODO: If someone complains that this is lower than what ZPL allows
-    // figure out a way to support the 99,999,999 supported.
-    // Who needs to print > 65 thousand labels at once??? I want to know.
-    this.labelCount = Util.clampToRange(labelCount, 0, 65534);
-    this.additionalDuplicateOfEach = Util.clampToRange(additionalDuplicateOfEach, 0, 65534);
-  }
-
-  effectFlags = new CommandEffectFlags(['feedsPaper']);
-}
-
-export class NoOp extends BasicCommand {
-  name = 'No operation placeholder';
-  type: CommandType = 'NoOp';
-  constructor() { super(); }
-}
-
-export class GetStatusCommand extends BasicCommand {
-  name = 'Get the immediate printer status';
-  type: CommandType = 'GetStatus';
-  constructor() { super(['waitsForResponse']); }
-}
-
-export class CutNowCommand extends BasicCommand {
-  name = 'Cycle the media cutter now';
-  type: CommandType = 'CutNow';
-  constructor() { super(['actuatesCutter']); }
-}
-
-/** A command to clear the image buffer. */
-export class ClearImageBufferCommand extends BasicCommand {
-  name = 'Clear image buffer';
-  type: CommandType = 'ClearImageBuffer';
-  constructor() { super([]); }
-}
-
-/** A command to have the printer send its configuration back over serial. */
-export class QueryConfigurationCommand extends BasicCommand {
-  name = 'Query for printer config';
-  type: CommandType = 'QueryConfiguration';
-  constructor() { super(['waitsForResponse']); }
-}
-
-/** A command to have the printer print its configuration labels. */
-export class PrintConfigurationCommand extends BasicCommand {
-  get name() { return "Print printer's config onto labels"; }
-  type: CommandType = 'PrintConfiguration';
-  constructor() { super([]); }
-}
-
-/** A command to store the current configuration as the stored configuration. */
-export class SaveCurrentConfigurationCommand extends BasicCommand {
-  name = 'Store the current configuration as the saved configuration.';
-  type: CommandType = 'SaveCurrentConfiguration';
-  constructor() { super([]); }
-}
-
-/** A command to set the darkness the printer prints at. */
-export class SetDarknessCommand implements IPrinterCommand {
-  name = 'Set darkness';
-  type: CommandType = 'SetDarkness';
-  toDisplay(): string {
-    return `Set darkness to ${this.darknessPercent}%`;
-  }
-
-  constructor(
-    public readonly darknessPercent: Conf.DarknessPercent
-  ) {}
-
-  effectFlags = new CommandEffectFlags(['altersConfig']);
-}
-
-export class SetBackfeedAfterTakenMode implements IPrinterCommand {
-  name = 'Set backfeed mode after label is taken';
-  type: CommandType = 'SetBackfeedAfterTaken';
-  toDisplay(): string {
-    if (this.mode === 'disabled') {
-      return 'Disable backfeed';
-    } else {
-      return `Set backfeed to ${this.mode}% after label cut/taken.`;
-    }
-  }
-  effectFlags = new CommandEffectFlags(['altersConfig']);
-
-  constructor(public readonly mode: Conf.BackfeedAfterTaken) { }
-}
-
-/** A command to set the direction a label prints, either upside down or not. */
-export class SetPrintDirectionCommand implements IPrinterCommand {
-  name = 'Set print direction';
-  type: CommandType = 'SetPrintDirection';
-  toDisplay(): string {
-    return `Print labels ${this.upsideDown ? 'upside-down' : 'right-side up'}`;
-  }
-  effectFlags = new CommandEffectFlags(['altersConfig']);
-
-  constructor(public readonly upsideDown: boolean) { }
-}
-
-/** A command to set the print speed a printer prints at. Support varies per printer. */
-export class SetPrintSpeedCommand implements IPrinterCommand {
-  name = 'Set print speed';
-  type: CommandType = 'SetPrintSpeed';
-  toDisplay(): string {
-    return `Set print speed to ${Conf.PrintSpeed[this.speed]} (inches per second).`;
-  }
-  effectFlags = new CommandEffectFlags(['altersConfig']);
-
-  constructor(
-    public readonly speed: Conf.PrintSpeed,
-    public readonly mediaSlewSpeed: Conf.PrintSpeed,
-  ) { }
-}
-
-/** A command to set the label dimensions of this label. */
-export class SetLabelDimensionsCommand implements IPrinterCommand {
-  name = 'Set label dimensions';
-  type: CommandType = 'SetLabelDimensions';
-  toDisplay(): string {
-    let str = `Set label size to ${this.widthInDots} wide`;
-    if (this.lengthInDots) {
-      str += ` x ${this.lengthInDots} high`;
-    }
-    if (this.gapLengthInDots) {
-      str += ` with a gap length of ${this.gapLengthInDots}`;
-    }
-    str += ' (in dots).';
-    return str;
-  }
-
-  get setsLength() {
-    return this.lengthInDots !== undefined && this.gapLengthInDots !== undefined;
-  }
-
-  // TODO: Black line mode for EPL?
-  constructor(
-    public readonly widthInDots: number,
-    public readonly lengthInDots?: number,
-    public readonly gapLengthInDots?: number) { }
-
-  effectFlags = new CommandEffectFlags(['altersConfig']);
-}
-
-export class SetLabelHomeCommand implements IPrinterCommand {
-  name = 'Sets the label home (origin) offset';
-  type: CommandType = 'SetLabelHome';
-  toDisplay(): string {
-    return `Set the label home (origin) to ${this.offset.left},${this.offset.top} from the top-left.`;
-  }
-  effectFlags = new CommandEffectFlags(['altersConfig']);
-
-  constructor(public offset: Conf.Coordinate) { }
-}
-
-/** Command class to set the print offset from the top-left of the label. */
-export class SetLabelPrintOriginOffsetCommand implements IPrinterCommand {
-  name = 'Sets the print offset from the top left corner.';
-  type: CommandType = 'SetLabelPrintOriginOffset';
-  toDisplay(): string {
-    return `Sets the print offset to ${this.offset.left} in and ${this.offset.top} down from the top-left.`;
-  }
-  effectFlags = new CommandEffectFlags(['altersConfig']);
-
-  constructor(public offset: Conf.Coordinate) { }
-}
-
-/** A command to set the media tracking type to continuous media. */
-export class SetMediaToContinuousMediaCommand implements IPrinterCommand {
-  name = 'Sets the media tracking type to continuous media.';
-  type: CommandType = 'SetMediaToContinuousMedia';
-  toDisplay(): string { return this.name; }
-  effectFlags = new CommandEffectFlags(['altersConfig']);
-
-  constructor(
-    public mediaLengthInDots: number,
-    public formGapInDots: number
-  ) { }
-}
-
-/** A command to set the media tracking type to web gap detection. */
-export class SetMediaToWebGapMediaCommand implements IPrinterCommand {
-  name = 'Sets the media tracking type to web gap detection.';
-  type: CommandType = 'SetMediaToWebGapMedia';
-  toDisplay(): string { return this.name; }
-  effectFlags = new CommandEffectFlags(['altersConfig']);
-
-  constructor(
-    public mediaLengthInDots: number,
-    public mediaGapInDots: number,
-    public mediaGapOffsetInDots: number = 0,
-  ) { }
-}
-
-/** A command to set the media tracking type to black mark detection. */
-export class SetMediaToMarkMediaCommand implements IPrinterCommand {
-  name = 'Sets the media tracking type to black mark detection.';
-  type: CommandType = 'SetMediaToMarkMedia';
-  toDisplay(): string { return this.name; }
-  effectFlags = new CommandEffectFlags(['altersConfig']);
-
-  constructor(
-    public mediaLengthInDots: number,
-    public blackLineThicknessInDots: number,
-    public blackLineOffset: number = 0
-  ) { }
-}
-
-/** Command to cause the printer to auto-sense the media length. */
-export class AutosenseMediaDimensionsCommand extends BasicCommand {
-  get name() { return 'Auto-sense the media length by feeding several labels.'; }
-  type: CommandType = 'AutosenseMediaDimensions';
-  constructor() { super (['altersConfig', 'feedsPaperIgnoringPeeler', 'feedsPaper'])}
-  override toDisplay(): string { return this.name; }
-}
-
-/** Command class to modify an offset. */
-export class OffsetCommand implements IPrinterCommand {
-  name = 'Modify offset';
-  type: CommandType = 'Offset';
-  toDisplay(): string {
-    let str = `Set offset to ${this.horizontal} from the left`;
-    if (this.vertical) {
-      str += ` and ${this.vertical} from the top`;
-    }
-    str += this.absolute ? `of the label.` : ` of the current offset.`;
-    return str;
-  }
-  effectFlags = NoEffect;
-
-  constructor(
-    public readonly horizontal: number,
-    public readonly vertical?: number,
-    public readonly absolute = false
-  ) {
-    this.horizontal = Math.floor(horizontal);
-    this.vertical = vertical !== undefined ? Math.floor(vertical) : undefined;
-    this.absolute = absolute;
-  }
-}
-
-/** Command class to force a printer to reset. */
-export class RebootPrinterCommand extends BasicCommand {
-  get name() { return 'Simulate a power-cycle for the printer. This should be the final command.'; }
-  type: CommandType = 'RebootPrinter';
-  constructor() { super(['lossOfConnection']); }
-}
-
-/** Command class to draw an image into the image buffer for immediate print. */
-export class AddImageCommand implements IPrinterCommand {
-  name = 'Add image to label';
-  type: CommandType = 'AddImage';
-  toDisplay(): string {
-    return `Adds a ${this.bitmap.width} wide x ${this.bitmap.height} high image.`;
-  }
-  effectFlags = NoEffect;
-
-  constructor(
-    public bitmap: Util.BitmapGRF,
-    public imageConversionOptions: Util.ImageConversionOptions
-  ) { }
-}
-
-/** Command class to draw a straight line. */
-export class AddLineCommand implements IPrinterCommand {
-  name = 'Add perpendicular line to label';
-  type: CommandType = 'AddLine';
-  toDisplay(): string {
-    return `Add a ${DrawColor[this.color]} line ${this.widthInDots} wide by ${this.heightInDots} high.`;
-  }
-  effectFlags = NoEffect;
-
-  constructor(
-    public readonly widthInDots: number,
-    public readonly heightInDots: number,
-    public readonly color: DrawColor
-  ) { }
-}
-
-/** Command to draw a box on a label */
-export class AddBoxCommand implements IPrinterCommand {
-  name = 'Add a box to label';
-  type: CommandType = 'AddBox';
-  toDisplay(): string {
-    return `Add a box ${this.widthInDots} wide by ${this.heightInDots} high.`;
-  }
-  effectFlags = NoEffect;
-
-  constructor(
-    public readonly widthInDots: number,
-    public readonly heightInDots: number,
-    public readonly thickness: number
-  ) { }
-}
-
-/** Sending a raw instruction to the printer. */
-export class Raw implements IPrinterCommand {
-  name = 'Sends a raw set of commands directly to the printer unmodified.';
-  type: CommandType = 'Raw';
-  toDisplay(): string { return this.name; }
-
-  constructor(
-    public readonly rawDocument: string,
-    public readonly effectFlags: CommandEffectFlags
-  ) { }
 }

--- a/src/Commands/Commands.ts
+++ b/src/Commands/Commands.ts
@@ -81,7 +81,7 @@ export type CommandType
   | "QueryConfiguration"
   // Configuration commands
   | "SaveCurrentConfiguration"
-  | "AutosenseLabelDimensions"
+  | "AutosenseMediaDimensions"
   | "SetDarkness"
   | "SetLabelDimensions"
   | "SetLabelHome"
@@ -343,14 +343,12 @@ export class SetLabelToMarkMediaCommand implements IPrinterCommand {
   ) { }
 }
 
-/** Command class to cause the printer to auto-sense the media length. */
-export class AutosenseLabelDimensionsCommand extends BasicCommand {
-  get name() { return 'Auto-sense the label length by feeding several labels.'; }
-  type: CommandType = 'AutosenseLabelDimensions';
+/** Command to cause the printer to auto-sense the media length. */
+export class AutosenseMediaDimensionsCommand extends BasicCommand {
+  get name() { return 'Auto-sense the media length by feeding several labels.'; }
+  type: CommandType = 'AutosenseMediaDimensions';
   constructor() { super (['altersConfig', 'feedsPaperIgnoringPeeler', 'feedsPaper'])}
-  override toDisplay(): string {
-    return this.name;
-  }
+  override toDisplay(): string { return this.name; }
 }
 
 /** Command class to modify an offset. */

--- a/src/Commands/Messages.ts
+++ b/src/Commands/Messages.ts
@@ -76,6 +76,19 @@ export function asString(commands: Conf.MessageArrayLike): string {
   }
 }
 
+export function asTargetMessageType<TMessage extends Conf.MessageArrayLike>(
+  msg: Conf.MessageArrayLike,
+  targetType: TMessage,
+): TMessage {
+  if (typeof targetType === "string") {
+    return asString(msg) as TMessage;
+  } else if (targetType instanceof Uint8Array) {
+    return asUint8Array(msg) as TMessage;
+  } else {
+    throw new Error("Unknown message type not implemented!");
+  }
+}
+
 export type AwaitedCommand = {
   cmd: IPrinterCommand,
   promise: Promise<boolean>,
@@ -273,56 +286,4 @@ export async function parseRaw<TInput extends Conf.MessageArrayLike>(
   } while (incomplete === false && remainderMsg.length > 0 && remainderCommands.length > 0)
 
   return { remainderMsg, remainderCommands, messages }
-}
-
-/**
- * Slice an array from the start to the first LF character, returning both pieces.
- *
- * If no LF character is found sliced will have a length of 0.
- *
- * CR characters are not removed if present!
- */
-export function sliceToNewline(msg: Uint8Array): {
-  sliced: Uint8Array,
-  remainder: Uint8Array,
-} {
-  const idx = msg.indexOf(Util.AsciiCodeNumbers.LF);
-  if (idx === -1) {
-    return {
-      sliced: new Uint8Array(),
-      remainder: msg
-    }
-  }
-
-  return {
-    sliced: msg.slice(0, idx + 1),
-    remainder: msg.slice(idx + 1),
-  };
-}
-
-/** Slice a string from the start to the first CRLF or LF, returning both pieces. */
-export function sliceToCRLF(msg: string): {
-  sliced: string,
-  remainder: string,
-} {
-  const cr = msg.indexOf('\r\n');
-  if (cr !== -1) {
-    return {
-      sliced: msg.substring(0, cr),
-      remainder: msg.substring(cr + 2)
-    }
-  }
-
-  const lf = msg.indexOf('\n');
-  if (lf !== -1) {
-    return {
-      sliced: msg.substring(0, lf),
-      remainder: msg.substring(lf + 1)
-    }
-  }
-
-  return {
-    sliced: "",
-    remainder: msg
-  }
 }

--- a/src/Commands/PrinterConfig.ts
+++ b/src/Commands/PrinterConfig.ts
@@ -32,5 +32,6 @@ export class PrinterConfig extends Conf.BasePrinterConfig {
     this._mediaLengthDots            = msg.printerMedia?.mediaLengthDots            ?? this._mediaLengthDots;
 
     this._backfeedAfterTaken = msg.printerSettings?.backfeedAfterTaken ?? this._backfeedAfterTaken;
+    this._feedButtonMode     = msg.printerSettings?.feedButtonMode     ?? this._feedButtonMode;
   }
 }

--- a/src/Commands/TranspileCommand.ts
+++ b/src/Commands/TranspileCommand.ts
@@ -1,7 +1,8 @@
 import * as Util from '../Util/index.js';
 import * as Conf from '../Configs/index.js';
-import * as Commands from './Commands.js';
 import type { PrinterConfig } from './PrinterConfig.js';
+import type { OffsetCommand } from './BasicCommands.js';
+import { CommandEffectFlags } from './Commands.js';
 
 /** Interface of document state effects carried between individual commands. */
 export interface TranspiledDocumentState {
@@ -20,8 +21,21 @@ export interface TranspiledDocumentState {
 
   characterSize: Conf.Coordinate;
 
-  commandEffectFlags: Commands.CommandEffectFlags;
+  commandEffectFlags: CommandEffectFlags;
 }
+
+  /** Apply an offset command to a document. */
+  export function applyOffsetToDocState(
+    cmd: OffsetCommand,
+    outDoc: TranspiledDocumentState
+  ) {
+    const newHoriz = cmd.absolute ? cmd.horizontal : outDoc.horizontalOffset + cmd.horizontal;
+    outDoc.horizontalOffset = newHoriz < 0 ? 0 : newHoriz;
+    if (cmd.vertical !== undefined) {
+      const newVert = cmd.absolute ? cmd.vertical : outDoc.verticalOffset + cmd.vertical;
+      outDoc.verticalOffset = newVert < 0 ? 0 : newVert;
+    }
+  }
 
 export function getNewTranspileState(config: PrinterConfig): TranspiledDocumentState {
   return {
@@ -38,7 +52,7 @@ export function getNewTranspileState(config: PrinterConfig): TranspiledDocumentS
       leftChars: 0,
       rightChars: 0
     },
-    commandEffectFlags: new Commands.CommandEffectFlags()
+    commandEffectFlags: new CommandEffectFlags()
   }
 }
 

--- a/src/Commands/index.ts
+++ b/src/Commands/index.ts
@@ -3,3 +3,4 @@ export * from './CommandSet.js';
 export * from './Messages.js';
 export * from './PrinterConfig.js';
 export * from './TranspileCommand.js';
+export * from './BasicCommands.js';

--- a/src/Configs/BasePrinterConfig.ts
+++ b/src/Configs/BasePrinterConfig.ts
@@ -1,4 +1,4 @@
-import { MediaMediaGapDetectionMode, MediaPrintMode, PrintOrientation, PrintSpeed, PrintSpeedSettings, SpeedTable, ThermalPrintMode, type BackfeedAfterTaken, type Coordinate, type DarknessPercent, type IPrinterHardware, type IPrinterMedia, type IPrinterSettings } from "./ConfigurationTypes.js";
+import { MediaMediaGapDetectionMode, MediaPrintMode, PrintOrientation, PrintSpeed, PrintSpeedSettings, SpeedTable, ThermalPrintMode, type BackfeedAfterTaken, type Coordinate, type DarknessPercent, type FeedButtonMode, type IPrinterHardware, type IPrinterMedia, type IPrinterSettings } from "./ConfigurationTypes.js";
 
 /** Configured options for a printer */
 export abstract class BasePrinterConfig implements IPrinterHardware, IPrinterSettings, IPrinterMedia {
@@ -30,6 +30,9 @@ export abstract class BasePrinterConfig implements IPrinterHardware, IPrinterSet
 
   protected _backfeedAfterTaken: BackfeedAfterTaken = '90';
   get backfeedAfterTaken() { return this._backfeedAfterTaken; }
+
+  protected _feedButtonMode: FeedButtonMode = 'feedBlank';
+  get feedButtonMode() { return this._feedButtonMode; }
 
   protected _maxMediaDarkness = 15;
   get maxMediaDarkness() { return this._maxMediaDarkness; }

--- a/src/Configs/ConfigurationTypes.ts
+++ b/src/Configs/ConfigurationTypes.ts
@@ -60,6 +60,13 @@ export enum ThermalPrintMode {
   transfer
 }
 
+/** Behavior of pressing the feed button on the printer. */
+export type FeedButtonMode
+  = 'disabled'
+  | 'feedBlank'
+  | 'tapToPrint'
+  | 'tapToReprint'
+
 /** Describes the way the medias are marked for the printer to detect separate medias. */
 export enum MediaMediaGapDetectionMode {
   /** Media is one continuous media with no gaps. Used with cutters usually. */
@@ -82,7 +89,7 @@ export enum MediaPrintMode {
   peel,
   /** Peel mode, but each media is fed to pre-peel a small portion. Helps some media types. ZPL only.*/
   peelWithPrePeel,
-  /** Peel mode, but printer waits for button tap between medias. */
+  /** Peel mode, but printer waits for button tap between media. */
   peelWithButtonTap,
   /** Media advances until web is over cutter. */
   cutter,
@@ -92,7 +99,7 @@ export enum MediaPrintMode {
   rewind,
   /** Media advances far enough for applicator device to grab. Printers with applicator ports only. */
   applicator,
-  /** Removes backfeed between RFID medias, improving throughput. RFID printers only. */
+  /** Removes backfeed between RFID media, improving throughput. RFID printers only. */
   rfid,
   /** Media is moved into a presentation position. ZPL only.*/
   kiosk
@@ -254,10 +261,14 @@ export interface IPrinterHardwareUpdate {
 export interface IPrinterSettings {
   /** What percentage of backfeed happens after cutting/taking label, vs before printing. */
   readonly backfeedAfterTaken: BackfeedAfterTaken;
+
+  /** The behavior when pressing the feed button on the printer. */
+  readonly feedButtonMode: FeedButtonMode;
 }
 
 export interface IPrinterSettingsUpdate {
   backfeedAfterTaken?: BackfeedAfterTaken;
+  feedButtonMode?: FeedButtonMode;
 }
 
 /** Printer options related to the media media being printed */

--- a/src/Documents/ConfigDocument.ts
+++ b/src/Documents/ConfigDocument.ts
@@ -104,9 +104,9 @@ export class ConfigDocumentBuilder
   ///////////////////// ALTER LABEL CONFIG
 
   autosenseLabelLength() {
-    return this.andThen(new Cmds.AutosenseLabelDimensionsCommand()).finalize();
+    return this.andThen(new Cmds.AutosenseMediaDimensionsCommand()).finalize();
   }
-  
+
   setBackfeedAfterTakenMode(mode: Conf.BackfeedAfterTaken) {
     return this.andThen(new Cmds.SetBackfeedAfterTakenMode(mode));
   }
@@ -148,11 +148,17 @@ export class ConfigDocumentBuilder
     );
   }
 
-  setLabelMediaToContinuous(labelLengthInInches: number): IConfigDocumentBuilder {
+  setLabelMediaToContinuous(
+    mediaLengthInInches: number,
+    formGapInInches: number = 0,
+  ): IConfigDocumentBuilder {
     this._doSave = true;
     const dpi = this._config.dpi;
     return this.andThen(
-      new Cmds.SetLabelToContinuousMediaCommand(dpi * labelLengthInInches)
+      new Cmds.SetMediaToContinuousMediaCommand(
+        dpi * mediaLengthInInches,
+        dpi * formGapInInches
+      )
     );
   }
 
@@ -163,7 +169,7 @@ export class ConfigDocumentBuilder
     this._doSave = true;
     const dpi = this._config.dpi;
     return this.andThen(
-      new Cmds.SetLabelToWebGapMediaCommand(
+      new Cmds.SetMediaToWebGapMediaCommand(
         labelLengthInInches * dpi,
         labelGapInInches * dpi
       )
@@ -178,7 +184,7 @@ export class ConfigDocumentBuilder
     this._doSave = true;
     const dpi = this._config.dpi;
     return this.andThen(
-      new Cmds.SetLabelToMarkMediaCommand(
+      new Cmds.SetMediaToMarkMediaCommand(
         labelLengthInInches * dpi,
         blackLineThicknessInInches * dpi,
         blackLineOffsetInInches * dpi

--- a/src/Documents/DocumentTranspiler.test.ts
+++ b/src/Documents/DocumentTranspiler.test.ts
@@ -221,13 +221,19 @@ describe('DocumentTranspiler', () => {
                       "type": "CustomCommand",
                       "typeExtended": Symbol(CmdXmlQuery),
                     },
+                    CmdHostConfig {
+                      "commandLanguageApplicability": 2,
+                      "effectFlags": Set {
+                        "waitsForResponse",
+                      },
+                      "name": "Get host config",
+                      "type": "CustomCommand",
+                      "typeExtended": Symbol(CmdHostStatus),
+                    },
                   ],
                   "commands": "
 
-            ^XA
-            ^HZa
-
-            ^XZ
+            ^XA^HZa^HH^XZ
 
             ",
                 },
@@ -303,9 +309,7 @@ describe('DocumentTranspiler', () => {
                   "awaitedCommands": [],
                   "commands": "
 
-            ^XA
-            ^FD ^PQ1,0,0
-            ^XZ
+            ^XA^FD ^PQ1,0,0^XZ
 
             ",
                 },
@@ -346,9 +350,7 @@ describe('DocumentTranspiler', () => {
                   "awaitedCommands": [],
                   "commands": "
 
-            ^XA
-            ^FO0,0,^GB4,40,4,B,^FS^FO0,40,^GB1,20,1,B,^FS^FO1,60,^GB1,20,1,B,^FS^FO2,80,^GB1,20,1,B,^FS^FO3,100,^GB1,20,1,B,^FS^FO0,125,^GB1,8,1,B,^FS^FO1,133,^GB1,8,1,B,^FS^FO2,141,^GB1,8,1,B,^FS^FO3,149,^GB1,8,1,B,^FS^FO4,125,^GB1,8,1,B,^FS^FO5,133,^GB1,8,1,B,^FS^FO6,141,^GB1,8,1,B,^FS^FO7,149,^GB1,8,1,B,^FS^FD ^PQ1,0,0
-            ^XZ
+            ^XA^FO0,0,^GB4,40,4,B,^FS^FO0,40,^GB1,20,1,B,^FS^FO1,60,^GB1,20,1,B,^FS^FO2,80,^GB1,20,1,B,^FS^FO3,100,^GB1,20,1,B,^FS^FO0,125,^GB1,8,1,B,^FS^FO1,133,^GB1,8,1,B,^FS^FO2,141,^GB1,8,1,B,^FS^FO3,149,^GB1,8,1,B,^FS^FO4,125,^GB1,8,1,B,^FS^FO5,133,^GB1,8,1,B,^FS^FO6,141,^GB1,8,1,B,^FS^FO7,149,^GB1,8,1,B,^FS^FD ^PQ1,0,0^XZ
 
             ",
                 },

--- a/src/Documents/DocumentTranspiler.ts
+++ b/src/Documents/DocumentTranspiler.ts
@@ -140,10 +140,8 @@ function splitTransactionsAndForms(
     }
 
     // Record the command in the transpile buffer.
-    if (command.type !== "NoOp") {
-      currentTrans.commands.push(command);
-      command.effectFlags.forEach(f => currentForm.effects.add(f));
-    }
+    currentTrans.commands.push(command);
+    command.effectFlags.forEach(f => currentForm.effects.add(f));
 
     if (command.effectFlags.has("waitsForResponse")) {
       // This command expects the printer to provide feedback.

--- a/src/Languages/Epl/CmdConfigurationInquiry.test.ts
+++ b/src/Languages/Epl/CmdConfigurationInquiry.test.ts
@@ -1,11 +1,91 @@
 import { expect, describe, it } from 'vitest';
 import { parseConfigResponse, tryGetModel } from './CmdConfigurationInquiry.js';
+import type { ISettingUpdateMessage } from '../../Commands/Messages.js';
+import { MediaMediaGapDetectionMode, PrintSpeed, ThermalPrintMode } from '../../Configs/ConfigurationTypes.js';
 
 describe("CmdConfigurationInquiry", () => {
   it('Rejects empty message', () => {
     const result = parseConfigResponse("", undefined!);
     expect(result.messages).toStrictEqual([]);
     expect(result.remainder).toStrictEqual("");
+  });
+
+  function getMsg(cfg: string): ISettingUpdateMessage {
+    const result = parseConfigResponse(`
+UKQ1935HLU       V4.70.1A
+${cfg}`, undefined!);
+    const msg = (result.messages[0] as ISettingUpdateMessage);
+    return msg;
+  }
+
+  describe('Individual config lines', () => {
+    it('Line A', () => {
+      const msg = getMsg("");
+      expect(msg.printerHardware?.firmware).toBe("V4.70.1A");
+      expect(msg.printerHardware?.model).toBe("LP2844");
+    });
+    it('S/N Line', () => {
+      const msg = getMsg("S/N: 42A000001234");
+      expect(msg.printerHardware?.serialNumber).toBe("42A000001234");
+    });
+    it('Line B wrong', () => {
+      const msg = `
+UKQ1935HLU       V4.70.1A
+Line Mode   `;
+      expect(() => parseConfigResponse(msg, undefined!)).toThrow();
+    });
+    // Line B is serial port, ignored.
+    // Line C is Page Mode, ignored.
+    // Line D is a test pattern when printed.
+    // Line E is image buffer size
+    // Line F Form memory
+    // Line G Graphics memory
+    // Line H Font memory
+    // Line I Total free memory
+    it('Line J', () => {
+      const msg = getMsg("I8,0,001 rY JF WY");
+      expect(msg.printerSettings?.backfeedAfterTaken).toBe('100');
+      const msg2 = getMsg("I8,0,001 rY JB WY");
+      expect(msg2.printerSettings?.backfeedAfterTaken).toBe('disabled');
+    });
+    it('Line K', () => {
+      const msg = getMsg("S4 D00 R0,0 ZT UN");
+      expect(msg.printerMedia?.speed).toMatchInlineSnapshot(`
+        PrintSpeedSettings {
+          "printSpeed": 7,
+          "slewSpeed": 7,
+        }
+      `);
+    });
+    it('Line L web sense media', () => {
+      const msg = getMsg("q832 Q1022,029+05");
+      expect(msg.printerMedia?.mediaGapDetectMode).toBe(MediaMediaGapDetectionMode.webSensing);
+      expect(msg.printerMedia?.mediaWidthDots).toBe(812);
+      expect(msg.printerMedia?.mediaLengthDots).toBe(1015);
+      expect(msg.printerMedia?.mediaGapDots).toBe(29);
+      expect(msg.printerMedia?.mediaLineOffsetDots).toBe(5);
+    });
+    it('Line L gapless media', () => {
+      const msg = getMsg("q328 Q163,0");
+      expect(msg.printerMedia?.mediaGapDetectMode).toBe(MediaMediaGapDetectionMode.continuous);
+      expect(msg.printerMedia?.mediaLengthDots).toBe(0);
+      expect(msg.printerMedia?.mediaGapDots).toBe(163);
+    });
+    it('Line L black line media', () => {
+      const msg = getMsg("q816 Q56,B189-4");
+      expect(msg.printerMedia?.mediaGapDetectMode).toBe(MediaMediaGapDetectionMode.markSensing);
+      expect(msg.printerMedia?.mediaLengthDots).toBe(50);
+      expect(msg.printerMedia?.mediaGapDots).toBe(189);
+      expect(msg.printerMedia?.mediaLineOffsetDots).toBe(-4);
+    });
+    it('Line M', () => {
+      const msg = getMsg("Option:d,Ff");
+      expect(msg.printerMedia?.thermalPrintMode).toBe(ThermalPrintMode.direct);
+    });
+    // Line N is autosense values
+    // Line O is cover sensor
+    // Line P is date and time
+    // Line Q is dump mode
   });
 
   describe('Real configs', () => {
@@ -57,8 +137,9 @@ Cover: T=137, C=147
             "printerMedia": {
               "darknessPercent": 40,
               "mediaGapDetectMode": 0,
-              "mediaGapDots": 0,
-              "mediaLengthDots": 152,
+              "mediaGapDots": 163,
+              "mediaLengthDots": 0,
+              "mediaLineOffsetDots": 0,
               "mediaPrintOriginOffsetDots": {
                 "left": 248,
                 "top": 0,
@@ -73,6 +154,7 @@ Cover: T=137, C=147
             },
             "printerSettings": {
               "backfeedAfterTaken": "100",
+              "feedButtonMode": "feedBlank",
             },
           },
         ]
@@ -129,6 +211,7 @@ Cover: T=144, C=167
               "mediaGapDetectMode": 1,
               "mediaGapDots": 25,
               "mediaLengthDots": 913,
+              "mediaLineOffsetDots": 0,
               "mediaPrintOriginOffsetDots": {
                 "left": 8,
                 "top": 0,
@@ -143,6 +226,7 @@ Cover: T=144, C=167
             },
             "printerSettings": {
               "backfeedAfterTaken": "100",
+              "feedButtonMode": "feedBlank",
             },
           },
         ]
@@ -197,6 +281,7 @@ Cover: T=118, C=129
               "mediaGapDetectMode": 1,
               "mediaGapDots": 24,
               "mediaLengthDots": 913,
+              "mediaLineOffsetDots": 0,
               "mediaPrintOriginOffsetDots": {
                 "left": 0,
                 "top": 0,
@@ -266,6 +351,7 @@ Cover: T=120, C=141`;
               "mediaGapDetectMode": 1,
               "mediaGapDots": 169,
               "mediaLengthDots": 50,
+              "mediaLineOffsetDots": 0,
               "mediaPrintOriginOffsetDots": {
                 "left": 104,
                 "top": 0,
@@ -280,6 +366,7 @@ Cover: T=120, C=141`;
             },
             "printerSettings": {
               "backfeedAfterTaken": "100",
+              "feedButtonMode": "feedBlank",
             },
           },
         ]
@@ -333,6 +420,7 @@ oUs,t,u
               "mediaGapDetectMode": 1,
               "mediaGapDots": 189,
               "mediaLengthDots": 50,
+              "mediaLineOffsetDots": 4,
               "mediaPrintOriginOffsetDots": {
                 "left": 8,
                 "top": 0,

--- a/src/Languages/Epl/CmdConfigurationInquiry.test.ts
+++ b/src/Languages/Epl/CmdConfigurationInquiry.test.ts
@@ -440,6 +440,77 @@ oUs,t,u
         ]
       `);
     });
+
+    it('Real Config 6', () => {
+      const real_config_6 = `
+FDX ZP 500 (ZPL) ZSP-002281B
+S/N: 27J130201516
+HEAD    usage =       43,551"
+PRINTER usage =       43,551"
+Serial Port: 96,N,8,1
+Page Mode
+RAM size: 2054496
+Fmem used: 0 (bytes)
+Gmem used: 0
+Emem used: 0
+Available: 1516992
+I8,A,001 JF WY
+S3 D11 R000,000 ZB UN
+q832 Q1218,0 Ymax:5000 eR$,0
+Option:D,Ff
+oEv,w,x,y,z
+00 05 31`;
+      const result = parseConfigResponse(real_config_6, undefined!);
+      expect(result.messages).toMatchInlineSnapshot(`
+        [
+          {
+            "messageType": "SettingUpdateMessage",
+            "printerHardware": {
+              "dpi": 203,
+              "firmware": "ZSP-002281B",
+              "manufacturer": "Zebra Corporation",
+              "maxMediaDarkness": 15,
+              "maxMediaLengthDots": 2223,
+              "maxMediaWidthDots": 448,
+              "model": "FDX ZP 500",
+              "serialNumber": "27J130201516",
+              "speedTable": SpeedTable {
+                "speedTable": Map {
+                  4 => 2,
+                  6 => 3,
+                  8 => 4,
+                  9 => 5,
+                  1 => 2,
+                  1000 => 5,
+                  0 => 4,
+                },
+              },
+            },
+            "printerMedia": {
+              "darknessPercent": 74,
+              "mediaGapDetectMode": 0,
+              "mediaGapDots": 1218,
+              "mediaLengthDots": 0,
+              "mediaLineOffsetDots": 0,
+              "mediaPrintOriginOffsetDots": {
+                "left": 0,
+                "top": 0,
+              },
+              "mediaWidthDots": 812,
+              "printOrientation": 0,
+              "speed": PrintSpeedSettings {
+                "printSpeed": 6,
+                "slewSpeed": 6,
+              },
+              "thermalPrintMode": 0,
+            },
+            "printerSettings": {
+              "feedButtonMode": "feedBlank",
+            },
+          },
+        ]
+      `);
+    });
   });
 
   describe('tryGetModel', () => {

--- a/src/Languages/Epl/CmdConfigurationInquiry.ts
+++ b/src/Languages/Epl/CmdConfigurationInquiry.ts
@@ -98,7 +98,8 @@ export function parseConfigResponse(
         update.printerHardware.serialNumber = str.substring(5).trim();
         break;
 
-      case str.startsWith("Serial port:"):
+      case /^Serial Port:/.test(str):
+      case /^Serial port:/.test(str):
         // Serial port:96,N,8,1    # Serial port config
         // TODO: Serial port settings and update
         //printerInfo.serialPort = str.substring(12).trim();
@@ -110,7 +111,7 @@ export function parseConfigResponse(
         break;
       }
 
-      case /^I\d,.+,\d\d\d r[YN]/.test(str): {
+      case /^I\d,.+,\d{3}/.test(str): {
         // I8,A,001 rY JF WY       # Config settings J
         updateSettingsLines(str.trim(), update);
         break;
@@ -176,6 +177,8 @@ export function parseConfigResponse(
       case /^Fmem[:\s]/.test(str):
       // Fmem:000.0K,060.9K avl  # Form storage
       // Fmem used: 0 (bytes)    # Form storage
+      case /^RAM size:/.test(str):
+      // RAM size: 2054496
       case /^Available:/.test(str):
       // Available: 130559       # Total memory for Forms, Fonts, or Graphics
       case /^Cover:/.test(str):

--- a/src/Languages/Epl/CmdConfigurationInquiry.ts
+++ b/src/Languages/Epl/CmdConfigurationInquiry.ts
@@ -197,7 +197,6 @@ export function parseConfigResponse(
     }
   }
 
-
   result.messages.push(update);
   return result;
 }
@@ -235,23 +234,24 @@ function updateFormDimensions(str: string, msg: Cmds.ISettingUpdateMessage) {
     msg.printerMedia.mediaGapDetectMode = Conf.MediaMediaGapDetectionMode.markSensing;
     // Q123,B24[+/-156]
     msg.printerMedia.mediaLengthDots = Number(len.substring(1));
-    if (mark.indexOf('-') > 0) {
+    const markLine = mark.substring(1);
+    if (markLine.indexOf('-') > 0) {
       // Negative offset
-      const idx = mark.indexOf('-');
-      msg.printerMedia.mediaGapDots = Number(mark.substring(1, idx));
-      msg.printerMedia.mediaLineOffsetDots = Number(mark.substring(idx + 1)) * -1;
+      const idx = markLine.indexOf('-');
+      msg.printerMedia.mediaGapDots = Number(markLine.substring(0, idx));
+      msg.printerMedia.mediaLineOffsetDots = Number(markLine.substring(idx + 1)) * -1;
     }
-    else if (mark.indexOf('+') > 0) {
+    else if (markLine.indexOf('+') > 0) {
       // Positive offset.
-      const idx = mark.indexOf('+');
-      msg.printerMedia.mediaGapDots = Number(mark.substring(1, idx));
-      msg.printerMedia.mediaLineOffsetDots = Number(mark.substring(idx + 1));
+      const idx = markLine.indexOf('+');
+      msg.printerMedia.mediaGapDots = Number(markLine.substring(0, idx));
+      msg.printerMedia.mediaLineOffsetDots = Number(markLine.substring(idx + 1));
     } else {
       // No offset
-      msg.printerMedia.mediaGapDots = Number(mark.substring(1));
+      msg.printerMedia.mediaGapDots = Number(mark);
       msg.printerMedia.mediaLineOffsetDots = 0;
     }
-  } else if (mark.at(0)) {
+  } else if (mark.at(0) === '0' && mark.length === 1) {
     msg.printerMedia.mediaGapDetectMode = Conf.MediaMediaGapDetectionMode.continuous;
     // Q24,0
     // Form length is variable, the Q value is feed distance between forms.
@@ -265,11 +265,11 @@ function updateFormDimensions(str: string, msg: Cmds.ISettingUpdateMessage) {
     if (mark.indexOf('+') > 0) {
       // Only Positive offset allowed, if present.
       const idx = mark.indexOf('+');
-      msg.printerMedia.mediaGapDots = Number(mark.substring(1, idx));
+      msg.printerMedia.mediaGapDots = Number(mark.substring(0, idx));
       msg.printerMedia.mediaLineOffsetDots = Number(mark.substring(idx + 1));
     } else {
       // No offset
-      msg.printerMedia.mediaGapDots = Number(mark.substring(1));
+      msg.printerMedia.mediaGapDots = Number(mark);
       msg.printerMedia.mediaLineOffsetDots = 0;
     }
   }

--- a/src/Languages/Epl/CmdErrorReporting.ts
+++ b/src/Languages/Epl/CmdErrorReporting.ts
@@ -23,6 +23,12 @@ export class CmdErrorReporting implements Cmds.IPrinterExtendedCommand {
   constructor(public readonly mode: CmdErrorReportingMode) {}
 }
 
+export const cmdErrorReportingMapping: Cmds.IPrinterCommandMapping<string> = {
+  commandType: CmdErrorReporting.typeE,
+  transpile: handleCmdErrorReporting,
+  formInclusionMode: Cmds.CommandFormInclusionMode.noForm,
+}
+
 export function handleCmdErrorReporting(
   cmd: Cmds.IPrinterCommand,
   _docState: Cmds.TranspiledDocumentState,

--- a/src/Languages/Epl/EplPrinterCommandSet.ts
+++ b/src/Languages/Epl/EplPrinterCommandSet.ts
@@ -11,7 +11,7 @@ export class EplPrinterCommandSet extends Cmds.StringCommandSet {
 
   // TODO: Method to add extended commands to the non-form list.
   protected nonFormCommands: (symbol | Cmds.CommandType)[] = [
-    'AutosenseLabelDimensions',
+    'AutosenseMediaDimensions',
     'PrintConfiguration',
     'QueryConfiguration',
     'RebootPrinter',
@@ -93,7 +93,7 @@ export class EplPrinterCommandSet extends Cmds.StringCommandSet {
         return this.setPrintDirectionCommand((cmd as Cmds.SetPrintDirectionCommand).upsideDown);
       case 'SetDarkness':
         return this.setDarknessCommand(cmd as Cmds.SetDarknessCommand, docState);
-      case 'AutosenseLabelDimensions':
+      case 'AutosenseMediaDimensions':
         return 'xa' + '\r\n';
       case 'SetPrintSpeed':
         // EPL has no separate media slew speed setting.

--- a/src/Languages/Epl/EplPrinters.json
+++ b/src/Languages/Epl/EplPrinters.json
@@ -65,6 +65,18 @@
         "width": 448,
         "length": 2223
       }
+    },
+    {
+      "modelName": "FDX ZP 500",
+      "modelHints": [
+        "FDX ZP 500"
+      ],
+      "dpi": 203,
+      "speedMap": "GK420",
+      "printArea": {
+        "width": 448,
+        "length": 2223
+      }
     }
   ],
   "speedMaps": {

--- a/src/Languages/Epl/ErrorMessage.ts
+++ b/src/Languages/Epl/ErrorMessage.ts
@@ -1,4 +1,5 @@
-import * as Cmds from "../../Commands/index.js"
+import * as Util from "../../Util/index.js";
+import * as Cmds from "../../Commands/index.js";
 
 const errorCodeMap: Map<number, Cmds.ErrorState[]> = new Map<number, Cmds.ErrorState[]>([
   [0, []],
@@ -19,7 +20,7 @@ const errorCodeMap: Map<number, Cmds.ErrorState[]> = new Map<number, Cmds.ErrorS
   [14, [Cmds.ErrorState.MotorTooHot]],
   [15, [Cmds.ErrorState.BatteryLowWarning40Percent]],
   [16, [Cmds.ErrorState.BatteryLowLimit20Percent]],
-  
+
   [50, [Cmds.ErrorState.PrinterBusyProcessingPrintJob]],
 
   [80, [Cmds.ErrorState.UnknownError]],
@@ -43,7 +44,7 @@ export function getErrorMessage(
     remainder: msg,
   }
 
-  const {sliced, remainder } = Cmds.sliceToCRLF(msg);
+  const {sliced, remainder } = Util.sliceToCRLF(msg);
   result.remainder = remainder;
   const errorMsg: Cmds.IErrorMessage = {
     messageType: 'ErrorMessage',

--- a/src/Languages/Epl/Messages.test.ts
+++ b/src/Languages/Epl/Messages.test.ts
@@ -1,10 +1,12 @@
 import { expect, describe, it } from 'vitest';
 import { handleMessage } from './Messages.js';
 import { AsciiCodeNumbers, AsciiCodeStrings, EncodeAscii } from '../../Util/ASCII.js';
+import { EplPrinterCommandSet } from './EplPrinterCommandSet.js';
 
 describe('handleMessage', () => {
+  const cmdSet = new EplPrinterCommandSet();
   it('ACK as status message', () => {
-    const result = handleMessage(
+    const result = handleMessage(cmdSet,
       new Uint8Array([AsciiCodeNumbers.ACK, AsciiCodeNumbers.CR, AsciiCodeNumbers.LF])
     );
     expect(result.messages).toMatchInlineSnapshot(`
@@ -17,7 +19,7 @@ describe('handleMessage', () => {
   });
 
   it('DLE as status message', () => {
-    const result = handleMessage(
+    const result = handleMessage(cmdSet,
       new Uint8Array([AsciiCodeNumbers.DLE, AsciiCodeNumbers.CR, AsciiCodeNumbers.LF])
     );
     expect(result.messages).toMatchInlineSnapshot(`
@@ -32,7 +34,7 @@ describe('handleMessage', () => {
 
   it('NAK as status message', () => {
     // Code 01 - Syntax error.
-    const result = handleMessage(
+    const result = handleMessage(cmdSet,
       EncodeAscii(`${AsciiCodeStrings.NAK}01\r\n`)
     );
     expect(result.messages).toMatchInlineSnapshot(`
@@ -49,7 +51,7 @@ describe('handleMessage', () => {
 
   it('NAK with busy error', () => {
     // Code 50 - Syntax error.
-    const result = handleMessage(
+    const result = handleMessage(cmdSet,
       EncodeAscii(`${AsciiCodeStrings.NAK}50\r\n`)
     );
     expect(result.messages).toMatchInlineSnapshot(`
@@ -65,7 +67,7 @@ describe('handleMessage', () => {
   })
 
   it('Extracts unprinted labels', () => {
-    const result = handleMessage(
+    const result = handleMessage(cmdSet,
       `${AsciiCodeStrings.NAK}07P001\r\n`
     );
     expect(result.messages).toMatchInlineSnapshot(`
@@ -83,7 +85,7 @@ describe('handleMessage', () => {
   });
 
   it('Extracts unprinted labels and lines', () => {
-    const result = handleMessage(
+    const result = handleMessage(cmdSet,
       `${AsciiCodeStrings.NAK}07P696L91234\r\n`
     );
     expect(result.messages).toMatchInlineSnapshot(`

--- a/src/Languages/Epl/Messages.ts
+++ b/src/Languages/Epl/Messages.ts
@@ -2,17 +2,12 @@ import * as Util from '../../Util/index.js';
 import * as Conf from '../../Configs/index.js';
 import * as Cmds from '../../Commands/index.js';
 import { getErrorMessage } from "./ErrorMessage.js";
-import { parseConfigResponse } from "./CmdConfigurationInquiry.js";
-
-const messageHandlerMap = new Map<symbol | Cmds.CommandType, Cmds.MessageHandlerDelegate<string>>([
-  ['GetStatus', getErrorMessage], // ^ee command
-  ['QueryConfiguration', parseConfigResponse], // UQ command
-]);
+import type { EplPrinterCommandSet } from './EplPrinterCommandSet.js';
 
 export function handleMessage<TReceived extends Conf.MessageArrayLike>(
+  cmdSet: EplPrinterCommandSet,
   message: TReceived,
-  sentCommand?: Cmds.IPrinterCommand,
-  handlerMap = messageHandlerMap
+  sentCommand?: Cmds.IPrinterCommand
 ): Cmds.IMessageHandlerResult<TReceived> {
   const result: Cmds.IMessageHandlerResult<TReceived> = {
     messageIncomplete: false,
@@ -77,7 +72,7 @@ export function handleMessage<TReceived extends Conf.MessageArrayLike>(
       // Everything else needs to be fully interpreted as an ASCII message.
       // Command responses may be fixed or variable length, usually with an
       // indicator of how many to expect.
-      const handled = Cmds.getMessageHandler(handlerMap, msg, sentCommand);
+      const handled = cmdSet.callMessageHandler(msg, sentCommand);
       result.messages.push(...handled.messages);
       result.messageIncomplete = handled.messageIncomplete;
       result.messageMatchedExpectedCommand = handled.messageMatchedExpectedCommand;

--- a/src/Languages/Epl/Messages.ts
+++ b/src/Languages/Epl/Messages.ts
@@ -34,6 +34,7 @@ export function handleMessage<TReceived extends Conf.MessageArrayLike>(
   if (firstByte === undefined) { return result; }
 
   switch (true) {
+    // TODO: Does this error reporting mode even work over USB? Maybe only serial?
     case (firstByte === Util.AsciiCodeStrings.ACK):
       // Different depending on error reporting mode:
       // Normal mode: either finished printing, or label taken when sensor enabled.
@@ -83,12 +84,6 @@ export function handleMessage<TReceived extends Conf.MessageArrayLike>(
   }
 
   // Put the remainder message back into its native format.
-  if (typeof result.remainder === "string") {
-    result.remainder = Cmds.asString(remainder) as TReceived;
-  } else if (result.remainder instanceof Uint8Array) {
-    result.remainder = remainder as TReceived;
-  } else {
-    throw new Error("Unknown message type not implemented!");
-  }
+  result.remainder = Cmds.asTargetMessageType(remainder, message);
   return result;
 }

--- a/src/Languages/PrinterCommandLanguage.ts
+++ b/src/Languages/PrinterCommandLanguage.ts
@@ -28,7 +28,9 @@ export function guessLanguageFromModelHint(deviceInfo?: IDeviceInformation): Con
       return Conf.PrinterCommandLanguage.zplEmulateEpl;
 
     // ZTC ZD410-203dpi ZPL
-    case /\sZPL$/gim.test(modelName): // Ends in literlaly 'ZPL'.
+    // ZTC ZP 500 (ZPL)
+    case /\(ZPL\)/gim.test(modelName): // Has (ZPL) in it
+    case /\sZPL$/gim.test(modelName): // Ends in literally 'ZPL'
     case /^T?LP28[24]4-Z/gim.test(modelName):  // LP2844-Z
     case /\sT?LP28[24]4-Z/gim.test(modelName): // ZTC LP2844-Z-200dpi
       return Conf.PrinterCommandLanguage.zpl;

--- a/src/Languages/Zpl/CmdConfigUpdate.ts
+++ b/src/Languages/Zpl/CmdConfigUpdate.ts
@@ -1,0 +1,37 @@
+import * as Conf from '../../Configs/index.js';
+import * as Cmds from '../../Commands/index.js';
+
+export type SetActiveConfig = 'ReloadFactory' | 'ReloadSaved' | 'SaveCurrent';
+
+export class CmdConfigUpdate implements Cmds.IPrinterExtendedCommand {
+  public static typeE = Symbol("CmdConfigUpdate");
+  typeExtended = CmdConfigUpdate.typeE;
+  commandLanguageApplicability = Conf.PrinterCommandLanguage.zpl;
+  name = 'Set the active config for the printer';
+  type = "CustomCommand" as const;
+  effectFlags = new Cmds.CommandEffectFlags(['altersConfig']);
+  toDisplay() { return this.name; }
+
+  constructor(public readonly config: SetActiveConfig) { }
+}
+
+export const cmdConfigUpdateMapping: Cmds.IPrinterCommandMapping<string> = {
+  commandType: CmdConfigUpdate.typeE,
+  transpile: handleCmdConfigUpdate
+}
+
+export function handleCmdConfigUpdate(
+  cmd: Cmds.IPrinterCommand,
+): string {
+  if (cmd instanceof CmdConfigUpdate) {
+    switch (cmd.config) {
+      case 'ReloadFactory':
+        return '^JUF'
+      case 'ReloadSaved':
+        return '^JUR'
+      case 'SaveCurrent':
+        return '^JUS'
+    }
+  }
+  return '';
+}

--- a/src/Languages/Zpl/CmdHostConfig.test.ts
+++ b/src/Languages/Zpl/CmdHostConfig.test.ts
@@ -1,0 +1,29 @@
+import { expect, describe, it } from 'vitest';
+import { ZD410_TXT } from './test_files/index.test.js';
+import { CmdHostConfig, parseCmdHostConfig } from './CmdHostConfig.js';
+
+describe('parseCmdHostConfig', () => {
+  describe('Full', () => {
+    const cmd = new CmdHostConfig();
+    it('Extracts the config', () => {
+      const file = ZD410_TXT();
+      expect(parseCmdHostConfig(file, cmd)).toMatchInlineSnapshot(`
+        {
+          "messageIncomplete": false,
+          "messageMatchedExpectedCommand": true,
+          "messages": [
+            {
+              "messageType": "SettingUpdateMessage",
+              "printerHardware": {},
+              "printerMedia": {
+                "mediaGapDetectMode": 1,
+              },
+              "printerSettings": {},
+            },
+          ],
+          "remainder": "",
+        }
+      `);
+    });
+  })
+});

--- a/src/Languages/Zpl/CmdHostConfig.ts
+++ b/src/Languages/Zpl/CmdHostConfig.ts
@@ -6,14 +6,19 @@ import * as Util from '../../Util/index.js';
 export class CmdHostConfig implements Cmds.IPrinterExtendedCommand {
   public static typeE = Symbol("CmdHostStatus");
   typeExtended = CmdHostConfig.typeE;
-  commandLanguageApplicability = Conf.PrinterCommandLanguage.epl;
+  commandLanguageApplicability = Conf.PrinterCommandLanguage.zpl;
   name = 'Get host config';
   type = "CustomCommand" as const;
   effectFlags = Cmds.AwaitsEffect;
   toDisplay() { return this.name; }
 
   constructor() { }
+}
 
+export const cmdHostConfigMapping: Cmds.IPrinterCommandMapping<string> = {
+  commandType: CmdHostConfig.typeE,
+  transpile: handleCmdHostConfig,
+  readMessage: parseCmdHostConfig,
 }
 
 export function handleCmdHostConfig(
@@ -21,7 +26,7 @@ export function handleCmdHostConfig(
   _docState: Cmds.TranspiledDocumentState,
   _commandSet: Cmds.CommandSet<string>
 ): string {
-  return '^HH\n';
+  return '^HH';
 }
 
 export function parseCmdHostConfig(
@@ -77,6 +82,7 @@ export function parseCmdHostConfig(
         console.debug('Unhandled line: ', str);
     }
 
+    // TODO LMAO
 
     // +21.0               DARKNESS
     // MEDIUM              DARKNESS SWITCH
@@ -146,8 +152,6 @@ export function parseCmdHostConfig(
     // 0                   MASS STORAGE COUNT
     // 0                   HID COUNT
     // OFF                 USB HOST LOCK OUT
-
-    // TODO LMAO
   });
 
   result.messages = [update];

--- a/src/Languages/Zpl/CmdHostConfig.ts
+++ b/src/Languages/Zpl/CmdHostConfig.ts
@@ -1,0 +1,155 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import * as Conf from '../../Configs/index.js';
+import * as Cmds from '../../Commands/index.js';
+import * as Util from '../../Util/index.js';
+
+export class CmdHostConfig implements Cmds.IPrinterExtendedCommand {
+  public static typeE = Symbol("CmdHostStatus");
+  typeExtended = CmdHostConfig.typeE;
+  commandLanguageApplicability = Conf.PrinterCommandLanguage.epl;
+  name = 'Get host config';
+  type = "CustomCommand" as const;
+  effectFlags = Cmds.AwaitsEffect;
+  toDisplay() { return this.name; }
+
+  constructor() { }
+
+}
+
+export function handleCmdHostConfig(
+  _cmd: Cmds.IPrinterCommand,
+  _docState: Cmds.TranspiledDocumentState,
+  _commandSet: Cmds.CommandSet<string>
+): string {
+  return '^HH\n';
+}
+
+export function parseCmdHostConfig(
+  msg: string,
+  _cmd: Cmds.IPrinterCommand
+): Cmds.IMessageHandlerResult<string> {
+  const result: Cmds.IMessageHandlerResult<string> = {
+    messageIncomplete: false,
+    messageMatchedExpectedCommand: true,
+    messages: [],
+    remainder: "",
+  }
+  // Each response should start with STX and end with ETX.
+  const msgStart = msg.indexOf(Util.AsciiCodeStrings.STX);
+  const msgEnd = msg.indexOf(Util.AsciiCodeStrings.ETX);
+  if (msgStart === -1) {
+    // Not the message we were looking for?
+    result.messageMatchedExpectedCommand = false;
+    result.remainder = msg;
+    return result;
+  }
+  if (msgEnd === -1) {
+    // Incomplete?
+    result.remainder = msg;
+    result.messageIncomplete = true;
+    return result;
+  }
+  result.remainder = msg.substring(msgEnd + 3); // TODO: Make sure response includes CRLF.
+  const response = msg.substring(msgStart + 1, msgEnd);
+
+  const update: Cmds.ISettingUpdateMessage = {
+    messageType: 'SettingUpdateMessage' as const,
+  }
+  update.printerHardware ??= {};
+  update.printerMedia ??= {};
+  update.printerSettings ??= {};
+
+  // Raw text from the printer contains \r\n, normalize to \n.
+  const lines = response
+    .replaceAll('\r', '')
+    .split('\n')
+    .filter((i) => i);
+
+  lines.forEach(l => {
+    const str = l.trim();
+    switch (true) {
+      case /MEDIA TYPE$/.test(str):
+        if (str.startsWith('MARK')) {
+          update.printerMedia!.mediaGapDetectMode = Conf.MediaMediaGapDetectionMode.markSensing;
+        }
+        break;
+      default:
+        console.debug('Unhandled line: ', str);
+    }
+
+
+    // +21.0               DARKNESS
+    // MEDIUM              DARKNESS SWITCH
+    // 6.0 IPS             PRINT SPEED
+    // +000                TEAR OFF ADJUST
+    // TEAR OFF            PRINT MODE
+    // MARK                MEDIA TYPE
+    // REFLECTIVE          SENSOR SELECT
+    // 203                 PRINT WIDTH
+    // 2205                LABEL LENGTH
+    // 10.0IN   253MM      MAXIMUM LENGTH
+    // MAINT. OFF          EARLY WARNING
+    // CONNECTED           USB COMM.
+    // AUTO                SER COMM. MODE
+    // 9600                BAUD
+    // 8 BITS              DATA BITS
+    // NONE                PARITY
+    // XON/XOFF            HOST HANDSHAKE
+    // NONE                PROTOCOL
+    // NORMAL MODE         COMMUNICATIONS
+    // <~>  7EH            CONTROL PREFIX
+    // <^>  5EH            FORMAT PREFIX
+    // <,>  2CH            DELIMITER CHAR
+    // ZPL II              ZPL MODE
+    // INACTIVE            COMMAND OVERRIDE
+    // NO MOTION           MEDIA POWER UP
+    // FEED                HEAD CLOSE
+    // 10%                 BACKFEED
+    // +000                LABEL TOP
+    // +0000               LEFT POSITION
+    // DISABLED            REPRINT MODE
+    // 036                 WEB SENSOR
+    // 096                 MEDIA SENSOR
+    // 128                 TAKE LABEL
+    // 050                 MARK SENSOR
+    // 004                 MARK MED SENSOR
+    // 035                 TRANS GAIN
+    // 022                 TRANS LED
+    // 017                 MARK GAIN
+    // 100                 MARK LED
+    // DPCSWFXM            MODES ENABLED
+    // ........            MODES DISABLED
+    //  448 8/MM FULL      RESOLUTION
+    // 6.0                 LINK-OS VERSION
+    // V84.20.18Z <-       FIRMWARE
+    // 1.3                 XML SCHEMA
+    // 6.5.0 0.770         HARDWARE ID
+    // 8192k............R: RAM
+    // 65536k...........E: ONBOARD FLASH
+    // NONE                FORMAT CONVERT
+    // ENABLED             IDLE DISPLAY
+    // 12/16/24            RTC DATE
+    // 14:40               RTC TIME
+    // DISABLED            ZBI
+    // 2.1                 ZBI VERSION
+    // READY               ZBI STATUS
+    // 7,332 LABELS        NONRESET CNTR
+    // 7,332 LABELS        RESET CNTR1
+    // 7,332 LABELS        RESET CNTR2
+    // 12,555 IN           NONRESET CNTR
+    // 12,543 IN           RESET CNTR1
+    // 12,543 IN           RESET CNTR2
+    // 31,859 CM           NONRESET CNTR
+    // 31,859 CM           RESET CNTR1
+    // 31,859 CM           RESET CNTR2
+    // 003 WIRED           SLOT 1
+    // 0                   MASS STORAGE COUNT
+    // 0                   HID COUNT
+    // OFF                 USB HOST LOCK OUT
+
+    // TODO LMAO
+  });
+
+  result.messages = [update];
+  return result
+}

--- a/src/Languages/Zpl/CmdHostIdentification.ts
+++ b/src/Languages/Zpl/CmdHostIdentification.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import * as Util from "../../Util/index.js";
 import * as Conf from '../../Configs/index.js';
 import * as Cmds from '../../Commands/index.js';
 import { AsciiCodeStrings } from '../../Util/ASCII.js';
@@ -40,7 +41,7 @@ export function parseCmdHostIdentification(
     messages: [],
     remainder: "",
   }
-  const {sliced, remainder} = Cmds.sliceToCRLF(msg);
+  const {sliced, remainder} = Util.sliceToCRLF(msg);
   result.remainder = remainder;
   if (sliced.length === 0) {
     return result;

--- a/src/Languages/Zpl/CmdHostIdentification.ts
+++ b/src/Languages/Zpl/CmdHostIdentification.ts
@@ -15,6 +15,13 @@ export class CmdHostIdentification implements Cmds.IPrinterExtendedCommand {
   constructor() {}
 }
 
+export const cmdHostIdentificationMapping: Cmds.IPrinterCommandMapping<string> = {
+  commandType: CmdHostIdentification.typeE,
+  transpile: handleCmdHostIdentification,
+  readMessage: parseCmdHostIdentification,
+  formInclusionMode: Cmds.CommandFormInclusionMode.noForm,
+}
+
 export function handleCmdHostIdentification(
   _cmd: Cmds.IPrinterCommand,
   _docState: Cmds.TranspiledDocumentState,

--- a/src/Languages/Zpl/CmdHostIdentification.ts
+++ b/src/Languages/Zpl/CmdHostIdentification.ts
@@ -37,41 +37,44 @@ export function parseCmdHostIdentification(
 ): Cmds.IMessageHandlerResult<string> {
   const result: Cmds.IMessageHandlerResult<string> = {
     messageIncomplete: false,
-    messageMatchedExpectedCommand: true,
+    messageMatchedExpectedCommand: false,
     messages: [],
-    remainder: "",
+    remainder: msg,
   }
-  const {sliced, remainder} = Util.sliceToCRLF(msg);
-  result.remainder = remainder;
-  if (sliced.length === 0) {
+  // Each line is wrapped in an STX_ETX\r\n pattern. Make sure there's one there
+  const msgStart = msg.indexOf(Util.AsciiCodeStrings.STX);
+  if (msgStart === -1) {
+    // Not the message we were looking for?
     return result;
   }
-  // Response format is a single line starting with STX and ends with ETX\r\n.
-  if (sliced.at(0) !== AsciiCodeStrings.STX || sliced.at(-1) !== AsciiCodeStrings.ETX) {
-    result.remainder = msg;
-    result.messageMatchedExpectedCommand = false;
-    return result;
-  }
+  // This should be the first line, which we can validate.
+  const line1Maybe = msg.substring(msgStart);
+
+  const {sliced, remainder} = Util.sliceToCRLF(line1Maybe);
 
   // Message format is documented as:
   // XXXXXX,V1.0.0,dpm,000KB,X
   // My LP2844-Z looks like this
   // LP2844-Z,V45.11.7Z   ,8,8192KB
-  // TThe second field should have a consistent pattern.
+  // The second field should have a consistent pattern.
   // ASSUMPTION: Min 4 fields always?
 
   // Several other commands have STX<data>>ETX patterns too.
-  // Firmware versions should (?) always start with /^V\d+\./ to disambiguate.
+  if (sliced.at(0) !== AsciiCodeStrings.STX
+    || sliced.at(-1) !== AsciiCodeStrings.ETX) {
+    return result;
+  }
+
   const line = sliced.split(',');
 
+  // Firmware versions should (?) always start with /^V\d+\./ to disambiguate.
   if (line.length < 4 || !/^V\d+\./.test(line.at(1) ?? '')) {
-    // Not our message!
-    result.remainder = msg;
-    result.messageMatchedExpectedCommand = false;
     return result;
   }
 
   // Okay this is our message.
+  result.messageMatchedExpectedCommand = true;
+  result.remainder = msg.substring(0, msgStart) + remainder;
 
   // The ZPL docs speak of a mysterious 5th field which my printers don't have.
   // "recognizable options"

--- a/src/Languages/Zpl/CmdHostQuery.ts
+++ b/src/Languages/Zpl/CmdHostQuery.ts
@@ -74,6 +74,13 @@ export class CmdHostQuery implements Cmds.IPrinterExtendedCommand {
   constructor(public readonly query: CmdHostQueryType) {}
 }
 
+export const cmdHostQueryMapping: Cmds.IPrinterCommandMapping<string> = {
+  commandType: CmdHostQuery.typeE,
+  transpile: handleCmdHostQuery,
+  readMessage: parseCmdHostQuery,
+  formInclusionMode: Cmds.CommandFormInclusionMode.noForm,
+}
+
 export function handleCmdHostQuery(
   cmd: Cmds.IPrinterCommand,
   docState: Cmds.TranspiledDocumentState,

--- a/src/Languages/Zpl/CmdHostStatus.test.ts
+++ b/src/Languages/Zpl/CmdHostStatus.test.ts
@@ -1,17 +1,40 @@
 import { expect, describe, it } from 'vitest';
 import { AsciiCodeStrings } from '../../Util/ASCII.js';
 import { CmdHostStatus, parseCmdHostStatus } from './CmdHostStatus.js';
+import { ErrorStateSet, type IErrorMessage } from '../../Commands/Messages.js';
 
 describe('parseCmdHostStatus', () => {
+  const msg = `${AsciiCodeStrings.STX}014,0,0,0633,000,0,0,0,000,0,0,0${AsciiCodeStrings.ETX}\r\n` +
+              `${AsciiCodeStrings.STX}000,0,0,0,0,2,6,0,00000000,1,000${AsciiCodeStrings.ETX}\r\n` +
+              `${AsciiCodeStrings.STX}1234,0${AsciiCodeStrings.ETX}\r\n`;
   it('Parses a valid message', () => {
-    const msg = `${AsciiCodeStrings.STX}014,0,0,0633,000,0,0,0,000,0,0,0${AsciiCodeStrings.ETX}\r\n` +
-                `${AsciiCodeStrings.STX}000,0,0,0,0,2,6,0,00000000,1,000${AsciiCodeStrings.ETX}\r\n` +
-                `${AsciiCodeStrings.STX}1234,0${AsciiCodeStrings.ETX}\r\n`;
     expect(parseCmdHostStatus(msg, new CmdHostStatus())).toEqual({
       messageIncomplete: false,
       messageMatchedExpectedCommand: true,
-      messages: [],
+      messages: [
+        {
+          messageType: "SettingUpdateMessage"
+        },
+        {
+          messageType: "StatusMessage"
+        },
+        {
+          messageType: "ErrorMessage",
+          errors: new ErrorStateSet()
+        } as IErrorMessage
+      ],
       remainder: "",
     })
+  });
+
+  it('Handles noisy messages', () => {
+    expect(parseCmdHostStatus(`hello\r\n${msg}`, new CmdHostStatus()).remainder)
+      .toBe("hello\r\n");
+    expect(parseCmdHostStatus(`${msg}hello\r\n`, new CmdHostStatus()).remainder)
+      .toBe("hello\r\n");
+    expect(parseCmdHostStatus(`hello\r\n`, new CmdHostStatus()).remainder)
+      .toBe("hello\r\n");
+    expect(parseCmdHostStatus(`${AsciiCodeStrings.STX}014,0`, new CmdHostStatus()).remainder)
+      .toBe(`${AsciiCodeStrings.STX}014,0`);
   });
 });

--- a/src/Languages/Zpl/CmdHostStatus.ts
+++ b/src/Languages/Zpl/CmdHostStatus.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as Conf from '../../Configs/index.js';
 import * as Cmds from '../../Commands/index.js';
+import * as Util from '../../Util/index.js';
 
 export class CmdHostStatus implements Cmds.IPrinterExtendedCommand {
   public static typeE = Symbol("CmdHostStatus");
@@ -35,13 +36,82 @@ export function parseCmdHostStatus(
 ): Cmds.IMessageHandlerResult<string> {
   const result: Cmds.IMessageHandlerResult<string> = {
     messageIncomplete: false,
-    messageMatchedExpectedCommand: true,
+    messageMatchedExpectedCommand: false,
     messages: [],
-    remainder: "",
+    remainder: msg,
   }
-  console.log("Got message: \n", msg);
+  // Each line is wrapped in an STX_ETX\r\n pattern. Make sure there's one there
+  const msgStart = msg.indexOf(Util.AsciiCodeStrings.STX);
+  if (msgStart === -1) {
+    // Not the message we were looking for?
+    return result;
+  }
+  // This should be the first line, which we can validate.
+  const line1Maybe = msg.substring(msgStart);
 
-  // TODO LMAO
+  // The structure of each line is always the same.
+  const { sliced: line1, remainder: line1r } = Util.sliceToCRLF(line1Maybe);
+  // Note, regex appears to ignore STX/ETX characters.
+  if (!/^\d{3},\d,\d,\d{4},\d{3},\d,\d,\d,000,\d,\d,\d$/.test(line1.slice(1, -1))) {
+    return result;
+  }
+  // First line is unique, so if it matched it's the right command.
+  result.messageMatchedExpectedCommand = true;
+  const { sliced: line2, remainder: line2r } = Util.sliceToCRLF(line1r);
+  if (!/^\d{3},\d,\d,\d,\d,\d,\d,\d,\d{8},1,\d{3}$/.test(line2.slice(1, -1))) {
+    // First line matched but not second, incomplete??
+    result.messageIncomplete = true;
+    return result;
+  }
+  const { sliced: line3, remainder: line3r } = Util.sliceToCRLF(line2r);
+  if (!/^\d{4},\d$/.test(line3.slice(1, -1))) {
+    result.messageIncomplete = true;
+    return result;
+  }
+  result.remainder = msg.substring(0, msgStart) + line3r;
 
+  const settingsMsg = {
+    messageType: 'SettingUpdateMessage'
+  } as Cmds.ISettingUpdateMessage
+  const statusMsg = {
+    messageType: 'StatusMessage',
+  } as Cmds.IStatusMessage;
+  const errorMsg = {
+    messageType: 'ErrorMessage',
+    errors: new Cmds.ErrorStateSet()
+  } as Cmds.IErrorMessage;
+
+  const l1 = line1.split(',');
+  // Serial port bitflag
+  if (l1.at(1) === '1') { errorMsg.errors.add(Cmds.ErrorState.MediaEmptyError); }
+  if (l1.at(2) === '1') { errorMsg.errors.add(Cmds.ErrorState.PrinterPaused); }
+  // label length
+  // formats in receive buffer
+  if (l1.at(5) === '1') { errorMsg.errors.add(Cmds.ErrorState.ReceiveBufferFull); }
+  // diag mode
+  // partial format in progress
+  // unused (always 000)
+  // corrupt RAM
+  if (l1.at(10) === '1') { errorMsg.errors.add(Cmds.ErrorState.PrintheadTooCold); }
+  if (l1.at(11) === '1') { errorMsg.errors.add(Cmds.ErrorState.PrintheadTooHot); }
+
+  const l2 = line2.split(',');
+  // function settings
+  // unused
+  if (l2.at(2) === '1') { errorMsg.errors.add(Cmds.ErrorState.PrintheadUp); }
+  if (l2.at(3) === '1') { errorMsg.errors.add(Cmds.ErrorState.RibbonEmptyError); }
+  // thermal transfer mode
+  // print mode???
+  // print width mode
+  if (l2.at(7) === '1') { errorMsg.errors.add(Cmds.ErrorState.LabelWaitingToBeTaken); }
+  // labels remaining in batch
+  // always 1
+  // images stored in memory
+
+  //const l3 = line3.split(',');
+  // password
+  // static ram installed flag
+
+  result.messages = [settingsMsg, statusMsg, errorMsg];
   return result
 }

--- a/src/Languages/Zpl/CmdHostStatus.ts
+++ b/src/Languages/Zpl/CmdHostStatus.ts
@@ -14,6 +14,13 @@ export class CmdHostStatus implements Cmds.IPrinterExtendedCommand {
   constructor() {}
 }
 
+export const cmdHostStatusMapping: Cmds.IPrinterCommandMapping<string> = {
+  commandType: CmdHostStatus.typeE,
+  transpile: handleCmdHostStatus,
+  readMessage: parseCmdHostStatus,
+  formInclusionMode: Cmds.CommandFormInclusionMode.noForm,
+}
+
 export function handleCmdHostStatus(
   _cmd: Cmds.IPrinterCommand,
   _docState: Cmds.TranspiledDocumentState,

--- a/src/Languages/Zpl/CmdXmlQuery.test.ts
+++ b/src/Languages/Zpl/CmdXmlQuery.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { ZD410_FULL_SNAPSHOT, ZD410_XML } from './test_files/index.test.js';
+import { ZD410_FULL_SNAPSHOT, ZD410_CONF_REMAINDER, ZD410_TXT, ZD410_XML } from './test_files/index.test.js';
 import { CmdXmlQuery, parseCmdXmlQuery } from './CmdXmlQuery.js';
 
 describe('parseCmdXmlQueryResponse', () => {
@@ -8,6 +8,18 @@ describe('parseCmdXmlQueryResponse', () => {
     it('Extracts the config', async () => {
       const file = ZD410_XML();
       await expect(parseCmdXmlQuery(file, cmd)).toMatchFileSnapshot(ZD410_FULL_SNAPSHOT);
+    });
+  });
+
+  describe('Partials', () => {
+    const cmd = new CmdXmlQuery('All');
+    it('Handles extra content at the end of the document', async () => {
+      const xml = ZD410_XML();
+      const conf = ZD410_TXT();
+      const prefix = `${conf}${xml}`;
+      const postfix = `${xml}${conf}`;
+      await (expect(parseCmdXmlQuery(postfix, cmd))).toMatchFileSnapshot(ZD410_CONF_REMAINDER);
+      await (expect(parseCmdXmlQuery(prefix, cmd))).toMatchFileSnapshot(ZD410_CONF_REMAINDER);
     });
   });
 });

--- a/src/Languages/Zpl/CmdXmlQuery.test.ts
+++ b/src/Languages/Zpl/CmdXmlQuery.test.ts
@@ -1,13 +1,13 @@
 import { expect, describe, it } from 'vitest';
 import { ZD410_FULL_SNAPSHOT, ZD410_XML } from './test_files/index.test.js';
-import { CmdXmlQuery, parseCmdXmlQueryResponse } from './CmdXmlQuery.js';
+import { CmdXmlQuery, parseCmdXmlQuery } from './CmdXmlQuery.js';
 
 describe('parseCmdXmlQueryResponse', () => {
   describe('Full', () => {
     const cmd = new CmdXmlQuery('All');
     it('Extracts the config', async () => {
       const file = ZD410_XML();
-      await expect(parseCmdXmlQueryResponse(file, cmd)).toMatchFileSnapshot(ZD410_FULL_SNAPSHOT);
+      await expect(parseCmdXmlQuery(file, cmd)).toMatchFileSnapshot(ZD410_FULL_SNAPSHOT);
     });
   });
 });

--- a/src/Languages/Zpl/CmdXmlQuery.ts
+++ b/src/Languages/Zpl/CmdXmlQuery.ts
@@ -106,7 +106,8 @@ export function parseCmdXmlQuery(
     pivotIdx++;
   }
 
-  result.remainder = msg.substring(pivotIdx);
+  // Content before and after should be preserved
+  result.remainder = msg.substring(0, msg.indexOf('<?xml ')) + msg.substring(pivotIdx);
 
   // For reasons I do not understand printers will tend to send _one_ invalid
   // XML line and it looks like
@@ -118,7 +119,7 @@ export function parseCmdXmlQuery(
   // text with a fixed version instead.
   // TODO: Deeper investigation with more printers?
   const rawXml = msg
-    .substring(msg.indexOf('<?xml '), pivotIdx + 1)
+    .substring(msg.indexOf('<?xml '), pivotIdx)
     .replace(
       /^ ENUM='NONE, AUTO DETECT, TAG-IT, ICODE, PICO, ISO15693, EPC, UID'>/gim,
       "<RFID-TYPE ENUM='NONE, AUTO DETECT, TAG-IT, ICODE, PICO, ISO15693, EPC, UID'>"
@@ -131,7 +132,7 @@ export function parseCmdXmlQuery(
   const errorNode = xmlDoc.querySelector('parsererror');
   if (errorNode) {
     throw new Cmds.MessageParsingError(
-      `Error parsing message as XML: '${errorNode.tagName}'`,
+      `Error parsing message as XML: '${errorNode.textContent}'`,
       rawXml
     );
   }

--- a/src/Languages/Zpl/CmdXmlQuery.ts
+++ b/src/Languages/Zpl/CmdXmlQuery.ts
@@ -33,22 +33,28 @@ export class CmdXmlQuery implements Cmds.IPrinterExtendedCommand {
   constructor(public readonly query: CmdXmlQueryType = 'All') {}
 }
 
+export const cmdXmlQueryTypeMapping: Cmds.IPrinterCommandMapping<string> = {
+  commandType: CmdXmlQuery.typeE,
+  transpile: handleCmdXmlQuery,
+  readMessage: parseCmdXmlQuery,
+}
+
 export function handleCmdXmlQuery(
   cmd: Cmds.IPrinterCommand,
   _docState: Cmds.TranspiledDocumentState,
   _commandSet: Cmds.CommandSet<string>
 ): string {
   const command = cmd as CmdXmlQuery;
-  return `^HZ${queryToCmdArg[command.query]}\n`;
+  return `^HZ${queryToCmdArg[command.query]}`;
 }
 
-export function parseCmdXmlQueryResponse(
+export function parseCmdXmlQuery(
   msg: string,
   cmd: Cmds.IPrinterCommand
 ): Cmds.IMessageHandlerResult<string> {
   if (cmd.type !== "CustomCommand" || (cmd as CmdXmlQuery).typeExtended !== CmdXmlQuery.typeE) {
     throw new Cmds.MessageParsingError(
-      `Incorrect command '${cmd.name}' passed to parseCmdXmlQueryResponse, expected 'CmdXmlQuery' instead.`,
+      `Incorrect command '${cmd.name}' passed to parseCmdXmlQuery, expected 'CmdXmlQuery' instead.`,
       msg
     );
   }

--- a/src/Languages/Zpl/Messages.ts
+++ b/src/Languages/Zpl/Messages.ts
@@ -1,22 +1,11 @@
 import * as Conf from '../../Configs/index.js';
 import * as Cmds from '../../Commands/index.js';
-import { CmdXmlQuery, parseCmdXmlQueryResponse } from "./CmdXmlQuery.js";
-import { CmdHostIdentification, parseCmdHostIdentification } from './CmdHostIdentification.js';
-import { CmdHostQuery, parseCmdHostQuery } from './CmdHostQuery.js';
-import { CmdHostStatus, parseCmdHostStatus } from './CmdHostStatus.js';
-import { CmdHostConfig, parseCmdHostConfig } from './CmdHostConfig.js';
-
-const messageHandlerMap = new Map<symbol | Cmds.CommandType, Cmds.MessageHandlerDelegate<string>>([
-  [CmdXmlQuery.typeE, parseCmdXmlQueryResponse], // ~HZ command
-  [CmdHostIdentification.typeE, parseCmdHostIdentification], // ~HI command
-  [CmdHostQuery.typeE, parseCmdHostQuery], // ~HQ command
-  [CmdHostStatus.typeE, parseCmdHostStatus], // ~HS command
-  [CmdHostConfig.typeE, parseCmdHostConfig], // ^HH command
-]);
+import type { ZplPrinterCommandSet } from './ZplPrinterCommandSet.js';
 
 export function handleMessage<TReceived extends Conf.MessageArrayLike>(
+  cmdSet: ZplPrinterCommandSet,
   message: TReceived,
-  sentCommand?: Cmds.IPrinterCommand
+  sentCommand?: Cmds.IPrinterCommand,
 ): Cmds.IMessageHandlerResult<TReceived> {
   const result: Cmds.IMessageHandlerResult<TReceived> = {
     messageIncomplete: false,
@@ -75,7 +64,7 @@ export function handleMessage<TReceived extends Conf.MessageArrayLike>(
     default: {
       // Everything else needs to be fully interpreted, and we need to know the
       // command that was sent to trigger the message.
-      const handled = Cmds.getMessageHandler(messageHandlerMap, msg, sentCommand);
+      const handled = cmdSet.callMessageHandler(msg, sentCommand);
       result.messages.push(...handled.messages);
       result.messageIncomplete = handled.messageIncomplete;
       result.messageMatchedExpectedCommand = handled.messageMatchedExpectedCommand;

--- a/src/Languages/Zpl/Messages.ts
+++ b/src/Languages/Zpl/Messages.ts
@@ -4,12 +4,14 @@ import { CmdXmlQuery, parseCmdXmlQueryResponse } from "./CmdXmlQuery.js";
 import { CmdHostIdentification, parseCmdHostIdentification } from './CmdHostIdentification.js';
 import { CmdHostQuery, parseCmdHostQuery } from './CmdHostQuery.js';
 import { CmdHostStatus, parseCmdHostStatus } from './CmdHostStatus.js';
+import { CmdHostConfig, parseCmdHostConfig } from './CmdHostConfig.js';
 
 const messageHandlerMap = new Map<symbol | Cmds.CommandType, Cmds.MessageHandlerDelegate<string>>([
   [CmdXmlQuery.typeE, parseCmdXmlQueryResponse], // ~HZ command
   [CmdHostIdentification.typeE, parseCmdHostIdentification], // ~HI command
   [CmdHostQuery.typeE, parseCmdHostQuery], // ~HQ command
   [CmdHostStatus.typeE, parseCmdHostStatus], // ~HS command
+  [CmdHostConfig.typeE, parseCmdHostConfig], // ^HH command
 ]);
 
 export function handleMessage<TReceived extends Conf.MessageArrayLike>(

--- a/src/Languages/Zpl/Messages.ts
+++ b/src/Languages/Zpl/Messages.ts
@@ -75,13 +75,7 @@ export function handleMessage<TReceived extends Conf.MessageArrayLike>(
   }
 
   // Put the remainder message back into its native format.
-  if (typeof result.remainder === "string") {
-    result.remainder = Cmds.asString(remainder) as TReceived;
-  } else if (result.remainder instanceof Uint8Array) {
-    result.remainder = remainder as TReceived;
-  } else {
-    throw new Error("Unknown message type not implemented!");
-  }
+  result.remainder = Cmds.asTargetMessageType(remainder, message);
   return result;
 }
 

--- a/src/Languages/Zpl/ZplPrinterCommandSet.ts
+++ b/src/Languages/Zpl/ZplPrinterCommandSet.ts
@@ -6,6 +6,7 @@ import { CmdXmlQuery, handleCmdXmlQuery } from './CmdXmlQuery.js';
 import { CmdHostIdentification, handleCmdHostIdentification } from './CmdHostIdentification.js';
 import { CmdHostQuery, handleCmdHostQuery } from './CmdHostQuery.js';
 import { CmdHostStatus, handleCmdHostStatus } from './CmdHostStatus.js';
+import { CmdHostConfig, handleCmdHostConfig } from './CmdHostConfig.js';
 
 /** Command set for communicating with a ZPL II printer. */
 export class ZplPrinterCommandSet extends Cmds.StringCommandSet {
@@ -18,7 +19,7 @@ export class ZplPrinterCommandSet extends Cmds.StringCommandSet {
   // ^ means form command
   // The pause commands have both versions just to make things fun!
   protected nonFormCommands: (symbol | Cmds.CommandType)[] = [
-    'AutosenseLabelDimensions',
+    'AutosenseMediaDimensions',
     'PrintConfiguration',
     'RebootPrinter',
     'SetDarkness',
@@ -39,6 +40,7 @@ export class ZplPrinterCommandSet extends Cmds.StringCommandSet {
     this.extendedCommandMap.set(CmdHostIdentification.typeE, handleCmdHostIdentification);
     this.extendedCommandMap.set(CmdHostQuery.typeE, handleCmdHostQuery);
     this.extendedCommandMap.set(CmdHostStatus.typeE, handleCmdHostStatus);
+    this.extendedCommandMap.set(CmdHostConfig.typeE, handleCmdHostConfig);
   }
 
   public override expandCommand(cmd: Cmds.IPrinterCommand): Cmds.IPrinterCommand[] {
@@ -50,7 +52,10 @@ export class ZplPrinterCommandSet extends Cmds.StringCommandSet {
       case 'GetStatus':
         return [new CmdHostStatus()];
       case 'QueryConfiguration':
-        return [new CmdXmlQuery('All')];
+        return [
+          new CmdXmlQuery('All'),
+          new CmdHostConfig(),
+        ];
       case 'NewLabel':
         return [
           new Cmds.EndLabel(),
@@ -100,7 +105,7 @@ export class ZplPrinterCommandSet extends Cmds.StringCommandSet {
         return this.setPrintDirectionCommand((cmd as Cmds.SetPrintDirectionCommand).upsideDown);
       case 'SetDarkness':
         return this.setDarknessCommand(cmd as Cmds.SetDarknessCommand, docState);
-      case 'AutosenseLabelDimensions':
+      case 'AutosenseMediaDimensions':
         return '~JC\n';
       case 'SetPrintSpeed':
         return this.setPrintSpeedCommand(cmd as Cmds.SetPrintSpeedCommand, docState);

--- a/src/Languages/Zpl/test_files/ZD410.txt
+++ b/src/Languages/Zpl/test_files/ZD410.txt
@@ -1,68 +1,69 @@
-+21.0               DARKNESS
-MEDIUM              DARKNESS SWITCH
-6.0 IPS             PRINT SPEED
-+000                TEAR OFF ADJUST
-TEAR OFF            PRINT MODE
-MARK                MEDIA TYPE
-REFLECTIVE          SENSOR SELECT
-203                 PRINT WIDTH
-2205                LABEL LENGTH
-10.0IN   253MM      MAXIMUM LENGTH
-MAINT. OFF          EARLY WARNING
-CONNECTED           USB COMM.
-AUTO                SER COMM. MODE
-9600                BAUD
-8 BITS              DATA BITS
-NONE                PARITY
-XON/XOFF            HOST HANDSHAKE
-NONE                PROTOCOL
-NORMAL MODE         COMMUNICATIONS
-<~>  7EH            CONTROL PREFIX
-<^>  5EH            FORMAT PREFIX
-<,>  2CH            DELIMITER CHAR
-ZPL II              ZPL MODE
-INACTIVE            COMMAND OVERRIDE
-NO MOTION           MEDIA POWER UP
-FEED                HEAD CLOSE
-10%                 BACKFEED
-+000                LABEL TOP
-+0000               LEFT POSITION
-DISABLED            REPRINT MODE
-036                 WEB SENSOR
-096                 MEDIA SENSOR
-128                 TAKE LABEL
-050                 MARK SENSOR
-004                 MARK MED SENSOR
-035                 TRANS GAIN
-022                 TRANS LED
-017                 MARK GAIN
-100                 MARK LED
-DPCSWFXM            MODES ENABLED
-........            MODES DISABLED
- 448 8/MM FULL      RESOLUTION
-6.0                 LINK-OS VERSION
-V84.20.18Z <-       FIRMWARE
-1.3                 XML SCHEMA
-6.5.0 0.770         HARDWARE ID
-8192k............R: RAM
-65536k...........E: ONBOARD FLASH
-NONE                FORMAT CONVERT
-ENABLED             IDLE DISPLAY
-12/16/24            RTC DATE
-14:40               RTC TIME
-DISABLED            ZBI
-2.1                 ZBI VERSION
-READY               ZBI STATUS
-7,332 LABELS        NONRESET CNTR
-7,332 LABELS        RESET CNTR1
-7,332 LABELS        RESET CNTR2
-12,555 IN           NONRESET CNTR
-12,543 IN           RESET CNTR1
-12,543 IN           RESET CNTR2
-31,859 CM           NONRESET CNTR
-31,859 CM           RESET CNTR1
-31,859 CM           RESET CNTR2
-003 WIRED           SLOT 1
-0                   MASS STORAGE COUNT
-0                   HID COUNT
-OFF                 USB HOST LOCK OUT
+  +21.0               DARKNESS          
+  MEDIUM              DARKNESS SWITCH   
+  6.0 IPS             PRINT SPEED       
+  +000                TEAR OFF ADJUST   
+  TEAR OFF            PRINT MODE        
+  GAP/NOTCH           MEDIA TYPE        
+  TRANSMISSIVE        SENSOR SELECT     
+  400                 PRINT WIDTH       
+  2205                LABEL LENGTH      
+  2.0IN     50MM      MAXIMUM LENGTH    
+  MAINT. OFF          EARLY WARNING     
+  CONNECTED           USB COMM.         
+  AUTO                SER COMM. MODE    
+  9600                BAUD              
+  8 BITS              DATA BITS         
+  NONE                PARITY            
+  XON/XOFF            HOST HANDSHAKE    
+  NONE                PROTOCOL          
+  NORMAL MODE         COMMUNICATIONS    
+  <~>  7EH            CONTROL PREFIX    
+  <^>  5EH            FORMAT PREFIX     
+  <,>  2CH            DELIMITER CHAR    
+  ZPL II              ZPL MODE          
+  INACTIVE            COMMAND OVERRIDE  
+  NO MOTION           MEDIA POWER UP    
+  FEED                HEAD CLOSE        
+  10%                 BACKFEED          
+  +000                LABEL TOP         
+  +0000               LEFT POSITION     
+  DISABLED            REPRINT MODE      
+  036                 WEB SENSOR        
+  096                 MEDIA SENSOR      
+  128                 TAKE LABEL        
+  050                 MARK SENSOR       
+  004                 MARK MED SENSOR   
+  035                 TRANS GAIN        
+  022                 TRANS LED         
+  017                 MARK GAIN         
+  100                 MARK LED          
+  DPCSWFXM            MODES ENABLED     
+  ........            MODES DISABLED    
+   448 8/MM FULL      RESOLUTION        
+  6.0                 LINK-OS VERSION   
+  V84.20.18Z <-       FIRMWARE          
+  1.3                 XML SCHEMA        
+  6.5.0 0.770         HARDWARE ID       
+  8192k............R: RAM               
+  65536k...........E: ONBOARD FLASH     
+  NONE                FORMAT CONVERT    
+  ENABLED             IDLE DISPLAY      
+  12/29/24            RTC DATE          
+  01:20               RTC TIME          
+  DISABLED            ZBI               
+  2.1                 ZBI VERSION       
+  READY               ZBI STATUS        
+  7,332 LABELS        NONRESET CNTR     
+  7,332 LABELS        RESET CNTR1       
+  7,332 LABELS        RESET CNTR2       
+  12,557 IN           NONRESET CNTR     
+  12,544 IN           RESET CNTR1       
+  12,544 IN           RESET CNTR2       
+  31,863 CM           NONRESET CNTR     
+  31,863 CM           RESET CNTR1       
+  31,863 CM           RESET CNTR2       
+  003 WIRED           SLOT 1            
+  0                   MASS STORAGE COUNT
+  0                   HID COUNT         
+  OFF                 USB HOST LOCK OUT 
+

--- a/src/Languages/Zpl/test_files/ZD410.txt
+++ b/src/Languages/Zpl/test_files/ZD410.txt
@@ -1,0 +1,68 @@
++21.0               DARKNESS
+MEDIUM              DARKNESS SWITCH
+6.0 IPS             PRINT SPEED
++000                TEAR OFF ADJUST
+TEAR OFF            PRINT MODE
+MARK                MEDIA TYPE
+REFLECTIVE          SENSOR SELECT
+203                 PRINT WIDTH
+2205                LABEL LENGTH
+10.0IN   253MM      MAXIMUM LENGTH
+MAINT. OFF          EARLY WARNING
+CONNECTED           USB COMM.
+AUTO                SER COMM. MODE
+9600                BAUD
+8 BITS              DATA BITS
+NONE                PARITY
+XON/XOFF            HOST HANDSHAKE
+NONE                PROTOCOL
+NORMAL MODE         COMMUNICATIONS
+<~>  7EH            CONTROL PREFIX
+<^>  5EH            FORMAT PREFIX
+<,>  2CH            DELIMITER CHAR
+ZPL II              ZPL MODE
+INACTIVE            COMMAND OVERRIDE
+NO MOTION           MEDIA POWER UP
+FEED                HEAD CLOSE
+10%                 BACKFEED
++000                LABEL TOP
++0000               LEFT POSITION
+DISABLED            REPRINT MODE
+036                 WEB SENSOR
+096                 MEDIA SENSOR
+128                 TAKE LABEL
+050                 MARK SENSOR
+004                 MARK MED SENSOR
+035                 TRANS GAIN
+022                 TRANS LED
+017                 MARK GAIN
+100                 MARK LED
+DPCSWFXM            MODES ENABLED
+........            MODES DISABLED
+ 448 8/MM FULL      RESOLUTION
+6.0                 LINK-OS VERSION
+V84.20.18Z <-       FIRMWARE
+1.3                 XML SCHEMA
+6.5.0 0.770         HARDWARE ID
+8192k............R: RAM
+65536k...........E: ONBOARD FLASH
+NONE                FORMAT CONVERT
+ENABLED             IDLE DISPLAY
+12/16/24            RTC DATE
+14:40               RTC TIME
+DISABLED            ZBI
+2.1                 ZBI VERSION
+READY               ZBI STATUS
+7,332 LABELS        NONRESET CNTR
+7,332 LABELS        RESET CNTR1
+7,332 LABELS        RESET CNTR2
+12,555 IN           NONRESET CNTR
+12,543 IN           RESET CNTR1
+12,543 IN           RESET CNTR2
+31,859 CM           NONRESET CNTR
+31,859 CM           RESET CNTR1
+31,859 CM           RESET CNTR2
+003 WIRED           SLOT 1
+0                   MASS STORAGE COUNT
+0                   HID COUNT
+OFF                 USB HOST LOCK OUT

--- a/src/Languages/Zpl/test_files/ZD410_CONF_REMAINDER.ts.snap
+++ b/src/Languages/Zpl/test_files/ZD410_CONF_REMAINDER.ts.snap
@@ -46,72 +46,73 @@
       },
     },
   ],
-  "remainder": "+21.0               DARKNESS
-MEDIUM              DARKNESS SWITCH
-6.0 IPS             PRINT SPEED
-+000                TEAR OFF ADJUST
-TEAR OFF            PRINT MODE
-MARK                MEDIA TYPE
-REFLECTIVE          SENSOR SELECT
-203                 PRINT WIDTH
-2205                LABEL LENGTH
-10.0IN   253MM      MAXIMUM LENGTH
-MAINT. OFF          EARLY WARNING
-CONNECTED           USB COMM.
-AUTO                SER COMM. MODE
-9600                BAUD
-8 BITS              DATA BITS
-NONE                PARITY
-XON/XOFF            HOST HANDSHAKE
-NONE                PROTOCOL
-NORMAL MODE         COMMUNICATIONS
-<~>  7EH            CONTROL PREFIX
-<^>  5EH            FORMAT PREFIX
-<,>  2CH            DELIMITER CHAR
-ZPL II              ZPL MODE
-INACTIVE            COMMAND OVERRIDE
-NO MOTION           MEDIA POWER UP
-FEED                HEAD CLOSE
-10%                 BACKFEED
-+000                LABEL TOP
-+0000               LEFT POSITION
-DISABLED            REPRINT MODE
-036                 WEB SENSOR
-096                 MEDIA SENSOR
-128                 TAKE LABEL
-050                 MARK SENSOR
-004                 MARK MED SENSOR
-035                 TRANS GAIN
-022                 TRANS LED
-017                 MARK GAIN
-100                 MARK LED
-DPCSWFXM            MODES ENABLED
-........            MODES DISABLED
- 448 8/MM FULL      RESOLUTION
-6.0                 LINK-OS VERSION
-V84.20.18Z <-       FIRMWARE
-1.3                 XML SCHEMA
-6.5.0 0.770         HARDWARE ID
-8192k............R: RAM
-65536k...........E: ONBOARD FLASH
-NONE                FORMAT CONVERT
-ENABLED             IDLE DISPLAY
-12/16/24            RTC DATE
-14:40               RTC TIME
-DISABLED            ZBI
-2.1                 ZBI VERSION
-READY               ZBI STATUS
-7,332 LABELS        NONRESET CNTR
-7,332 LABELS        RESET CNTR1
-7,332 LABELS        RESET CNTR2
-12,555 IN           NONRESET CNTR
-12,543 IN           RESET CNTR1
-12,543 IN           RESET CNTR2
-31,859 CM           NONRESET CNTR
-31,859 CM           RESET CNTR1
-31,859 CM           RESET CNTR2
-003 WIRED           SLOT 1
-0                   MASS STORAGE COUNT
-0                   HID COUNT
-OFF                 USB HOST LOCK OUT",
+  "remainder": "  +21.0               DARKNESS          
+  MEDIUM              DARKNESS SWITCH   
+  6.0 IPS             PRINT SPEED       
+  +000                TEAR OFF ADJUST   
+  TEAR OFF            PRINT MODE        
+  GAP/NOTCH           MEDIA TYPE        
+  TRANSMISSIVE        SENSOR SELECT     
+  400                 PRINT WIDTH       
+  2205                LABEL LENGTH      
+  2.0IN     50MM      MAXIMUM LENGTH    
+  MAINT. OFF          EARLY WARNING     
+  CONNECTED           USB COMM.         
+  AUTO                SER COMM. MODE    
+  9600                BAUD              
+  8 BITS              DATA BITS         
+  NONE                PARITY            
+  XON/XOFF            HOST HANDSHAKE    
+  NONE                PROTOCOL          
+  NORMAL MODE         COMMUNICATIONS    
+  <~>  7EH            CONTROL PREFIX    
+  <^>  5EH            FORMAT PREFIX     
+  <,>  2CH            DELIMITER CHAR    
+  ZPL II              ZPL MODE          
+  INACTIVE            COMMAND OVERRIDE  
+  NO MOTION           MEDIA POWER UP    
+  FEED                HEAD CLOSE        
+  10%                 BACKFEED          
+  +000                LABEL TOP         
+  +0000               LEFT POSITION     
+  DISABLED            REPRINT MODE      
+  036                 WEB SENSOR        
+  096                 MEDIA SENSOR      
+  128                 TAKE LABEL        
+  050                 MARK SENSOR       
+  004                 MARK MED SENSOR   
+  035                 TRANS GAIN        
+  022                 TRANS LED         
+  017                 MARK GAIN         
+  100                 MARK LED          
+  DPCSWFXM            MODES ENABLED     
+  ........            MODES DISABLED    
+   448 8/MM FULL      RESOLUTION        
+  6.0                 LINK-OS VERSION   
+  V84.20.18Z <-       FIRMWARE          
+  1.3                 XML SCHEMA        
+  6.5.0 0.770         HARDWARE ID       
+  8192k............R: RAM               
+  65536k...........E: ONBOARD FLASH     
+  NONE                FORMAT CONVERT    
+  ENABLED             IDLE DISPLAY      
+  12/29/24            RTC DATE          
+  01:20               RTC TIME          
+  DISABLED            ZBI               
+  2.1                 ZBI VERSION       
+  READY               ZBI STATUS        
+  7,332 LABELS        NONRESET CNTR     
+  7,332 LABELS        RESET CNTR1       
+  7,332 LABELS        RESET CNTR2       
+  12,557 IN           NONRESET CNTR     
+  12,544 IN           RESET CNTR1       
+  12,544 IN           RESET CNTR2       
+  31,863 CM           NONRESET CNTR     
+  31,863 CM           RESET CNTR1       
+  31,863 CM           RESET CNTR2       
+  003 WIRED           SLOT 1            
+  0                   MASS STORAGE COUNT
+  0                   HID COUNT         
+  OFF                 USB HOST LOCK OUT 
+",
 }

--- a/src/Languages/Zpl/test_files/ZD410_CONF_REMAINDER.ts.snap
+++ b/src/Languages/Zpl/test_files/ZD410_CONF_REMAINDER.ts.snap
@@ -1,0 +1,117 @@
+{
+  "messageIncomplete": false,
+  "messageMatchedExpectedCommand": true,
+  "messages": [
+    {
+      "messageType": "SettingUpdateMessage",
+      "printerHardware": {
+        "dpi": 200,
+        "firmware": "V84.20.18Z",
+        "maxMediaDarkness": 30,
+        "maxMediaLengthDots": 7967,
+        "maxMediaWidthDots": 448,
+        "model": "ZD410",
+        "speedTable": SpeedTable {
+          "speedTable": Map {
+            0 => 0,
+            1 => 2,
+            1000 => 6,
+            4 => 2,
+            6 => 3,
+            8 => 4,
+            9 => 5,
+            10 => 6,
+          },
+        },
+      },
+      "printerMedia": {
+        "darknessPercent": 67,
+        "mediaGapDetectMode": 1,
+        "mediaLengthDots": 200,
+        "mediaPrintMode": 0,
+        "mediaPrintOriginOffsetDots": {
+          "left": 0,
+          "top": 0,
+        },
+        "mediaWidthDots": 400,
+        "printOrientation": 0,
+        "speed": PrintSpeedSettings {
+          "printSpeed": 10,
+          "slewSpeed": 10,
+        },
+        "thermalPrintMode": 0,
+      },
+      "printerSettings": {
+        "backfeedAfterTaken": "disabled",
+      },
+    },
+  ],
+  "remainder": "+21.0               DARKNESS
+MEDIUM              DARKNESS SWITCH
+6.0 IPS             PRINT SPEED
++000                TEAR OFF ADJUST
+TEAR OFF            PRINT MODE
+MARK                MEDIA TYPE
+REFLECTIVE          SENSOR SELECT
+203                 PRINT WIDTH
+2205                LABEL LENGTH
+10.0IN   253MM      MAXIMUM LENGTH
+MAINT. OFF          EARLY WARNING
+CONNECTED           USB COMM.
+AUTO                SER COMM. MODE
+9600                BAUD
+8 BITS              DATA BITS
+NONE                PARITY
+XON/XOFF            HOST HANDSHAKE
+NONE                PROTOCOL
+NORMAL MODE         COMMUNICATIONS
+<~>  7EH            CONTROL PREFIX
+<^>  5EH            FORMAT PREFIX
+<,>  2CH            DELIMITER CHAR
+ZPL II              ZPL MODE
+INACTIVE            COMMAND OVERRIDE
+NO MOTION           MEDIA POWER UP
+FEED                HEAD CLOSE
+10%                 BACKFEED
++000                LABEL TOP
++0000               LEFT POSITION
+DISABLED            REPRINT MODE
+036                 WEB SENSOR
+096                 MEDIA SENSOR
+128                 TAKE LABEL
+050                 MARK SENSOR
+004                 MARK MED SENSOR
+035                 TRANS GAIN
+022                 TRANS LED
+017                 MARK GAIN
+100                 MARK LED
+DPCSWFXM            MODES ENABLED
+........            MODES DISABLED
+ 448 8/MM FULL      RESOLUTION
+6.0                 LINK-OS VERSION
+V84.20.18Z <-       FIRMWARE
+1.3                 XML SCHEMA
+6.5.0 0.770         HARDWARE ID
+8192k............R: RAM
+65536k...........E: ONBOARD FLASH
+NONE                FORMAT CONVERT
+ENABLED             IDLE DISPLAY
+12/16/24            RTC DATE
+14:40               RTC TIME
+DISABLED            ZBI
+2.1                 ZBI VERSION
+READY               ZBI STATUS
+7,332 LABELS        NONRESET CNTR
+7,332 LABELS        RESET CNTR1
+7,332 LABELS        RESET CNTR2
+12,555 IN           NONRESET CNTR
+12,543 IN           RESET CNTR1
+12,543 IN           RESET CNTR2
+31,859 CM           NONRESET CNTR
+31,859 CM           RESET CNTR1
+31,859 CM           RESET CNTR2
+003 WIRED           SLOT 1
+0                   MASS STORAGE COUNT
+0                   HID COUNT
+OFF                 USB HOST LOCK OUT",
+}

--- a/src/Languages/Zpl/test_files/index.test.ts
+++ b/src/Languages/Zpl/test_files/index.test.ts
@@ -10,4 +10,9 @@ describe('Files exist', () => {
 export const ZD410_XML = () => {
   return fs.readFileSync('./src/Languages/Zpl/test_files/ZD410.xml', { encoding: 'utf-8'});
 }
-export const ZD410_FULL_SNAPSHOT = "./test_files/ZD410.ts.snap"
+export const ZD410_FULL_SNAPSHOT = "./test_files/ZD410.ts.snap";
+
+export const ZD410_TXT = () => {
+  return fs.readFileSync('./src/Languages/Zpl/test_files/ZD410.txt', { encoding: 'utf-8'});
+}
+export const ZD410_CONF_REMAINDER = "./test_files/ZD410_CONF_REMAINDER.ts.snap";

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -259,7 +259,7 @@ export class LabelPrinter<TChannelType extends Conf.MessageArrayLike> extends Ev
       Conf.PrinterCommandLanguage.cpcl
     ];
 
-    const doc = { commands: [new Cmds.GetStatusCommand()]} as Docs.IDocument
+    const doc = { commands: [new Cmds.IdentifyDeviceCommand()]} as Docs.IDocument
     const awaitedTimeoutOriginal = this._awaitedCommandTimeoutMS;
 
     // For each language, we send the appropriate command to try and get the
@@ -276,7 +276,7 @@ export class LabelPrinter<TChannelType extends Conf.MessageArrayLike> extends Ev
       // to the query we made. Sending a status query will be an awaited command
       // and the message parser will make sure it's a valid response to what we
       // asked. If we time out waiting for the response we move on to the next.
-      this._awaitedCommandTimeoutMS = 1000;
+      this._awaitedCommandTimeoutMS = 1500;
       this._commandSet = set;
 
       try {

--- a/src/Util/NumericRange.test.ts
+++ b/src/Util/NumericRange.test.ts
@@ -1,16 +1,36 @@
-import { test, expect, describe } from 'vitest';
-import { clampToRange } from './NumericRange.js';
+import { it, expect, describe } from 'vitest';
+import { clampToRange, numberInRange, repeat } from './NumericRange.js';
 
-describe("clampToRange tests", () => {
-  test('high number is clamped down', () => {
+describe("clampToRange", () => {
+  it('high number is clamped down', () => {
     expect(clampToRange(5, 0, 2)).toBe(2);
   });
 
-  test('low number is clamped up', () => {
+  it('low number is clamped up', () => {
     expect(clampToRange(-1, 0, 5)).toBe(0);
   });
 
-  test('in-range number is not modified', () => {
+  it('in-range number is not modified', () => {
     expect(clampToRange(3, 0, 5)).toBe(3);
   });
 });
+
+describe('numberInRange', () => {
+  it('Returns numbers in the range', () => {
+    expect(numberInRange("1", 0, 2)).toBe(1);
+    expect(numberInRange("-1", -5, 5)).toBe(-1);
+    expect(numberInRange("0", 0, 0)).toBe(0);
+  });
+  it('Returns undefined for out of range', () => {
+    expect(numberInRange("nope")).toBe(undefined);
+    expect(numberInRange("-1", 0)).toBe(undefined);
+    expect(numberInRange("0", -2, -1)).toBe(undefined);
+    expect(numberInRange("5", 6, 4)).toBe(undefined);
+  });
+});
+
+describe('repeat', () => {
+  it('Repeats', () => {
+    expect(repeat("a", 5)).toStrictEqual(["a", "a", "a", "a", "a"]);
+  })
+})

--- a/src/Util/NumericRange.ts
+++ b/src/Util/NumericRange.ts
@@ -20,7 +20,7 @@ export function numberInRange(
   str: string,
   min?: number,
   max?: number) {
-  if (!/^\d+$/.test(str)) {
+  if (!/^[+-]?\d+$/.test(str)) {
     return;
   }
   const val = Number(str);

--- a/src/Util/StringUtils.test.ts
+++ b/src/Util/StringUtils.test.ts
@@ -1,0 +1,75 @@
+import { expect, describe, it } from 'vitest';
+import { AsciiCodeNumbers } from './ASCII.js';
+import { sliceToCRLF, sliceToNewline } from './StringUtils.js';
+
+describe('sliceToNewline', () => {
+  it('Finds a newline', () => {
+    const msg = new Uint8Array([
+      AsciiCodeNumbers.STX,
+      AsciiCodeNumbers.LF,
+      AsciiCodeNumbers.ETX
+    ]);
+    expect(sliceToNewline(msg)).toMatchInlineSnapshot(`
+      {
+        "remainder": Uint8Array [
+          3,
+        ],
+        "sliced": Uint8Array [
+          2,
+          10,
+        ],
+      }
+    `);
+  });
+  it('Handles no newlines gracefully', () => {
+    expect(sliceToNewline(new Uint8Array())).toMatchInlineSnapshot(`
+      {
+        "remainder": Uint8Array [],
+        "sliced": Uint8Array [],
+      }
+    `);
+    expect(sliceToNewline(undefined!)).toMatchInlineSnapshot(`
+      {
+        "remainder": Uint8Array [],
+        "sliced": Uint8Array [],
+      }
+    `);
+  });
+});
+
+describe('sliceToCRLF', () => {
+  it('Finds a newline', () => {
+    expect(sliceToCRLF("hello\r\ngoodbye")).toMatchInlineSnapshot(`
+      {
+        "remainder": "goodbye",
+        "sliced": "hello",
+      }
+    `);
+    expect(sliceToCRLF("hello\ngoodbye")).toMatchInlineSnapshot(`
+      {
+        "remainder": "goodbye",
+        "sliced": "hello",
+      }
+    `);
+  });
+  it('Handles no newlines', () => {
+    expect(sliceToCRLF("hello")).toMatchInlineSnapshot(`
+      {
+        "remainder": "hello",
+        "sliced": "",
+      }
+    `);
+    expect(sliceToCRLF("")).toMatchInlineSnapshot(`
+      {
+        "remainder": "",
+        "sliced": "",
+      }
+    `);
+    expect(sliceToCRLF(undefined!)).toMatchInlineSnapshot(`
+      {
+        "remainder": "",
+        "sliced": "",
+      }
+    `);
+  });
+});

--- a/src/Util/StringUtils.ts
+++ b/src/Util/StringUtils.ts
@@ -1,0 +1,67 @@
+import { AsciiCodeNumbers } from "./ASCII.js";
+
+/**
+ * Slice an array from the start to the first LF character, returning both pieces.
+ *
+ * If no LF character is found sliced will have a length of 0.
+ *
+ * CR characters are not removed if present!
+ */
+export function sliceToNewline(msg: Uint8Array): {
+  sliced: Uint8Array,
+  remainder: Uint8Array,
+} {
+  if (msg === undefined) {
+    return {
+      sliced: new Uint8Array(),
+      remainder: new Uint8Array()
+    }
+  }
+  
+  const idx = msg.indexOf(AsciiCodeNumbers.LF);
+  if (idx === -1) {
+    return {
+      sliced: new Uint8Array(),
+      remainder: msg
+    }
+  }
+
+  return {
+    sliced: msg.slice(0, idx + 1),
+    remainder: msg.slice(idx + 1),
+  };
+}
+
+/** Slice a string from the start to the first CRLF or LF, returning both pieces. */
+export function sliceToCRLF(msg: string): {
+  sliced: string,
+  remainder: string,
+} {
+  if (msg === undefined) {
+    return {
+      sliced: "",
+      remainder: ""
+    }
+  }
+
+  const cr = msg.indexOf('\r\n');
+  if (cr !== -1) {
+    return {
+      sliced: msg.substring(0, cr),
+      remainder: msg.substring(cr + 2)
+    }
+  }
+
+  const lf = msg.indexOf('\n');
+  if (lf !== -1) {
+    return {
+      sliced: msg.substring(0, lf),
+      remainder: msg.substring(lf + 1)
+    }
+  }
+
+  return {
+    sliced: "",
+    remainder: msg
+  }
+}

--- a/src/Util/index.ts
+++ b/src/Util/index.ts
@@ -2,4 +2,5 @@ export * from './ASCII.js';
 export * from './BitmapGRF.js';
 export * from './EnumUtils.js';
 export * from './NumericRange.js';
+export * from './StringUtils.js';
 export * from './WebZlpError.js';


### PR DESCRIPTION
Two structural changes:

### Improved message handling

ZPL breaks some assumptions this library made with the order of message responses. The handling code was originally designed for ESC/POS, which has a simple "ask a question get an answer" exchange format. ZPL however allows you to ask multiple questions, and the answers may come back in a different order than you expected.

The message handling code has been improved to be more selective about picking out exactly what it wants. I'm not very happy with the amount of manual work each ZPL message handler is currently doing, it feels like some of it can be abstracted more later on. Tests have been added to better cover common scenarios.

Most testing has been done against a ZD410 unit, I've gotten more mysterious responses from a ZD411 that needs additional testing.

### Better command handler layout

I never quite liked the switch/case setup for the command language methods. Not only did it make it difficult to add 'extended' commands, it was difficult to juggle the command transpiler, the response message handler, and possible replacement commands in separate locations. The CommandSet class now expects a Record of all standard command types. This preserves the typechecked completeness of the standard command pool, while easily being extended with additional commands by adding to the map. 

I'd like to make it cleaner to write as well. This should make implementing additional languages much easier.