### PR TITLE
Add ZPL-specific settings to advanced demo

### DIFF
--- a/demo/advanced.html
+++ b/demo/advanced.html
@@ -153,18 +153,42 @@
         // Get some bookkeeping out of the way..
         // First we create an interface to describe our settings form.
         interface ConfigModalForm extends HTMLCollection {
-          modalCancel         : HTMLButtonElement
-          modalDarkness       : HTMLSelectElement
+          modalCancel          : HTMLButtonElement
+          modalSubmit          : HTMLButtonElement
+          modalPrinterIndex    : HTMLInputElement
+
+          // Media
+          modalLabelWidth     : HTMLInputElement
           modalLabelHeight    : HTMLInputElement
           modalLabelOffsetLeft: HTMLInputElement
           modalLabelOffsetTop : HTMLInputElement
-          modalLabelWidth     : HTMLInputElement
           modalMediaType      : HTMLSelectElement
+          modalWithAutosense  : HTMLInputElement
+
+          // Printer
+          modalDarkness       : HTMLSelectElement
           modalSpeed          : HTMLSelectElement
           modalBackfeedPercent: HTMLSelectElement
-          modalSubmit         : HTMLButtonElement
-          modalWithAutosense  : HTMLInputElement
+
+          // These are ZPL-specific settings. Different languages can have additional
+          // commands or configs specific to their printers.
+          // Sensors
+          modalZplRibbonTHold: HTMLInputElement
+          modalZplRibbonLed  : HTMLInputElement
+          modalZplWebTHold   : HTMLInputElement
+          modalZplWebMedia   : HTMLInputElement
+          modalZplWebLed     : HTMLInputElement
+          modalZplMarkTHold  : HTMLInputElement
+          modalZplMarkMedia  : HTMLInputElement
+          modalZplMarkLed    : HTMLInputElement
+
+          modalZplWithSensorGraph: HTMLInputElement
+
+          // Power up/head close actions
+          modalZplPowerUpAction  : HTMLSelectElement
+          modalZplHeadCloseAction: HTMLSelectElement
         }
+
 
         // A function to find and hide any alerts for a given alert ID.
         function hideAlerts(alertId: string) {
@@ -303,14 +327,27 @@
 
           /** Display the configuration for a printer. */
           public showConfigModal(printer: WebLabel.LabelPrinterUsb, printerIdx: number) {
-            if (printer == undefined) {
+            if (printer === undefined || printerIdx < 0) {
               return;
             }
             const config = printer.printerOptions;
+            // If the printer uses ZPL it will have a special config, show those!
+            const isZpl = config instanceof WebLabel.ZPL.ZplPrinterConfig;
+
+            const formElement = this.configModal.querySelector('form')!;
+            const form = formElement.elements as ConfigModalForm;
+
+            // Only show ZPL settings if the printer language is ZPL.
+            for (const e of formElement.getElementsByTagName('modal-setting-zpl')) {
+              if (isZpl) {
+                e.classList.remove('d-hide');
+              } else {
+                e.classList.add('d-hide');
+              }
+            }
 
             // Translate the available speeds to options to be selected
-            const speedSelect = this.configModal.querySelector('#modalSpeed')! as HTMLSelectElement;
-            speedSelect.innerHTML = '';
+            form.modalSpeed.innerHTML = '';
             const speedTable = printer.printerOptions.speedTable.table;
             for (const [key] of speedTable) {
               // Skip utility values, so long as there's more than the defaults.
@@ -325,32 +362,47 @@
               const opt = document.createElement('option');
               opt.value = key.toString();
               opt.innerHTML = WebLabel.PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
-              speedSelect.appendChild(opt);
+              form.modalSpeed.appendChild(opt);
             }
-            speedSelect.value = config.speed.printSpeed.toString();
+            form.modalSpeed.value = config.speed.printSpeed.toString();
 
-            const mediaSelect = this.configModal.querySelector('#modalMediaType')! as HTMLSelectElement;
             switch (config.mediaGapDetectMode) {
               case WebLabel.MediaMediaGapDetectionMode.continuous:
-                mediaSelect.value = "continuous";
+                form.modalMediaType.value = "continuous";
                 break;
               default:
               case WebLabel.MediaMediaGapDetectionMode.webSensing:
-                mediaSelect.value = "gap";
+                form.modalMediaType.value = "gap";
                 break;
               case WebLabel.MediaMediaGapDetectionMode.markSensing:
-                mediaSelect.value = "mark";
+                form.modalMediaType.value = "mark";
                 break;
             }
 
-            (this.configModal.querySelector('#modalPrinterIndex')     as HTMLInputElement)!.value = config.serialNumber;
-            (this.configModal.querySelector('#modalPrinterIndexText') as HTMLInputElement)!.textContent = printerIdx.toString();
-            (this.configModal.querySelector('#modalLabelWidth')       as HTMLInputElement)!.value = config.mediaWidthInches.toString();
-            (this.configModal.querySelector('#modalLabelHeight')      as HTMLInputElement)!.value = config.mediaLengthInches.toString();
-            (this.configModal.querySelector('#modalDarkness')         as HTMLInputElement)!.value = config.darknessPercent.toString();
-            (this.configModal.querySelector('#modalLabelOffsetLeft')  as HTMLInputElement)!.value = config.mediaPrintOriginOffsetDots.left.toString();
-            (this.configModal.querySelector('#modalLabelOffsetTop')   as HTMLInputElement)!.value = config.mediaPrintOriginOffsetDots.top.toString();
-            (this.configModal.querySelector('#modalBackfeedPercent')  as HTMLSelectElement)!.value = config.backfeedAfterTaken.toString();
+            // The other elements are just text.
+            (formElement.querySelector('#modalPrinterIndexText') as HTMLInputElement)!.textContent = printerIdx.toString();
+            form.modalPrinterIndex.value    = config.serialNumber;
+            form.modalLabelWidth.value      = config.mediaWidthInches.toString();
+            form.modalLabelHeight.value     = config.mediaLengthInches.toString();
+            form.modalDarkness.value        = config.darknessPercent.toString();
+            form.modalLabelOffsetLeft.value = config.mediaPrintOriginOffsetDots.left.toString();
+            form.modalLabelOffsetTop.value  = config.mediaPrintOriginOffsetDots.top.toString();
+            form.modalBackfeedPercent.value = config.backfeedAfterTaken.toString();
+            if (isZpl) {
+              const sensors = config.sensorLevels;
+              form.modalZplRibbonTHold.value = sensors.ribbonThreshold.toString();
+              form.modalZplRibbonLed.value   = sensors.ribbonLedBrightness.toString();
+              form.modalZplWebTHold.value    = sensors.webThreshold.toString();
+              form.modalZplWebMedia.value    = sensors.mediaThreshold.toString();
+              form.modalZplWebLed.value      = sensors.mediaLedBrightness.toString();
+              form.modalZplMarkTHold.value   = sensors.markThreshold.toString();
+              form.modalZplMarkMedia.value   = sensors.markMediaThreshold.toString();
+              form.modalZplMarkLed.value     = sensors.markLedBrightness.toString();
+
+              form.modalZplPowerUpAction.value   = config.actionPowerUp.toString();
+              form.modalZplHeadCloseAction.value = config.actionHeadClose.toString();
+            }
+
             this.configModalHandle.show();
           }
 
@@ -556,6 +608,7 @@
             if (printer === undefined) {
               return;
             }
+            const isZpl = printer.printerOptions instanceof WebLabel.ZPL.ZplPrinterConfig;
 
             form.modalSubmit.setAttribute("disabled", "");
             form.modalCancel.setAttribute("disabled", "");
@@ -564,7 +617,6 @@
             const darkness = parseInt(form.modalDarkness.value) as WebLabel.DarknessPercent;
             const rawSpeed = parseInt(form.modalSpeed.value) as WebLabel.PrintSpeed;
             const mediaWidthInches = parseFloat(form.modalLabelWidth.value);
-            const autosense = form.modalWithAutosense.checked;
 
             const mediaLengthInches = parseFloat(form.modalLabelHeight.value);
             const offsetLeft = parseInt(form.modalLabelOffsetLeft.value);
@@ -598,13 +650,67 @@
               .setDarknessConfig(darkness)
               .setLabelDimensions(mediaWidthInches)
               .setBackfeedAfterTakenMode(backfeedAfterTaken);
-            const doc = autosense
-              ? configDoc.autosenseLabelLength()
-              : configDoc.finalize();
+
+            if (isZpl) {
+              // Send the ZPL-specific settings too!
+              let actionPowerUp: WebLabel.ZPL.PowerUpAction;
+              switch (form.modalZplPowerUpAction.value) {
+                case "none":
+                  actionPowerUp = "none";
+                  break;
+                default:
+                case "feedBlank":
+                  actionPowerUp = "feedBlank";
+                  break;
+                case "calibrateWebSensor":
+                  actionPowerUp = "calibrateWebLength";
+                  break;
+              }
+
+              let actionHeadClose: WebLabel.ZPL.PowerUpAction;
+              switch (form.modalZplHeadCloseAction.value) {
+                case "none":
+                  actionHeadClose = "none";
+                  break;
+                default:
+                case "feedBlank":
+                  actionHeadClose = "feedBlank";
+                  break;
+                case "calibrateWebSensor":
+                  actionHeadClose = "calibrateWebLength";
+                  break;
+              }
+
+              configDoc
+                .andThen(new WebLabel.ZPL.CmdSetPowerUpAndHeadCloseAction(
+                  actionPowerUp, actionHeadClose
+                ))
+                .andThen(new WebLabel.ZPL.CmdSetSensorCalibration({
+                  markLedBrightness: Number(form.modalZplMarkLed.value),
+                  markMediaThreshold: Number(form.modalZplMarkMedia.value),
+                  markThreshold: Number(form.modalZplMarkTHold.value),
+                  mediaLedBrightness: Number(form.modalZplWebLed.value),
+                  mediaThreshold: Number(form.modalZplWebMedia.value),
+                  ribbonLedBrightness: Number(form.modalZplRibbonLed.value),
+                  ribbonThreshold: Number(form.modalZplRibbonTHold.value),
+                  webThreshold: Number(form.modalZplWebTHold.value),
+                }));
+            }
+
+            let doc: WebLabel.IDocument;
+            if (form.modalWithAutosense.checked) {
+              doc = configDoc.autosenseLabelLength();
+            } else if (isZpl && form.modalZplWithSensorGraph) {
+              doc = configDoc.andThen(new WebLabel.ZPL.CmdGraphSensorCalibration()).finalize();
+            } else {
+              doc = configDoc.finalize();
+            }
+
             // And send the whole shebang to the printer!
             await printer.sendDocument(doc);
 
             form.modalWithAutosense.checked = false;
+            form.modalZplWithSensorGraph.checked = false;
             form.modalSubmit.removeAttribute("disabled");
             form.modalCancel.removeAttribute("disabled");
             this.activePrinterIndex = printerIdx;
@@ -701,6 +807,7 @@
                 <div class="alert alert-info" role="alert" id="loadingIndicator">
                   <h4>Loading....</h4>
                   <p>If you see this for a long time check the dev console for errors and try the <button id="emergencyRefreshBtn">emergency reset button.</button></p>
+                  <p>Chrome has a bug that prevents this page working in incognito, private browsing, or a Guest profile on ChomeOS.</p>
                 </div>
               </div>
             </div>
@@ -728,7 +835,7 @@
       </div>
     </div>
     <div id="printerOptionModal" class="modal" tabindex="-1">
-      <div class="modal-dialog">
+      <div class="modal-dialog modal-lg">
         <div class="modal-content">
           <form id="printerSettingsForm">
             <div class="modal-header">
@@ -736,12 +843,14 @@
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-              <div class="row">
-                <label for="modalPrinterIndex" class="form-label">Printer ID</label>
-                <div class="input-group mb-3">
-                  <span id="modalPrinterIndexText" class="input-group-text">42Q424242424</span>
-                  <input id="modalPrinterIndex" class="form-control" type="text" value="-1"
-                    aria-label="Printer ID" aria-describedby="modalPrinterIndexText" disabled readonly>
+              <div class="mb-3">
+                <div class="row">
+                  <label for="modalPrinterIndex" class="form-label">Printer ID</label>
+                  <div class="input-group mb-3">
+                    <span id="modalPrinterIndexText" class="input-group-text">42Q424242424</span>
+                    <input id="modalPrinterIndex" class="form-control" type="text" value="-1"
+                      aria-label="Printer ID" aria-describedby="modalPrinterIndexText" disabled readonly>
+                  </div>
                 </div>
               </div>
               <div class="mb-3">
@@ -749,7 +858,7 @@
                   <h5>Media Settings</h5>
                 </div>
                 <div class="row">
-                  <div class="col">
+                  <div class="col-md-4">
                     <label for="modalLabelWidth" class="form-label">Media Width</label>
                     <div class="input-group mb-3">
                       <input id="modalLabelWidth" type="text" class="form-control" placeholder="1.23"
@@ -758,7 +867,7 @@
                       <span id="modalLabelWidthText" class="input-group-text">in</span>
                     </div>
                   </div>
-                  <div class="col">
+                  <div class="col-md-4">
                     <label for="modalLabelHeight" class="form-label">Media Length</label>
                     <div class="input-group mb-3">
                       <input id="modalLabelHeight" type="text" class="form-control" placeholder="1.23"
@@ -767,7 +876,7 @@
                       <span id="modalLabelHeightText" class="input-group-text">in</span>
                     </div>
                   </div>
-                  <div class="col">
+                  <div class="col-md-4">
                     <label class="form-label">Auto-Calibrate</label>
                     <div class="input-group mb-3">
                       <input id="modalWithAutosense" type="checkbox" class="btn-check"
@@ -779,7 +888,7 @@
                   </div>
                 </div>
                 <div class="row">
-                  <div class="col">
+                  <div class="col-md-3">
                     <label for="modalLabelOffsetLeft" class="form-label">Left Offset</label>
                     <div class="input-group mb-3">
                       <input id="modalLabelOffsetLeft" type="text" class="form-control" placeholder="0"
@@ -788,7 +897,7 @@
                       <span class="input-group-text">dots</span>
                     </div>
                   </div>
-                  <div class="col">
+                  <div class="col-md-3">
                     <label for="modalLabelOffsetTop" class="form-label">Top Offset</label>
                     <div class="input-group mb-3">
                       <input id="modalLabelOffsetTop" type="text" class="form-control" placeholder="0"
@@ -796,7 +905,7 @@
                       <span class="input-group-text">dots</span>
                     </div>
                   </div>
-                  <div class="col">
+                  <div class="col-md-6">
                     <label for="modalMediaType" class="form-label">Media Type</label>
                     <div class="mb-3">
                       <select id="modalMediaType" class="form-select" aria-label="Media Type">
@@ -809,6 +918,7 @@
                 </div>
               </div>
               <div class="mb-3">
+                <hr/>
                 <div class="row">
                   <h5>Printer Settings</h5>
                 </div>
@@ -858,6 +968,120 @@
                         <option value="90">90%</option>
                         <option value="100">100%</option>
                       </select>
+                    </div>
+                  </div>
+                </div>
+                <div class="row modal-setting-zpl">
+                  <div class="col-md-6">
+                    <div class="form-floating">
+                      <select id="modalZplPowerUpAction" class="form-select">
+                        <option value="feedBlank">Feed to next label</option>
+                        <option value="none">Do Nothing</option>
+                        <option value="calibrateWebSensor">Media Auto-Calibrate</option>
+                      </select>
+                      <label for="modalZplPowerUpAction">Action on power-up</label>
+                    </div>
+                  </div>
+                  <div class="col-md-6">
+                    <div class="form-floating">
+                      <select id="modalZplHeadCloseAction" class="form-select">
+                        <option value="feedBlank">Feed to next label</option>
+                        <option value="none">Do Nothing</option>
+                        <option value="calibrateWebSensor">Media Auto-Calibrate</option>
+                      </select>
+                      <label for="modalZplHeadCloseAction">Action on head close</label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="mb-3 modal-settings-zpl">
+                <hr/>
+                <div class="row">
+                  <div class="col-md-7">
+                    <h5>Sensor Settings</h5>
+                  </div>
+                  <div class="col-md-5">
+                    <div class="input-group mb-3">
+                      <input id="modalZplWithSensorGraph" type="checkbox" class="btn-check"
+                        aria-label="Run sensor graph" autocomplete="off">
+                      <label for="modalZplWithSensorGraph" class="btn btn-outline-primary"
+                        data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right" title="SET LABEL LENGTH FIRST. Will graph sensor values on labels.<br/><b>Make sure to unspool peeler first!</b>"
+                        >Print graph on save</label>
+                    </div>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-md-4"
+                  data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="top"
+                  title="Sensor level, run graph calibrate to check.<br>Only relevant for printers with ribbon."
+                  >
+                    <p class="h5">Ribbon</p>
+                  </div>
+                  <div class="col-md-4"
+                  data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="top"
+                  title="Sensor level, run graph calibrate to check.<br>Only active for web/gap sense mode."
+                  >
+                    <p class="h5">Web sense</p>
+                  </div>
+                  <div class="col-md-4"
+                  data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="top"
+                  title="Sensor level, run graph calibrate to check.<br>Only active for mark/reflective sense mode."
+                  >
+                    <p class="h5">Mark sense</p>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplRibbonTHold" value="50" />
+                      <label for="modalZplRibbonTHold">Threshold</label>
+                    </div>
+                  </div>
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplWebTHold" value="50" />
+                      <label for="modalZplWebTHold">Threshold</label>
+                    </div>
+                  </div>
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplMarkTHold" value="50" />
+                      <label for="modalZplMarkTHold">Threshold</label>
+                    </div>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-md-4"></div>
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplWebMedia" value="50" />
+                      <label for="modalZplWebMedia">Media</label>
+                    </div>
+                  </div>
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplMarkMedia" value="50" />
+                      <label for="modalZplMarkMedia">Media</label>
+                    </div>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplRibbonLed" value="50" />
+                      <label for="modalZplRibbonLed">LED</label>
+                    </div>
+                  </div>
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplWebLed" value="50" />
+                      <label for="modalZplWebLed">LED</label>
+                    </div>
+                  </div>
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplMarkLed" value="50" />
+                      <label for="modalZplMarkLed">LED</label>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
These are demo-only changes. I wanted to demonstrate detecting when a printer is using a specific language to access advanced behavior. Since the config object is a proper object, you can use `instanceof` to detect alternate config types.

These changes expose some settings I've needed to mess with a few times now.