### PR TITLE
Split things out for more testability

### DIFF
--- a/src/Commands/Messages.ts
+++ b/src/Commands/Messages.ts
@@ -96,17 +96,13 @@ export type AwaitedCommand = {
   reject?: (reason?: unknown) => void,
 }
 
-export type UpdateClass<Type> = {
-  -readonly [Property in keyof Type]?: Type[Property];
-};
-
 /** A printer settings message, describing printer configuration status. */
 export interface ISettingUpdateMessage {
   messageType: 'SettingUpdateMessage';
 
-  printerHardware?: UpdateClass<Conf.IPrinterHardware>;
-  printerMedia   ?: UpdateClass<Conf.IPrinterMedia>;
-  printerSettings?: UpdateClass<Conf.IPrinterSettings>;
+  printerHardware?: Conf.UpdateFor<Conf.IPrinterHardware>;
+  printerMedia   ?: Conf.UpdateFor<Conf.IPrinterMedia>;
+  printerSettings?: Conf.UpdateFor<Conf.IPrinterSettings>;
 }
 
 /** A status message sent by the printer. */

--- a/src/Configs/ConfigurationTypes.ts
+++ b/src/Configs/ConfigurationTypes.ts
@@ -1,5 +1,10 @@
 import * as Util from '../Util/index.js';
 
+/** Utility type to create an 'update' object, making all properties optional and not readonly. */
+export type UpdateFor<Type> = {
+  -readonly [Property in keyof Type]?: Type[Property];
+};
+
 /** The darkness of the printer setting, higher being printing darker. */
 export type DarknessPercent = Util.Percent;
 
@@ -245,18 +250,6 @@ export interface IPrinterHardware {
   readonly speedTable: SpeedTable;
 }
 
-export interface IPrinterHardwareUpdate {
-  dpi?: number;
-  firmware?: string;
-  manufacturer?: string;
-  model?: string;
-  maxMediaWidthDots?: number;
-  maxMediaLengthDots?: number;
-  maxMediaDarkness?: number,
-  serialNumber?: string;
-  speedTable?: SpeedTable;
-}
-
 /** Settings for printer behavior */
 export interface IPrinterSettings {
   /** What percentage of backfeed happens after cutting/taking label, vs before printing. */
@@ -264,11 +257,6 @@ export interface IPrinterSettings {
 
   /** The behavior when pressing the feed button on the printer. */
   readonly feedButtonMode: FeedButtonMode;
-}
-
-export interface IPrinterSettingsUpdate {
-  backfeedAfterTaken?: BackfeedAfterTaken;
-  feedButtonMode?: FeedButtonMode;
 }
 
 /** Printer options related to the media media being printed */
@@ -325,20 +313,4 @@ export interface IPrinterMedia {
 
   /** Whether the media prints right-side-up or upside-down. */
   printOrientation: PrintOrientation;
-}
-
-export interface IPrinterMediaUpdate {
-  darknessPercent?: DarknessPercent;
-  mediaGapDetectMode?: MediaMediaGapDetectionMode;
-  mediaGapDots?: number;
-  mediaLineOffsetDots?: number;
-  mediaLengthDots?: number;
-  mediaWidthDots?: number;
-  mediaPrintOriginOffsetDots?: Coordinate;
-  mediaDimensionRoundingStep?: number;
-  thermalPrintMode?: ThermalPrintMode;
-  mediaPrintMode?: MediaPrintMode;
-  printOrientation?: PrintOrientation;
-
-  speed?: PrintSpeedSettings;
 }

--- a/src/Languages/Epl/BasicCommands.test.ts
+++ b/src/Languages/Epl/BasicCommands.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, it } from 'vitest';
 import * as Util from '../../Util/index.js';
 import * as Cmds from '../../Commands/index.js';
-import { EplPrinterCommandSet } from './index.js';
+import { addImageCommand } from './BasicCommands.js';
 
 // Class pulled from jest-mock-canvas which I can't seem to actually import.
 class ImageData {
@@ -83,15 +83,13 @@ function getImageDataInput(width: number, height: number, fill: number, alpha?: 
   return arr;
 }
 
-
-describe('EPL Image Conversion', () => {
+describe('addImageCommand', () => {
   it('Should convert blank images to valid command', () => {
-    const cmdSet = new EplPrinterCommandSet();
     const imageData = new ImageData(getImageDataInput(8, 1, 0), 8, 1);
     const bitmap = Util.BitmapGRF.fromCanvasImageData(imageData, { trimWhitespace: false });
     const cmd = new Cmds.AddImageCommand(bitmap, {});
     const doc = Cmds.getNewTranspileState(new Cmds.PrinterConfig());
-    const resultCmd = cmdSet['addImageCommand'](cmd, doc);
+    const resultCmd = addImageCommand(cmd, doc);
 
     const expectedCmd = 'GW0,0,1,1,ÿ\r\n';
 
@@ -99,7 +97,6 @@ describe('EPL Image Conversion', () => {
   });
 
   it('Should apply offsets in command', () => {
-    const cmdSet = new EplPrinterCommandSet();
     const imageData = new ImageData(getImageDataInput(8, 1, 0), 8, 1);
     const bitmap = Util.BitmapGRF.fromCanvasImageData(imageData, { trimWhitespace: false });
     const cmd = new Cmds.AddImageCommand(bitmap, {});
@@ -107,10 +104,11 @@ describe('EPL Image Conversion', () => {
     const doc = Cmds.getNewTranspileState(new Cmds.PrinterConfig());
     doc.horizontalOffset = appliedOffset;
     doc.verticalOffset = appliedOffset * 2;
-    const resultCmd = cmdSet['addImageCommand'](cmd, doc);
+    const resultCmd = addImageCommand(cmd, doc);
 
     const expectedCmd = `GW${appliedOffset},${appliedOffset * 2},1,1,ÿ\r\n`;
 
     expect(resultCmd).toEqual(expectedCmd);
   });
+
 });

--- a/src/Languages/Epl/BasicCommands.ts
+++ b/src/Languages/Epl/BasicCommands.ts
@@ -1,0 +1,295 @@
+import * as Util from '../../Util/index.js';
+import * as Conf from '../../Configs/index.js';
+import * as Cmds from '../../Commands/index.js';
+
+export function setBackfeedAfterTaken(
+  mode: Conf.BackfeedAfterTaken
+): string {
+  if (mode === 'disabled') {
+    // TODO: Does JC matter? It's only supported on 28X4
+    // Send JB first for universal support and JC after just in case?
+    return `JB\r\nJC\r\n`
+  } else {
+    // EPL doesn't support percentages so just turn it on.
+    return `JF\r\n`;
+  }
+}
+
+export function setPrintDirectionCommand(
+  upsideDown: boolean
+): string {
+  const dir = upsideDown ? 'T' : 'B';
+  return `Z${dir}` + '\r\n';
+}
+
+export function setDarknessCommand(
+  cmd: Cmds.SetDarknessCommand,
+  docState: Cmds.TranspiledDocumentState
+): string {
+  const percent = cmd.darknessPercent / 100.0;
+  const dark = Math.ceil(percent * docState.initialConfig.maxMediaDarkness);
+  return `D${dark}` + '\r\n';
+}
+
+export function setPrintSpeedCommand(
+  cmd: Cmds.SetPrintSpeedCommand,
+  docState: Cmds.TranspiledDocumentState
+): string {
+  const table = docState.initialConfig.speedTable;
+  const printSpeed = table.toRawSpeed(cmd.speed);
+  // Validation should have happened on setup, printer will just reject
+  // invalid speeds.
+  return `S${printSpeed}` + '\r\n';
+}
+
+export function setLabelDimensionsCommand(
+  cmd: Cmds.SetLabelDimensionsCommand,
+): string {
+  const width = Math.trunc(cmd.widthInDots);
+  let outCmd = `q${width}` + '\r\n';
+
+  if (cmd.setsLength && cmd.lengthInDots !== undefined && cmd.gapLengthInDots !== undefined) {
+    const length = Math.trunc(cmd.lengthInDots);
+    const gap = Math.trunc(cmd.gapLengthInDots);
+    outCmd += `Q${length},${gap}` + '\r\n';
+  }
+
+  return outCmd;
+}
+
+export function setLabelHomeCommand(
+  cmd: Cmds.SetLabelHomeCommand,
+  outDoc: Cmds.TranspiledDocumentState
+): string {
+  Cmds.applyOffsetToDocState(
+    new Cmds.OffsetCommand(cmd.offset.left, cmd.offset.top, true),
+    outDoc
+  );
+  return '';
+}
+
+export function setLabelPrintOriginOffsetCommand(
+  cmd: Cmds.SetLabelPrintOriginOffsetCommand,
+): string {
+  const xOffset = Math.trunc(cmd.offset.left);
+  const yOffset = Math.trunc(cmd.offset.top);
+  return `R${xOffset},${yOffset}` + '\r\n';
+}
+
+export function setLabelToContinuousMediaCommand(
+  cmd: Cmds.SetMediaToContinuousMediaCommand,
+  conf: Cmds.PrinterConfig,
+): string {
+  return setMediaTrackingMode(conf, {
+    mode: 'continuous',
+    formGapFeed: Util.clampToRange(Math.trunc(cmd.formGapInDots), 0, 65535),
+  });
+}
+
+export function setLabelToWebGapMediaCommand(
+  cmd: Cmds.SetMediaToWebGapMediaCommand,
+  conf: Cmds.PrinterConfig,
+): string {
+  const length = Util.clampToRange(Math.trunc(cmd.mediaLengthInDots), 24, 65535);
+  const minGap = conf.dpi === 300 ? 18 : 16;
+  return setMediaTrackingMode(conf, {
+    mode: 'web',
+    length,
+    gapLength: Util.clampToRange(Math.trunc(cmd.mediaGapInDots), minGap, 240),
+    gapOffset: Util.clampToRange(Math.trunc(cmd.mediaGapOffsetInDots), 0, length),
+  });
+}
+
+export function setLabelToMarkMediaCommand(
+  cmd: Cmds.SetMediaToMarkMediaCommand,
+  conf: Cmds.PrinterConfig,
+): string {
+  const length = Util.clampToRange(Math.trunc(cmd.mediaLengthInDots), 24, 65535);
+  const minLine = conf.dpi === 300 ? 18 : 16;
+  return setMediaTrackingMode(conf, {
+    mode: 'mark',
+    length,
+    blackLength: Util.clampToRange(Math.trunc(cmd.blackLineThicknessInDots), minLine, 240),
+    blackOffset: Util.clampToRange(Math.trunc(cmd.blackLineOffset), 0, length),
+  });
+}
+
+export function setMediaTrackingMode(
+  conf: Cmds.PrinterConfig,
+  mode: {
+    mode: 'web'
+    length: number,
+    gapLength: number,
+    gapOffset: number,
+  } | {
+    mode: 'continuous'
+    formGapFeed: number,
+  } | {
+    mode: 'mark',
+    length: number,
+    blackLength: number,
+    blackOffset: number,
+  }
+) {
+  switch (mode.mode) {
+    case 'web': {
+      // Length is the label length, marker is gap length
+      // Marker offset is additional dots 'down' into the label. If a notch is
+      // 4mm 'down' from the true edge then 4mm * 8 dots = 24 offset.
+      // Q123,24+24
+      const offset = mode.gapOffset === 0 ? '' : ('+' + mode.gapOffset);
+      return `Q${mode.length},${mode.gapLength}${offset}\r\n` +
+        setHardwareMode(conf, { reverseSensor: false });
+    }
+    case 'mark': {
+      // Length is distance between black line marks.
+      // Marker length is the length of the black line mark.
+      // Marker offset is the distance from the end of the black mark to the
+      // perforation point. Positive is 'down' into the black line, positive
+      // is 'up' into the label.
+      // TODO: validate that statement...
+      // Q123,B24-156
+      let offset = '';
+      if (mode.blackOffset < 0) {
+        offset = '-' + mode.blackOffset;
+      } else if (mode.blackOffset > 0) {
+        offset = '+' + mode.blackOffset;
+      }
+      return `Q${mode.length},B${mode.blackLength}${offset}\r\n` +
+        setHardwareMode(conf, { reverseSensor: true });
+    }
+    case 'continuous':
+      // Form length is variable, we just use the gap between forms.
+      // Q24,0
+      return `Q${mode.formGapFeed},0\r\n` +
+        setHardwareMode(conf, { reverseSensor: false });
+  }
+}
+
+export function setHardwareMode(
+  config: Cmds.PrinterConfig,
+  modify: {
+    // TODO: Support C{num} batching
+    cutter?: 'off' | 'on' | 'cmd',
+    directThermal?: Conf.ThermalPrintMode,
+    labelTaken?: boolean,
+    reverseSensor?: boolean,
+    feedButton?: Conf.FeedButtonMode
+}) {
+  // The EPL 'O' command is stateless, if you try to change one setting it resets
+  // the other settings to defaults. To properly modify a setting you must supply
+  // the other current settings too.
+  // The parameters for this function are overrides, we default to current set
+  // values from the printer for the rest.
+
+  // Cutter - C, Cb, C{batch}
+  let c = '';
+  if (modify.cutter === undefined) {
+    switch (config.mediaPrintMode) {
+      case Conf.MediaPrintMode.cutter:
+        c = 'C';
+        break;
+      case Conf.MediaPrintMode.cutterWaitForCommand:
+        c = 'Cb';
+        break;
+    }
+  } else if (modify.cutter === 'on') {
+    c = 'C';
+  } else if (modify.cutter === 'cmd') {
+    c = 'Cb';
+  }
+
+  // Direct thermal - D, <blank>
+  const directThermal = modify.directThermal ?? config.thermalPrintMode === Conf.ThermalPrintMode.direct;
+  const d = directThermal ? 'D' : '';
+
+  // Label taken sensor - P, <blank>
+  const labelTaken = modify.labelTaken ?? (
+    config.mediaPrintMode === Conf.MediaPrintMode.peel
+    || config.mediaPrintMode === Conf.MediaPrintMode.peelWithPrePeel)
+  let p = labelTaken ? 'P' : '';
+
+  // Reverse sensor - S, <blank>
+  const revSensor = modify.reverseSensor ?? config.mediaGapDetectMode === Conf.MediaMediaGapDetectionMode.markSensing;
+  const s = revSensor ? 'S' : '';
+
+  const feedButton = modify.feedButton ?? config.feedButtonMode;
+  let l = '';
+  let f = 'Ff';
+  if (feedButton === 'disabled') {
+    f = 'Fi';
+  } else if (feedButton === 'tapToReprint') {
+    f = 'Fr';
+  } else if (feedButton === 'tapToPrint') {
+    // Special mode, overrides label taken sensor too.
+    p = '';
+    l = 'L';
+  }
+
+  // Put it together in the correct order.
+  // OCp1,D,P,L,S,F
+  return 'O' + ([c, d, p, l, s, f].join(','));
+}
+
+export function printCommand(
+  cmd: Cmds.PrintCommand,
+): string {
+  const total = Math.trunc(cmd.labelCount);
+  const dup = Math.trunc(cmd.additionalDuplicateOfEach);
+  return `P${total},${dup}` + '\r\n';
+}
+
+export function addImageCommand(
+  cmd: Cmds.AddImageCommand,
+  outDoc: Cmds.TranspiledDocumentState,
+): string {
+  // EPL only supports raw binary, get that.
+  const bitmap = cmd.bitmap;
+  const rawBitmap = bitmap.toBinaryGRF();
+  const decoder = new TextDecoder("ascii");
+  const buffer = decoder.decode(rawBitmap);
+
+  // Add the text command prefix to the buffer data
+  const parameters = [
+    Math.trunc(outDoc.horizontalOffset + bitmap.boundingBox.paddingLeft),
+    Math.trunc(outDoc.verticalOffset + bitmap.boundingBox.paddingTop),
+    bitmap.bytesPerRow,
+    bitmap.height
+  ];
+  // Bump the offset according to the image being added.
+  outDoc.verticalOffset += bitmap.boundingBox.height;
+  return 'GW' + parameters.join(',') + ',' + buffer + '\r\n';
+}
+
+export function addLineCommand(
+  cmd: Cmds.AddLineCommand,
+  outDoc: Cmds.TranspiledDocumentState,
+): string {
+  const length = Math.trunc(cmd.widthInDots) || 0;
+  const height = Math.trunc(cmd.heightInDots) || 0;
+  let drawMode = 'LO';
+  switch (cmd.color) {
+    case Cmds.DrawColor.black:
+      drawMode = 'LO';
+      break;
+    case Cmds.DrawColor.white:
+      drawMode = 'LW';
+      break;
+  }
+
+  const params = [outDoc.horizontalOffset, outDoc.verticalOffset, length, height]
+  return drawMode + params.join(',') + '\r\n';
+}
+
+export function addBoxCommand(
+  cmd: Cmds.AddBoxCommand,
+  outDoc: Cmds.TranspiledDocumentState,
+): string {
+  const length = Math.trunc(cmd.widthInDots) || 0;
+  const height = Math.trunc(cmd.heightInDots) || 0;
+  const thickness = Math.trunc(cmd.thickness) || 0;
+
+
+  const params = [outDoc.horizontalOffset, outDoc.verticalOffset, thickness, length, height]
+  return 'X' + params.join(',') + '\r\n';
+}

--- a/src/Languages/Epl/CmdConfigurationInquiry.ts
+++ b/src/Languages/Epl/CmdConfigurationInquiry.ts
@@ -392,14 +392,14 @@ function updateHardwareOptions(str: string, msg: Cmds.ISettingUpdateMessage) {
   });
 }
 
-export function tryGetModel(rawModel?: string): Conf.IPrinterHardwareUpdate | undefined {
+export function tryGetModel(rawModel?: string): Conf.UpdateFor<Conf.IPrinterHardware> | undefined {
   if (rawModel === undefined || rawModel === '') { return undefined }
   const model = getModel(rawModel);
   return model.model !== "Unknown_EPL" ? model : undefined;
 }
 
 // TODO: Way to have user supply new models?
-function getModel(rawModel: string): Conf.IPrinterHardwareUpdate {
+function getModel(rawModel: string): Conf.UpdateFor<Conf.IPrinterHardware> {
   const speeds = eplPrinters.default.speedMaps;
   const models = eplPrinters.default.models;
 

--- a/src/Languages/Epl/EplPrinterCommandSet.ts
+++ b/src/Languages/Epl/EplPrinterCommandSet.ts
@@ -1,6 +1,6 @@
-import * as Util from '../../Util/index.js';
 import * as Conf from '../../Configs/index.js';
 import * as Cmds from '../../Commands/index.js';
+import * as Basic from './BasicCommands.js';
 import { handleMessage } from './Messages.js';
 import { cmdErrorReportingMapping } from './CmdErrorReporting.js';
 import { getErrorMessage } from './ErrorMessage.js';
@@ -68,24 +68,24 @@ export class EplPrinterCommandSet extends Cmds.StringCommandSet {
 
         SetDarkness: {
           commandType: 'SetDarkness',
-          transpile: (c, d) => this.setDarknessCommand(c as Cmds.SetDarknessCommand, d),
+          transpile: (c, d) => Basic.setDarknessCommand(c as Cmds.SetDarknessCommand, d),
           formInclusionMode: Cmds.CommandFormInclusionMode.noForm,
         },
         SetLabelDimensions: {
           commandType: 'SetLabelDimensions',
-          transpile: (c) => this.setLabelDimensionsCommand(c as Cmds.SetLabelDimensionsCommand),
+          transpile: (c) => Basic.setLabelDimensionsCommand(c as Cmds.SetLabelDimensionsCommand),
         },
         SetLabelHome: {
           commandType: 'SetLabelHome',
-          transpile: (c, d) => this.setLabelHomeCommand(c as Cmds.SetLabelHomeCommand, d),
+          transpile: (c, d) => Basic.setLabelHomeCommand(c as Cmds.SetLabelHomeCommand, d),
         },
         SetLabelPrintOriginOffset: {
           commandType: 'SetLabelPrintOriginOffset',
-          transpile: (c) => this.setLabelPrintOriginOffsetCommand(c as Cmds.SetLabelPrintOriginOffsetCommand),
+          transpile: (c) => Basic.setLabelPrintOriginOffsetCommand(c as Cmds.SetLabelPrintOriginOffsetCommand),
         },
         SetMediaToContinuousMedia: {
           commandType: 'SetMediaToContinuousMedia',
-          transpile: (c, d) => this.setLabelToContinuousMediaCommand(
+          transpile: (c, d) => Basic.setLabelToContinuousMediaCommand(
             c as Cmds.SetMediaToContinuousMediaCommand,
             d.initialConfig,
           ),
@@ -93,7 +93,7 @@ export class EplPrinterCommandSet extends Cmds.StringCommandSet {
         },
         SetMediaToWebGapMedia: {
           commandType: 'SetMediaToWebGapMedia',
-          transpile: (c, d) => this.setLabelToWebGapMediaCommand(
+          transpile: (c, d) => Basic.setLabelToWebGapMediaCommand(
             c as Cmds.SetMediaToWebGapMediaCommand,
             d.initialConfig,
           ),
@@ -101,7 +101,7 @@ export class EplPrinterCommandSet extends Cmds.StringCommandSet {
         },
         SetMediaToMarkMedia: {
           commandType: 'SetMediaToMarkMedia',
-          transpile: (c, d) => this.setLabelToMarkMediaCommand(
+          transpile: (c, d) => Basic.setLabelToMarkMediaCommand(
             c as Cmds.SetMediaToMarkMediaCommand,
             d.initialConfig,
           ),
@@ -109,16 +109,16 @@ export class EplPrinterCommandSet extends Cmds.StringCommandSet {
         },
         SetPrintDirection: {
           commandType: 'SetPrintDirection',
-          transpile: (c) => this.setPrintDirectionCommand((c as Cmds.SetPrintDirectionCommand).upsideDown),
+          transpile: (c) => Basic.setPrintDirectionCommand((c as Cmds.SetPrintDirectionCommand).upsideDown),
         },
         SetPrintSpeed: {
           commandType: 'SetPrintSpeed',
-          transpile: (c, d) => this.setPrintSpeedCommand(c as Cmds.SetPrintSpeedCommand, d),
+          transpile: (c, d) => Basic.setPrintSpeedCommand(c as Cmds.SetPrintSpeedCommand, d),
           formInclusionMode: Cmds.CommandFormInclusionMode.noForm,
         },
         SetBackfeedAfterTaken: {
           commandType: 'SetBackfeedAfterTaken',
-          transpile: (c) => this.setBackfeedAfterTaken((c as Cmds.SetBackfeedAfterTakenMode).mode),
+          transpile: (c) => Basic.setBackfeedAfterTaken((c as Cmds.SetBackfeedAfterTakenMode).mode),
           formInclusionMode: Cmds.CommandFormInclusionMode.noForm,
         },
 
@@ -147,7 +147,7 @@ export class EplPrinterCommandSet extends Cmds.StringCommandSet {
         },
         Print: {
           commandType: 'Print',
-          transpile: (c) => this.printCommand(c as Cmds.PrintCommand),
+          transpile: (c) => Basic.printCommand(c as Cmds.PrintCommand),
         },
         ClearImageBuffer: {
           commandType: 'ClearImageBuffer',
@@ -158,15 +158,15 @@ export class EplPrinterCommandSet extends Cmds.StringCommandSet {
         // Content
         AddBox: {
           commandType: 'AddBox',
-          transpile: (c, d) => this.addBoxCommand(c as Cmds.AddBoxCommand, d),
+          transpile: (c, d) => Basic.addBoxCommand(c as Cmds.AddBoxCommand, d),
         },
         AddImage: {
           commandType: 'AddImage',
-          transpile: (c, d) => this.addImageCommand(c as Cmds.AddImageCommand, d),
+          transpile: (c, d) => Basic.addImageCommand(c as Cmds.AddImageCommand, d),
         },
         AddLine: {
           commandType: 'AddLine',
-          transpile: (c, d) => this.addLineCommand(c as Cmds.AddLineCommand, d),
+          transpile: (c, d) => Basic.addLineCommand(c as Cmds.AddLineCommand, d),
         },
         Offset: {
           commandType: 'Offset',
@@ -180,297 +180,5 @@ export class EplPrinterCommandSet extends Cmds.StringCommandSet {
         cmdErrorReportingMapping,
         ...extendedCommands
       ]);
-  }
-
-  private setBackfeedAfterTaken(
-    mode: Conf.BackfeedAfterTaken
-  ): string {
-    if (mode === 'disabled') {
-      // TODO: Does JC matter? It's only supported on 28X4
-      // Send JB first for universal support and JC after just in case?
-      return `JB\r\nJC\r\n`
-    } else {
-      // EPL doesn't support percentages so just turn it on.
-      return `JF\r\n`;
-    }
-  }
-
-  private setPrintDirectionCommand(
-    upsideDown: boolean
-  ): string {
-    const dir = upsideDown ? 'T' : 'B';
-    return `Z${dir}` + '\r\n';
-  }
-
-  private setDarknessCommand(
-    cmd: Cmds.SetDarknessCommand,
-    docState: Cmds.TranspiledDocumentState
-  ): string {
-    const percent = cmd.darknessPercent / 100.0;
-    const dark = Math.ceil(percent * docState.initialConfig.maxMediaDarkness);
-    return `D${dark}` + '\r\n';
-  }
-
-  private setPrintSpeedCommand(
-    cmd: Cmds.SetPrintSpeedCommand,
-    docState: Cmds.TranspiledDocumentState
-  ): string {
-    const table = docState.initialConfig.speedTable;
-    const printSpeed = table.toRawSpeed(cmd.speed);
-    // Validation should have happened on setup, printer will just reject
-    // invalid speeds.
-    return `S${printSpeed}` + '\r\n';
-  }
-
-  private setLabelDimensionsCommand(
-    cmd: Cmds.SetLabelDimensionsCommand,
-  ): string {
-    const width = Math.trunc(cmd.widthInDots);
-    let outCmd = `q${width}` + '\r\n';
-
-    if (cmd.setsLength && cmd.lengthInDots !== undefined && cmd.gapLengthInDots !== undefined) {
-      const length = Math.trunc(cmd.lengthInDots);
-      const gap = Math.trunc(cmd.gapLengthInDots);
-      outCmd += `Q${length},${gap}` + '\r\n';
-    }
-
-    return outCmd;
-  }
-
-  private setLabelHomeCommand(
-    cmd: Cmds.SetLabelHomeCommand,
-    outDoc: Cmds.TranspiledDocumentState
-  ): string {
-    Cmds.applyOffsetToDocState(
-      new Cmds.OffsetCommand(cmd.offset.left, cmd.offset.top, true),
-      outDoc
-    );
-    return this.noop;
-  }
-
-  private setLabelPrintOriginOffsetCommand(
-    cmd: Cmds.SetLabelPrintOriginOffsetCommand,
-  ): string {
-    const xOffset = Math.trunc(cmd.offset.left);
-    const yOffset = Math.trunc(cmd.offset.top);
-    return `R${xOffset},${yOffset}` + '\r\n';
-  }
-
-  private setLabelToContinuousMediaCommand(
-    cmd: Cmds.SetMediaToContinuousMediaCommand,
-    conf: Cmds.PrinterConfig,
-  ): string {
-    return this.setMediaTrackingMode(conf, {
-      mode: 'continuous',
-      formGapFeed: Util.clampToRange(Math.trunc(cmd.formGapInDots), 0, 65535),
-    });
-  }
-
-  private setLabelToWebGapMediaCommand(
-    cmd: Cmds.SetMediaToWebGapMediaCommand,
-    conf: Cmds.PrinterConfig,
-  ): string {
-    const length = Util.clampToRange(Math.trunc(cmd.mediaLengthInDots), 24, 65535);
-    const minGap = conf.dpi === 300 ? 18 : 16;
-    return this.setMediaTrackingMode(conf, {
-      mode: 'web',
-      length,
-      gapLength: Util.clampToRange(Math.trunc(cmd.mediaGapInDots), minGap, 240),
-      gapOffset: Util.clampToRange(Math.trunc(cmd.mediaGapOffsetInDots), 0, length),
-    });
-  }
-
-  private setLabelToMarkMediaCommand(
-    cmd: Cmds.SetMediaToMarkMediaCommand,
-    conf: Cmds.PrinterConfig,
-  ): string {
-    const length = Util.clampToRange(Math.trunc(cmd.mediaLengthInDots), 24, 65535);
-    const minLine = conf.dpi === 300 ? 18 : 16;
-    return this.setMediaTrackingMode(conf, {
-      mode: 'mark',
-      length,
-      blackLength: Util.clampToRange(Math.trunc(cmd.blackLineThicknessInDots), minLine, 240),
-      blackOffset: Util.clampToRange(Math.trunc(cmd.blackLineOffset), 0, length),
-    });
-  }
-
-  private setMediaTrackingMode(
-    conf: Cmds.PrinterConfig,
-    mode: {
-      mode: 'web'
-      length: number,
-      gapLength: number,
-      gapOffset: number,
-    } | {
-      mode: 'continuous'
-      formGapFeed: number,
-    } | {
-      mode: 'mark',
-      length: number,
-      blackLength: number,
-      blackOffset: number,
-    }
-  ) {
-    switch (mode.mode) {
-      case 'web': {
-        // Length is the label length, marker is gap length
-        // Marker offset is additional dots 'down' into the label. If a notch is
-        // 4mm 'down' from the true edge then 4mm * 8 dots = 24 offset.
-        // Q123,24+24
-        const offset = mode.gapOffset === 0 ? '' : ('+' + mode.gapOffset);
-        return `Q${mode.length},${mode.gapLength}${offset}\r\n` +
-          this.setHardwareMode(conf, { reverseSensor: false });
-      }
-      case 'mark': {
-        // Length is distance between black line marks.
-        // Marker length is the length of the black line mark.
-        // Marker offset is the distance from the end of the black mark to the
-        // perforation point. Positive is 'down' into the black line, positive
-        // is 'up' into the label.
-        // TODO: validate that statement...
-        // Q123,B24-156
-        let offset = '';
-        if (mode.blackOffset < 0) {
-          offset = '-' + mode.blackOffset;
-        } else if (mode.blackOffset > 0) {
-          offset = '+' + mode.blackOffset;
-        }
-        return `Q${mode.length},B${mode.blackLength}${offset}\r\n` +
-          this.setHardwareMode(conf, { reverseSensor: true });
-      }
-      case 'continuous':
-        // Form length is variable, we just use the gap between forms.
-        // Q24,0
-        return `Q${mode.formGapFeed},0\r\n` +
-          this.setHardwareMode(conf, { reverseSensor: false });
-    }
-  }
-
-  private setHardwareMode(
-    config: Cmds.PrinterConfig,
-    modify: {
-      // TODO: Support C{num} batching
-      cutter?: 'off' | 'on' | 'cmd',
-      directThermal?: Conf.ThermalPrintMode,
-      labelTaken?: boolean,
-      reverseSensor?: boolean,
-      feedButton?: Conf.FeedButtonMode
-  }) {
-    // The EPL 'O' command is stateless, if you try to change one setting it resets
-    // the other settings to defaults. To properly modify a setting you must supply
-    // the other current settings too.
-    // The parameters for this function are overrides, we default to current set
-    // values from the printer for the rest.
-
-    // Cutter - C, Cb, C{batch}
-    let c = '';
-    if (modify.cutter === undefined) {
-      switch (config.mediaPrintMode) {
-        case Conf.MediaPrintMode.cutter:
-          c = 'C';
-          break;
-        case Conf.MediaPrintMode.cutterWaitForCommand:
-          c = 'Cb';
-          break;
-      }
-    } else if (modify.cutter === 'on') {
-      c = 'C';
-    } else if (modify.cutter === 'cmd') {
-      c = 'Cb';
-    }
-
-    // Direct thermal - D, <blank>
-    const directThermal = modify.directThermal ?? config.thermalPrintMode === Conf.ThermalPrintMode.direct;
-    const d = directThermal ? 'D' : '';
-
-    // Label taken sensor - P, <blank>
-    const labelTaken = modify.labelTaken ?? (
-      config.mediaPrintMode === Conf.MediaPrintMode.peel
-      || config.mediaPrintMode === Conf.MediaPrintMode.peelWithPrePeel)
-    let p = labelTaken ? 'P' : '';
-
-    // Reverse sensor - S, <blank>
-    const revSensor = modify.reverseSensor ?? config.mediaGapDetectMode === Conf.MediaMediaGapDetectionMode.markSensing;
-    const s = revSensor ? 'S' : '';
-
-    const feedButton = modify.feedButton ?? config.feedButtonMode;
-    let l = '';
-    let f = 'Ff';
-    if (feedButton === 'disabled') {
-      f = 'Fi';
-    } else if (feedButton === 'tapToReprint') {
-      f = 'Fr';
-    } else if (feedButton === 'tapToPrint') {
-      // Special mode, overrides label taken sensor too.
-      p = '';
-      l = 'L';
-    }
-
-    // Put it together in the correct order.
-    // OCp1,D,P,L,S,F
-    return 'O' + ([c, d, p, l, s, f].join(','));
-  }
-
-  private printCommand(
-    cmd: Cmds.PrintCommand,
-  ): string {
-    const total = Math.trunc(cmd.labelCount);
-    const dup = Math.trunc(cmd.additionalDuplicateOfEach);
-    return `P${total},${dup}` + '\r\n';
-  }
-
-  private addImageCommand(
-    cmd: Cmds.AddImageCommand,
-    outDoc: Cmds.TranspiledDocumentState,
-  ): string {
-    // EPL only supports raw binary, get that.
-    const bitmap = cmd.bitmap;
-    const rawBitmap = bitmap.toBinaryGRF();
-    const decoder = new TextDecoder("ascii");
-    const buffer = decoder.decode(rawBitmap);
-
-    // Add the text command prefix to the buffer data
-    const parameters = [
-      Math.trunc(outDoc.horizontalOffset + bitmap.boundingBox.paddingLeft),
-      Math.trunc(outDoc.verticalOffset + bitmap.boundingBox.paddingTop),
-      bitmap.bytesPerRow,
-      bitmap.height
-    ];
-    // Bump the offset according to the image being added.
-    outDoc.verticalOffset += bitmap.boundingBox.height;
-    return 'GW' + parameters.join(',') + ',' + buffer + '\r\n';
-  }
-
-  private addLineCommand(
-    cmd: Cmds.AddLineCommand,
-    outDoc: Cmds.TranspiledDocumentState,
-  ): string {
-    const length = Math.trunc(cmd.widthInDots) || 0;
-    const height = Math.trunc(cmd.heightInDots) || 0;
-    let drawMode = 'LO';
-    switch (cmd.color) {
-      case Cmds.DrawColor.black:
-        drawMode = 'LO';
-        break;
-      case Cmds.DrawColor.white:
-        drawMode = 'LW';
-        break;
-    }
-
-    const params = [outDoc.horizontalOffset, outDoc.verticalOffset, length, height]
-    return drawMode + params.join(',') + '\r\n';
-  }
-
-  private addBoxCommand(
-    cmd: Cmds.AddBoxCommand,
-    outDoc: Cmds.TranspiledDocumentState,
-  ): string {
-    const length = Math.trunc(cmd.widthInDots) || 0;
-    const height = Math.trunc(cmd.heightInDots) || 0;
-    const thickness = Math.trunc(cmd.thickness) || 0;
-
-
-    const params = [outDoc.horizontalOffset, outDoc.verticalOffset, thickness, length, height]
-    return 'X' + params.join(',') + '\r\n';
   }
 }

--- a/src/Languages/Epl/EplPrinterCommandSet.ts
+++ b/src/Languages/Epl/EplPrinterCommandSet.ts
@@ -16,6 +16,7 @@ export class EplPrinterCommandSet extends Cmds.StringCommandSet {
   ) {
     super(
       Conf.PrinterCommandLanguage.epl,
+      handleMessage,
       {
         // Printer control
         NoOp: { commandType: 'NoOp' },
@@ -179,13 +180,6 @@ export class EplPrinterCommandSet extends Cmds.StringCommandSet {
         cmdErrorReportingMapping,
         ...extendedCommands
       ]);
-  }
-
-  public parseMessage<TReceived extends Conf.MessageArrayLike>(
-    msg: TReceived,
-    sentCommand?: Cmds.IPrinterCommand
-  ): Cmds.IMessageHandlerResult<TReceived> {
-    return handleMessage(this, msg, sentCommand);
   }
 
   private setBackfeedAfterTaken(

--- a/src/Languages/Epl/Messages.test.ts
+++ b/src/Languages/Epl/Messages.test.ts
@@ -1,13 +1,17 @@
 import { expect, describe, it } from 'vitest';
+import * as Cmds from '../../Commands/index.js';
 import { handleMessage } from './Messages.js';
 import { AsciiCodeNumbers, AsciiCodeStrings, EncodeAscii } from '../../Util/ASCII.js';
 import { EplPrinterCommandSet } from './EplPrinterCommandSet.js';
 
 describe('handleMessage', () => {
   const cmdSet = new EplPrinterCommandSet();
+  const cfg = new Cmds.PrinterConfig();
   it('ACK as status message', () => {
-    const result = handleMessage(cmdSet,
-      new Uint8Array([AsciiCodeNumbers.ACK, AsciiCodeNumbers.CR, AsciiCodeNumbers.LF])
+    const result = handleMessage(
+      cmdSet,
+      new Uint8Array([AsciiCodeNumbers.ACK, AsciiCodeNumbers.CR, AsciiCodeNumbers.LF]),
+      cfg
     );
     expect(result.messages).toMatchInlineSnapshot(`
       [
@@ -20,7 +24,8 @@ describe('handleMessage', () => {
 
   it('DLE as status message', () => {
     const result = handleMessage(cmdSet,
-      new Uint8Array([AsciiCodeNumbers.DLE, AsciiCodeNumbers.CR, AsciiCodeNumbers.LF])
+      new Uint8Array([AsciiCodeNumbers.DLE, AsciiCodeNumbers.CR, AsciiCodeNumbers.LF]),
+      cfg
     );
     expect(result.messages).toMatchInlineSnapshot(`
       [
@@ -35,7 +40,8 @@ describe('handleMessage', () => {
   it('NAK as status message', () => {
     // Code 01 - Syntax error.
     const result = handleMessage(cmdSet,
-      EncodeAscii(`${AsciiCodeStrings.NAK}01\r\n`)
+      EncodeAscii(`${AsciiCodeStrings.NAK}01\r\n`),
+      cfg
     );
     expect(result.messages).toMatchInlineSnapshot(`
       [
@@ -52,7 +58,8 @@ describe('handleMessage', () => {
   it('NAK with busy error', () => {
     // Code 50 - Syntax error.
     const result = handleMessage(cmdSet,
-      EncodeAscii(`${AsciiCodeStrings.NAK}50\r\n`)
+      EncodeAscii(`${AsciiCodeStrings.NAK}50\r\n`),
+      cfg
     );
     expect(result.messages).toMatchInlineSnapshot(`
       [
@@ -68,7 +75,8 @@ describe('handleMessage', () => {
 
   it('Extracts unprinted labels', () => {
     const result = handleMessage(cmdSet,
-      `${AsciiCodeStrings.NAK}07P001\r\n`
+      `${AsciiCodeStrings.NAK}07P001\r\n`,
+      cfg
     );
     expect(result.messages).toMatchInlineSnapshot(`
       [
@@ -86,7 +94,8 @@ describe('handleMessage', () => {
 
   it('Extracts unprinted labels and lines', () => {
     const result = handleMessage(cmdSet,
-      `${AsciiCodeStrings.NAK}07P696L91234\r\n`
+      `${AsciiCodeStrings.NAK}07P696L91234\r\n`,
+      cfg
     );
     expect(result.messages).toMatchInlineSnapshot(`
       [

--- a/src/Languages/Epl/Messages.ts
+++ b/src/Languages/Epl/Messages.ts
@@ -2,11 +2,11 @@ import * as Util from '../../Util/index.js';
 import * as Conf from '../../Configs/index.js';
 import * as Cmds from '../../Commands/index.js';
 import { getErrorMessage } from "./ErrorMessage.js";
-import type { EplPrinterCommandSet } from './EplPrinterCommandSet.js';
 
 export function handleMessage<TReceived extends Conf.MessageArrayLike>(
-  cmdSet: EplPrinterCommandSet,
+  cmdSet: Cmds.CommandSet<string>,
   message: TReceived,
+  _config: Cmds.PrinterConfig,
   sentCommand?: Cmds.IPrinterCommand
 ): Cmds.IMessageHandlerResult<TReceived> {
   const result: Cmds.IMessageHandlerResult<TReceived> = {

--- a/src/Languages/Zpl/BasicCommands.ts
+++ b/src/Languages/Zpl/BasicCommands.ts
@@ -1,0 +1,204 @@
+import * as Util from '../../Util/index.js';
+import * as Conf from '../../Configs/index.js';
+import * as Cmds from '../../Commands/index.js';
+
+export function getFieldOffsetCommand(
+  formMetadata: Cmds.TranspiledDocumentState,
+  additionalHorizontal = 0,
+  additionalVertical = 0
+) {
+  const xOffset = Math.trunc(formMetadata.horizontalOffset + additionalHorizontal);
+  const yOffset = Math.trunc(formMetadata.verticalOffset + additionalVertical);
+  return `^FO${xOffset},${yOffset}`;
+}
+
+export function addImageCommand(
+  cmd: Cmds.AddImageCommand,
+  outDoc: Cmds.TranspiledDocumentState
+): string {
+  // ZPL treats colors as print element enable. 1 means black, 0 means white.
+  const bitmap = cmd.bitmap.toInvertedGRF();
+  // TODO: support image conversion options.
+  //const imageOptions = cmd.imageConversionOptions;
+
+  // ZPL supports compressed binary on pretty much all firmware, default to that.
+  // TODO: ASCII-compressed formats are only supported on newer firmware.
+  // Implement feature detection into the transpiler operation to choose the most
+  // appropriate compression format such as LZ77/DEFLATE compression for Z64.
+  const buffer = bitmap.toZebraCompressedGRF();
+
+  // Because the image may be trimmed add an offset command to position to the image data.
+  const fieldStart = getFieldOffsetCommand(
+    outDoc,
+    bitmap.boundingBox.paddingLeft,
+    bitmap.boundingBox.paddingTop
+  );
+
+  const byteLen = bitmap.bytesUncompressed;
+  const graphicCmd = `^GFA,${byteLen},${byteLen},${bitmap.bytesPerRow},${buffer}`;
+
+  const fieldEnd = '^FS';
+
+  // Finally, bump the document offset according to the image height.
+  outDoc.verticalOffset += bitmap.boundingBox.height;
+
+  return fieldStart + graphicCmd + fieldEnd;
+}
+
+export function setPrintDirectionCommand(upsideDown: boolean) {
+  const dir = upsideDown ? 'I' : 'N';
+  return `^PO${dir}`;
+}
+
+export function setBackfeedAfterTaken(
+  mode: Conf.BackfeedAfterTaken
+) {
+  // ZPL has special names for some percentages because of course it does.
+  switch (mode) {
+    case 'disabled': return '~JSO';
+    case '100'     : return '~JSA';
+    case '90'      : return '~JSN';
+    case '0'       : return '~JSB';
+    default        : return `~JS${mode}`;
+  }
+}
+
+export function setDarknessCommand(
+  cmd: Cmds.SetDarknessCommand,
+  docState: Cmds.TranspiledDocumentState
+) {
+  const percent = cmd.darknessPercent / 100.0;
+  const dark = Math.trunc(Math.ceil(
+    percent * docState.initialConfig.maxMediaDarkness
+  ));
+  return `~SD${dark}`;
+}
+
+export function setPrintSpeedCommand(
+  cmd: Cmds.SetPrintSpeedCommand,
+  docState: Cmds.TranspiledDocumentState
+) {
+  const table = docState.initialConfig.speedTable;
+  const printSpeed = table.toRawSpeed(cmd.speed);
+  const slewSpeed  = table.toRawSpeed(cmd.mediaSlewSpeed);
+  // ZPL uses separate print, slew, and backfeed speeds.
+  // Not all printers can have a separate backfeed, so re-use print speed.
+  return `^PR${printSpeed},${slewSpeed},${printSpeed}`;
+}
+
+export function setLabelDimensionsCommand(cmd: Cmds.SetLabelDimensionsCommand) {
+  const width = Math.trunc(cmd.widthInDots);
+  let outCmd = `^PW${width}`;
+
+  if (cmd.setsLength && cmd.lengthInDots !== undefined) {
+    outCmd += setLengthCommand(cmd.lengthInDots);
+  }
+
+  return outCmd;
+}
+
+export function setLengthCommand(length: number) {
+  const len = Util.clampToRange(Math.trunc(length), 1, 32000);
+  return `^LL${len}^ML${(len * 2) + 100}`;
+}
+
+export function setLabelHomeCommand(cmd: Cmds.SetLabelHomeCommand) {
+  const xOffset = Math.trunc(cmd.offset.left);
+  const yOffset = Math.trunc(cmd.offset.top);
+  return `^LH${xOffset},${yOffset}`;
+}
+
+export function setLabelPrintOriginOffsetCommand(
+  cmd: Cmds.SetLabelPrintOriginOffsetCommand
+): string {
+  // This ends up being two commands, one to set the top and one to set the
+  // horizontal shift. LS moves the horizontal, LT moves the top. LT is
+  // clamped to +/- 120 dots, horizontal is 9999.
+  const xOffset = Util.clampToRange(Math.trunc(cmd.offset.left), -9999, 9999);
+  const yOffset = Util.clampToRange(Math.trunc(cmd.offset.top), -120, 120);
+  return `^LS${xOffset}^LT${yOffset}`;
+}
+
+export function setLabelToContinuousMediaCommand(
+  cmd: Cmds.SetMediaToContinuousMediaCommand
+): string {
+  const length = Util.clampToRange(Math.trunc(cmd.mediaLengthInDots), 1, 32000);
+  const gap    = Util.clampToRange(Math.trunc(cmd.formGapInDots), 0, 2000);
+  return '^MNN' + setLengthCommand(length + gap);
+}
+
+export function setLabelToWebGapMediaCommand(
+  cmd: Cmds.SetMediaToWebGapMediaCommand
+): string {
+  return '^MNY' + setLengthCommand(cmd.mediaLengthInDots);
+}
+
+export function setLabelToMarkMediaCommand(
+  cmd: Cmds.SetMediaToMarkMediaCommand
+): string {
+  return '^MNM' + setLengthCommand(cmd.mediaLengthInDots);
+}
+
+export function printCommand(
+  cmd: Cmds.PrintCommand
+): string {
+  // TODO: Make sure this actually works this way..
+  // According to the docs the first parameter is "total" labels,
+  // while the third is duplicates.
+  const total = Math.trunc(cmd.labelCount * (cmd.additionalDuplicateOfEach + 1));
+  const dup = Math.trunc(cmd.additionalDuplicateOfEach);
+  // Add a single space character to ensure blank labels print too.
+  return `^FD ^PQ${total},0,${dup}`;
+}
+
+export function addLineCommand(
+  cmd: Cmds.AddLineCommand,
+  outDoc: Cmds.TranspiledDocumentState
+): string {
+  return lineOrBoxToCmd(
+    outDoc,
+    cmd.heightInDots,
+    cmd.widthInDots,
+    cmd.color,
+    // A line is just a box filled in!
+    Math.min(cmd.heightInDots, cmd.widthInDots)
+  );
+}
+
+export function addBoxCommand(
+  cmd: Cmds.AddBoxCommand,
+  outDoc: Cmds.TranspiledDocumentState,
+): string {
+  return lineOrBoxToCmd(
+    outDoc,
+    cmd.heightInDots,
+    cmd.widthInDots,
+    Cmds.DrawColor.black,
+    cmd.thickness
+  );
+}
+
+export function lineOrBoxToCmd(
+  outDoc: Cmds.TranspiledDocumentState,
+  height: number,
+  length: number,
+  color: Cmds.DrawColor,
+  thickness?: number
+): string {
+  height = Math.trunc(height) || 0;
+  length = Math.trunc(length) || 0;
+  thickness = Math.trunc(thickness ?? 1) || 1;
+  let drawMode: string;
+  switch (color) {
+    case Cmds.DrawColor.black:
+      drawMode = 'B';
+      break;
+    case Cmds.DrawColor.white:
+      drawMode = 'W';
+      break;
+  }
+  const fieldStart = getFieldOffsetCommand(outDoc);
+
+  // TODO: Support rounding?
+  return [fieldStart, `^GB${length}`, height, thickness, drawMode, '^FS'].join(',');
+}

--- a/src/Languages/Zpl/Config.ts
+++ b/src/Languages/Zpl/Config.ts
@@ -1,4 +1,5 @@
 import * as Cmds from '../../Commands/index.js';
+import * as Conf from '../../Configs/index.js';
 
 export type PowerUpAction
   = 'none'
@@ -18,7 +19,7 @@ export type SensorLevels = {
 }
 
 export interface IZplSettingUpdateMessage extends Cmds.ISettingUpdateMessage {
-  printerZplSettings?: Cmds.UpdateClass<IZplPrinterSettings>;
+  printerZplSettings?: Conf.UpdateFor<IZplPrinterSettings>;
 }
 
 /** ZPL-specific config information about a printer. */

--- a/src/Languages/Zpl/Messages.ts
+++ b/src/Languages/Zpl/Messages.ts
@@ -1,10 +1,10 @@
 import * as Conf from '../../Configs/index.js';
 import * as Cmds from '../../Commands/index.js';
-import type { ZplPrinterCommandSet } from './ZplPrinterCommandSet.js';
 
 export function handleMessage<TReceived extends Conf.MessageArrayLike>(
-  cmdSet: ZplPrinterCommandSet,
+  cmdSet: Cmds.CommandSet<string>,
   message: TReceived,
+  _config: Cmds.PrinterConfig,
   sentCommand?: Cmds.IPrinterCommand,
 ): Cmds.IMessageHandlerResult<TReceived> {
   const result: Cmds.IMessageHandlerResult<TReceived> = {

--- a/src/Languages/Zpl/ZplPrinterCommandSet.ts
+++ b/src/Languages/Zpl/ZplPrinterCommandSet.ts
@@ -27,6 +27,7 @@ export class ZplPrinterCommandSet extends Cmds.StringCommandSet {
   ) {
     super(
       Conf.PrinterCommandLanguage.zpl,
+      handleMessage,
       {
         NoOp: { commandType: 'NoOp' },
         CustomCommand: {
@@ -197,14 +198,6 @@ export class ZplPrinterCommandSet extends Cmds.StringCommandSet {
   public override getConfig(config: Cmds.PrinterConfig) {
     return new ZplPrinterConfig(config);
   }
-
-  public parseMessage<TReceived extends Conf.MessageArrayLike>(
-    msg: TReceived,
-    sentCommand?: Cmds.IPrinterCommand
-  ): Cmds.IMessageHandlerResult<TReceived> {
-    return handleMessage(this, msg, sentCommand);
-  }
-
   private getFieldOffsetCommand(
     formMetadata: Cmds.TranspiledDocumentState,
     additionalHorizontal = 0,

--- a/src/Languages/Zpl/ZplPrinterCommandSet.ts
+++ b/src/Languages/Zpl/ZplPrinterCommandSet.ts
@@ -1,6 +1,6 @@
-import * as Util from '../../Util/index.js';
 import * as Conf from '../../Configs/index.js';
 import * as Cmds from '../../Commands/index.js';
+import * as Basic from './BasicCommands.js';
 import { handleMessage } from './Messages.js';
 import { CmdXmlQuery, cmdXmlQueryTypeMapping } from './CmdXmlQuery.js';
 import { CmdHostIdentification, cmdHostIdentificationMapping } from './CmdHostIdentification.js';
@@ -84,44 +84,44 @@ export class ZplPrinterCommandSet extends Cmds.StringCommandSet {
 
         SetDarkness: {
           commandType: 'SetDarkness',
-          transpile: (c, d) => this.setDarknessCommand(c as Cmds.SetDarknessCommand, d),
+          transpile: (c, d) => Basic.setDarknessCommand(c as Cmds.SetDarknessCommand, d),
           formInclusionMode: Cmds.CommandFormInclusionMode.noForm,
         },
         SetLabelDimensions: {
           commandType: 'SetLabelDimensions',
-          transpile: (c) => this.setLabelDimensionsCommand(c as Cmds.SetLabelDimensionsCommand),
+          transpile: (c) => Basic.setLabelDimensionsCommand(c as Cmds.SetLabelDimensionsCommand),
         },
         SetLabelHome: {
           commandType: 'SetLabelHome',
-          transpile: (c) => this.setLabelHomeCommand(c as Cmds.SetLabelHomeCommand),
+          transpile: (c) => Basic.setLabelHomeCommand(c as Cmds.SetLabelHomeCommand),
         },
         SetLabelPrintOriginOffset: {
           commandType: 'SetLabelPrintOriginOffset',
-          transpile: (c) => this.setLabelPrintOriginOffsetCommand(c as Cmds.SetLabelPrintOriginOffsetCommand),
+          transpile: (c) => Basic.setLabelPrintOriginOffsetCommand(c as Cmds.SetLabelPrintOriginOffsetCommand),
         },
         SetMediaToContinuousMedia: {
           commandType: 'SetMediaToContinuousMedia',
-          transpile: (c) => this.setLabelToContinuousMediaCommand(c as Cmds.SetMediaToContinuousMediaCommand),
+          transpile: (c) => Basic.setLabelToContinuousMediaCommand(c as Cmds.SetMediaToContinuousMediaCommand),
         },
         SetMediaToWebGapMedia: {
           commandType: 'SetMediaToWebGapMedia',
-          transpile: (c) => this.setLabelToWebGapMediaCommand(c as Cmds.SetMediaToWebGapMediaCommand),
+          transpile: (c) => Basic.setLabelToWebGapMediaCommand(c as Cmds.SetMediaToWebGapMediaCommand),
         },
         SetMediaToMarkMedia: {
           commandType: 'SetMediaToMarkMedia',
-          transpile: (c) => this.setLabelToMarkMediaCommand(c as Cmds.SetMediaToMarkMediaCommand),
+          transpile: (c) => Basic.setLabelToMarkMediaCommand(c as Cmds.SetMediaToMarkMediaCommand),
         },
         SetPrintDirection: {
           commandType: 'SetPrintDirection',
-          transpile: (c) => this.setPrintDirectionCommand((c as Cmds.SetPrintDirectionCommand).upsideDown),
+          transpile: (c) => Basic.setPrintDirectionCommand((c as Cmds.SetPrintDirectionCommand).upsideDown),
         },
         SetPrintSpeed: {
           commandType: 'SetPrintSpeed',
-          transpile: (c, d) => this.setPrintSpeedCommand(c as Cmds.SetPrintSpeedCommand, d),
+          transpile: (c, d) => Basic.setPrintSpeedCommand(c as Cmds.SetPrintSpeedCommand, d),
         },
         SetBackfeedAfterTaken: {
           commandType: 'SetBackfeedAfterTaken',
-          transpile: (c) => this.setBackfeedAfterTaken((c as Cmds.SetBackfeedAfterTakenMode).mode),
+          transpile: (c) => Basic.setBackfeedAfterTaken((c as Cmds.SetBackfeedAfterTakenMode).mode),
         },
 
         // Media
@@ -149,7 +149,7 @@ export class ZplPrinterCommandSet extends Cmds.StringCommandSet {
         },
         Print: {
           commandType: 'Print',
-          transpile: (c) => this.printCommand(c as Cmds.PrintCommand),
+          transpile: (c) => Basic.printCommand(c as Cmds.PrintCommand),
         },
         ClearImageBuffer: {
           commandType: 'ClearImageBuffer',
@@ -162,15 +162,15 @@ export class ZplPrinterCommandSet extends Cmds.StringCommandSet {
         // Content
         AddBox: {
           commandType: 'AddBox',
-          transpile: (c, d) => this.addBoxCommand(c as Cmds.AddBoxCommand, d),
+          transpile: (c, d) => Basic.addBoxCommand(c as Cmds.AddBoxCommand, d),
         },
         AddImage: {
           commandType: 'AddImage',
-          transpile: (c, d) => this.addImageCommand(c as Cmds.AddImageCommand, d),
+          transpile: (c, d) => Basic.addImageCommand(c as Cmds.AddImageCommand, d),
         },
         AddLine: {
           commandType: 'AddLine',
-          transpile: (c, d) => this.addLineCommand(c as Cmds.AddLineCommand, d),
+          transpile: (c, d) => Basic.addLineCommand(c as Cmds.AddLineCommand, d),
         },
         Offset: {
           commandType: 'Offset',
@@ -197,205 +197,5 @@ export class ZplPrinterCommandSet extends Cmds.StringCommandSet {
 
   public override getConfig(config: Cmds.PrinterConfig) {
     return new ZplPrinterConfig(config);
-  }
-  private getFieldOffsetCommand(
-    formMetadata: Cmds.TranspiledDocumentState,
-    additionalHorizontal = 0,
-    additionalVertical = 0
-  ) {
-    const xOffset = Math.trunc(formMetadata.horizontalOffset + additionalHorizontal);
-    const yOffset = Math.trunc(formMetadata.verticalOffset + additionalVertical);
-    return `^FO${xOffset},${yOffset}`;
-  }
-
-  private addImageCommand(
-    cmd: Cmds.AddImageCommand,
-    outDoc: Cmds.TranspiledDocumentState
-  ): string {
-    // ZPL treats colors as print element enable. 1 means black, 0 means white.
-    const bitmap = cmd.bitmap.toInvertedGRF();
-    // TODO: support image conversion options.
-    //const imageOptions = cmd.imageConversionOptions;
-
-    // ZPL supports compressed binary on pretty much all firmware, default to that.
-    // TODO: ASCII-compressed formats are only supported on newer firmware.
-    // Implement feature detection into the transpiler operation to choose the most
-    // appropriate compression format such as LZ77/DEFLATE compression for Z64.
-    const buffer = bitmap.toZebraCompressedGRF();
-
-    // Because the image may be trimmed add an offset command to position to the image data.
-    const fieldStart = this.getFieldOffsetCommand(
-      outDoc,
-      bitmap.boundingBox.paddingLeft,
-      bitmap.boundingBox.paddingTop
-    );
-
-    const byteLen = bitmap.bytesUncompressed;
-    const graphicCmd = `^GFA,${byteLen},${byteLen},${bitmap.bytesPerRow},${buffer}`;
-
-    const fieldEnd = '^FS';
-
-    // Finally, bump the document offset according to the image height.
-    outDoc.verticalOffset += bitmap.boundingBox.height;
-
-    return fieldStart + graphicCmd + fieldEnd;
-  }
-
-  private setPrintDirectionCommand(upsideDown: boolean) {
-    const dir = upsideDown ? 'I' : 'N';
-    return `^PO${dir}`;
-  }
-
-  private setBackfeedAfterTaken(
-    mode: Conf.BackfeedAfterTaken
-  ) {
-    // ZPL has special names for some percentages because of course it does.
-    switch (mode) {
-      case 'disabled': return '~JSO';
-      case '100'     : return '~JSA';
-      case '90'      : return '~JSN';
-      case '0'       : return '~JSB';
-      default        : return `~JS${mode}`;
-    }
-  }
-
-  private setDarknessCommand(
-    cmd: Cmds.SetDarknessCommand,
-    docState: Cmds.TranspiledDocumentState
-  ) {
-    const percent = cmd.darknessPercent / 100.0;
-    const dark = Math.trunc(Math.ceil(
-      percent * docState.initialConfig.maxMediaDarkness
-    ));
-    return `~SD${dark}`;
-  }
-
-  private setPrintSpeedCommand(
-    cmd: Cmds.SetPrintSpeedCommand,
-    docState: Cmds.TranspiledDocumentState
-  ) {
-    const table = docState.initialConfig.speedTable;
-    const printSpeed = table.toRawSpeed(cmd.speed);
-    const slewSpeed  = table.toRawSpeed(cmd.mediaSlewSpeed);
-    // ZPL uses separate print, slew, and backfeed speeds.
-    // Not all printers can have a separate backfeed, so re-use print speed.
-    return `^PR${printSpeed},${slewSpeed},${printSpeed}`;
-  }
-
-  private setLabelDimensionsCommand(cmd: Cmds.SetLabelDimensionsCommand) {
-    const width = Math.trunc(cmd.widthInDots);
-    let outCmd = `^PW${width}`;
-
-    if (cmd.setsLength && cmd.lengthInDots !== undefined) {
-      outCmd += this.setLengthCommand(cmd.lengthInDots);
-    }
-
-    return outCmd;
-  }
-
-  private setLengthCommand(length: number) {
-    const len = Util.clampToRange(Math.trunc(length), 1, 32000);
-    return `^LL${len}^ML${(len * 2) + 100}`;
-  }
-
-  private setLabelHomeCommand(cmd: Cmds.SetLabelHomeCommand) {
-    const xOffset = Math.trunc(cmd.offset.left);
-    const yOffset = Math.trunc(cmd.offset.top);
-    return `^LH${xOffset},${yOffset}`;
-  }
-
-  private setLabelPrintOriginOffsetCommand(
-    cmd: Cmds.SetLabelPrintOriginOffsetCommand
-  ): string {
-    // This ends up being two commands, one to set the top and one to set the
-    // horizontal shift. LS moves the horizontal, LT moves the top. LT is
-    // clamped to +/- 120 dots, horizontal is 9999.
-    const xOffset = Util.clampToRange(Math.trunc(cmd.offset.left), -9999, 9999);
-    const yOffset = Util.clampToRange(Math.trunc(cmd.offset.top), -120, 120);
-    return `^LS${xOffset}^LT${yOffset}`;
-  }
-
-  private setLabelToContinuousMediaCommand(
-    cmd: Cmds.SetMediaToContinuousMediaCommand
-  ): string {
-    const length = Util.clampToRange(Math.trunc(cmd.mediaLengthInDots), 1, 32000);
-    const gap    = Util.clampToRange(Math.trunc(cmd.formGapInDots), 0, 2000);
-    return '^MNN' + this.setLengthCommand(length + gap);
-  }
-
-  private setLabelToWebGapMediaCommand(
-    cmd: Cmds.SetMediaToWebGapMediaCommand
-  ): string {
-    return '^MNY' + this.setLengthCommand(cmd.mediaLengthInDots);
-  }
-
-  private setLabelToMarkMediaCommand(
-    cmd: Cmds.SetMediaToMarkMediaCommand
-  ): string {
-    return '^MNM' + this.setLengthCommand(cmd.mediaLengthInDots);
-  }
-
-  private printCommand(
-    cmd: Cmds.PrintCommand
-  ): string {
-    // TODO: Make sure this actually works this way..
-    // According to the docs the first parameter is "total" labels,
-    // while the third is duplicates.
-    const total = Math.trunc(cmd.labelCount * (cmd.additionalDuplicateOfEach + 1));
-    const dup = Math.trunc(cmd.additionalDuplicateOfEach);
-    // Add a single space character to ensure blank labels print too.
-    return `^FD ^PQ${total},0,${dup}`;
-  }
-
-  private addLineCommand(
-    cmd: Cmds.AddLineCommand,
-    outDoc: Cmds.TranspiledDocumentState
-  ): string {
-    return this.lineOrBoxToCmd(
-      outDoc,
-      cmd.heightInDots,
-      cmd.widthInDots,
-      cmd.color,
-      // A line is just a box filled in!
-      Math.min(cmd.heightInDots, cmd.widthInDots)
-    );
-  }
-
-  private addBoxCommand(
-    cmd: Cmds.AddBoxCommand,
-    outDoc: Cmds.TranspiledDocumentState,
-  ): string {
-    return this.lineOrBoxToCmd(
-      outDoc,
-      cmd.heightInDots,
-      cmd.widthInDots,
-      Cmds.DrawColor.black,
-      cmd.thickness
-    );
-  }
-
-  private lineOrBoxToCmd(
-    outDoc: Cmds.TranspiledDocumentState,
-    height: number,
-    length: number,
-    color: Cmds.DrawColor,
-    thickness?: number
-  ): string {
-    height = Math.trunc(height) || 0;
-    length = Math.trunc(length) || 0;
-    thickness = Math.trunc(thickness ?? 1) || 1;
-    let drawMode: string;
-    switch (color) {
-      case Cmds.DrawColor.black:
-        drawMode = 'B';
-        break;
-      case Cmds.DrawColor.white:
-        drawMode = 'W';
-        break;
-    }
-    const fieldStart = this.getFieldOffsetCommand(outDoc);
-
-    // TODO: Support rounding?
-    return [fieldStart, `^GB${length}`, height, thickness, drawMode, '^FS'].join(',');
   }
 }

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -404,7 +404,11 @@ export class LabelPrinter<TChannelType extends Conf.MessageArrayLike> extends Ev
     // Iterate through the response message and the command candidates in order,
     // but always validate the message is the format we wanted.
     const msg = this._channelMessageTransformer.combineMessages(...input);
-    const parsed = await Cmds.parseRaw(msg, this._commandSet, this._awaitedCommands);
+    const parsed = await Cmds.parseRaw(
+      msg,
+      this._commandSet,
+      this._printerOptions,
+      this._awaitedCommands);
 
     parsed.messages.forEach(m => {
       switch (m.messageType) {

--- a/src/Util/ASCII.test.ts
+++ b/src/Util/ASCII.test.ts
@@ -1,0 +1,41 @@
+import { expect, describe, it } from 'vitest';
+import { asciiToDisplay, DecodeAscii, EncodeAscii, hex } from './ASCII.js';
+
+describe('asciiToDisplay', () => {
+  it('Encodes ascii as human legible output', () => {
+    expect(asciiToDisplay(2, 69, 69, 3, 13, 10))
+      .toMatchInlineSnapshot(`"0x02[STX], 0x45[E], 0x45[E], 0x03[ETX], 0x0d[CR], 0x0a[LF]"`);
+  });
+
+  it('Hex displays value as hex value', () => {
+    expect(hex(155)).toMatchInlineSnapshot(`"0x9b"`);
+  });
+});
+
+describe('Encode and Decode', () => {
+  it('Encodes ASCII', () => {
+    expect(EncodeAscii("hello\r\n")).toMatchInlineSnapshot(`
+      Uint8Array [
+        104,
+        101,
+        108,
+        108,
+        111,
+        13,
+        10,
+      ]
+    `);
+  });
+
+  it('Complains about non-ASCII', () => {
+    expect(() => {EncodeAscii("🐁")}).toThrow();
+  });
+
+  it('Decodes ASCII', () => {
+    expect(DecodeAscii(new Uint8Array([2, 69, 69, 3, 13, 10])))
+      .toMatchInlineSnapshot(`
+      "EE
+      "
+    `);
+  });
+});

--- a/src/Util/EnumUtils.test.ts
+++ b/src/Util/EnumUtils.test.ts
@@ -1,0 +1,21 @@
+import { expect, describe, it } from 'vitest';
+import { exhaustiveMatchGuard, hasFlag } from './EnumUtils.js';
+
+describe('hasFlag', () => {
+  enum testEnum {
+    zero = 0,
+    one,
+  }
+  it('Has the flag', () => {
+    expect(hasFlag(testEnum.one, testEnum.one)).toBe(true);
+  });
+  it('Does not have flag', () => {
+    expect(hasFlag(testEnum.one, 5)).toBe(false);
+  });
+});
+
+describe('exhaustiveMatchGuard', () => {
+  it('Only allows never', () => {
+    expect(() => {exhaustiveMatchGuard(false as never); }).toThrow();
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
       enabled: true,
       reporter: ['text', 'json-summary', 'json'],
       reportOnFailure: true,
+      include: ['src/**']
     }
   }
 });


### PR DESCRIPTION
With the previous changes in place it's easier to make more of these functions pure and break them out into separate modules. Writing more tests against the smaller functions will be easier now.

This also moves the initial message handling function down to the base CommandSet class, with a delegate being registered in the child language classes. We also expose the current config to the message handling delegate as there are some EPL messages that may benefit from the added context.