### PR TITLE
Add editor demo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 
 root = true
 
-[{src,scripts}/**.{ts,json,js}]
+[*.{ts,json,js}]
 end_of_line = crlf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/demo/editor.html
+++ b/demo/editor.html
@@ -13,7 +13,6 @@
     <meta name="theme-color" content="#eeeeee" media="(prefers-color-scheme: dark)">
 </head>
 <body>
-    <a href="https://github.com/cellivar/webzlp" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
     <script type="importmap">
         {
           "imports": {
@@ -69,712 +68,630 @@
     <!-- Here's some actual demo code. Note that it is typescript, not javascript. -->
     <script type="text/typescript" id="cool_demo_code_to_show_off_the_lib">
 
-        // Import the canvas editor lib and make it available
-        import * as Editor from 'fabricjs-label-editor'
-        (window as any).LabelEditor = Editor;
-        (window as any).EditorApp = new Editor.ImageEditor(document.getElementById('image-editor-container')!);
+      // This demo uses a more complex label designer using the Fabric.JS library.
+      // Internally it makes use of an HTML canvas, and thus it's easy to plug into
+      // WebZLP for label designing!
+      // Import the canvas editor lib and create a canvas to use for printing.
+      import * as Editor from 'fabricjs-label-editor'
+      import * as WebLabel from 'webzlp';
+      import * as WebDevices from 'web-device-mux';
+      (window as any).FabricEditor = Editor;
+      (window as any).WebLabel = WebLabel;
+      (window as any).WebDevices = WebDevices;
 
-        // First import the lib!
-        // This is our lib in this repo here
-        import * as WebLabel from 'webzlp';
+      const editor = new Editor.ImageEditor(document.getElementById('image-editor-container')!);
+      (window as any).LabelEditor = editor;
 
-        // This is a utility lib we'll be using that makes it easier to use devices.
-        import * as WebDevices from 'web-device-mux';
+      // For this demo we're going to make use of the USB printer manager
+      // so it can take care of concerns like the USB connect and disconnect events.
 
-        // We'll drop these into the Window object so we can play with them in
-        // the DevTools console if we want to.
-        (window as any).WebLabel = WebLabel;
-        (window as any).WebDevices = WebDevices;
+      // For this demo we're going to make use of the USB printer manager
+      // so it can take care of concerns like the USB connect and disconnect events.
 
-        // For this demo we're going to make use of the USB printer manager
-        // so it can take care of concerns like the USB connect and disconnect events.
-
-        // We'll set a type alias so it's easier to read our code
-        type PrinterManager = WebDevices.UsbDeviceManager<WebLabel.LabelPrinterUsb>;
-        // Then we'll construct one to use
-        const printerMgr: PrinterManager = new WebDevices.UsbDeviceManager(
-          window.navigator.usb,
-          WebLabel.LabelPrinter.fromUSBDevice,
-          {
-            // Enable debugging, so the dev console can fill up with interesting messages!
-            debug: true,
-            requestOptions: {
-              // Limit the USB devices we try to connect to.
-              filters: [
-                {
-                  vendorId: 0x0A5F // Zebra
-                }
-              ]
-            }
+      // We'll set a type alias so it's easier to read our code
+      type PrinterManager = WebDevices.UsbDeviceManager<WebLabel.LabelPrinterUsb>;
+      // Then we'll construct one to use
+      const printerMgr: PrinterManager = new WebDevices.UsbDeviceManager(
+        window.navigator.usb,
+        WebLabel.LabelPrinter.fromUSBDevice,
+        {
+          // Enable debugging, so the dev console can fill up with interesting messages!
+          debug: true,
+          requestOptions: {
+            // Limit the USB devices we try to connect to.
+            filters: [
+              {
+                vendorId: 0x0A5F // Zebra
+              }
+            ]
           }
-        )
-
-        // We'll wire up some basic event listeners to the printer manager.
-        // First, a button to prompt a user to add a printer.
-        const addPrinterBtn = document.getElementById('addprinter')!;
-        addPrinterBtn.addEventListener('click', async () => printerMgr.promptForNewDevice());
-
-        // Next a button to manually refresh all printers, just in case.
-        const refreshPrinterBtn = document.getElementById('refreshPrinters')!;
-        refreshPrinterBtn.addEventListener('click', async () => printerMgr.forceReconnect());
-
-        // Next we wire up some events on the UsbDeviceManager itself.
-        printerMgr.addEventListener('connectedDevice', ({ detail }) => {
-
-          // Let's print some details about the printer that was connected.
-          const printer = detail.device;
-          console.log('New printer is a', printer.printerModel);
-          const config = printer.printerOptions;
-          console.log('Printer darkness is', config.darknessPercent, 'percent');
-          console.log('Printer speed is', WebLabel.PrintSpeed[config.speed.printSpeed]);
-          console.log(
-            'Label is',
-            config.mediaWidthInches,
-            'in wide and',
-            config.mediaLengthInches,
-            'in long');
-          console.log('Printer media mode is', WebLabel.MediaMediaGapDetectionMode[config.mediaGapDetectMode]);
-
-          // You can do stuff with the printer that connected. It's a good idea
-          // to immediately query the printer for its status.
-          printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
-        });
-
-        // There's also an event that will tell you when a printer disconnects.
-        printerMgr.addEventListener('disconnectedDevice', ({ detail }) => {
-          const printer = detail.device;
-          console.log('Lost printer', printer.printerModel, 'serial', printer.printerOptions.serialNumber);
-        });
-
-        // When the browser first loaded the page any previously connected printers would have caused
-        // a connection event. Our listener wasn't listening yet so missed it.
-        // It's good practice to force a reconnect once your event handlers are ready.
-        // We're going to skip this for now though, because we want it to happen after the app is ready.
-        //await printerMgr.reconnectAllPrinters();
-
-        // And that's all there is to setup! The page can now talk to printers.
-        // If you're using a chromebook this should just work. If you're on Windows
-        // you might need to do some driver setup, see the repo README for more details.
-
-        // The rest of this demo is an example of a basic label generator app.
-
-        // Get some bookkeeping out of the way..
-        // First we create an interface to describe our settings form.
-        interface ConfigModalForm extends HTMLCollection {
-          modalCancel          : HTMLButtonElement
-          modalSubmit          : HTMLButtonElement
-          modalPrinterIndex    : HTMLInputElement
-
-          // Media
-          modalLabelWidth     : HTMLInputElement
-          modalLabelHeight    : HTMLInputElement
-          modalLabelOffsetLeft: HTMLInputElement
-          modalLabelOffsetTop : HTMLInputElement
-          modalMediaType      : HTMLSelectElement
-          modalWithAutosense  : HTMLInputElement
-
-          // Printer
-          modalDarkness       : HTMLSelectElement
-          modalSpeed          : HTMLSelectElement
-          modalBackfeedPercent: HTMLSelectElement
-
-          // These are ZPL-specific settings. Different languages can have additional
-          // commands or configs specific to their printers.
-          // Sensors
-          modalZplRibbonTHold: HTMLInputElement
-          modalZplRibbonGain  : HTMLInputElement
-          modalZplWebTHold   : HTMLInputElement
-          modalZplWebMedia   : HTMLInputElement
-          modalZplTransGain     : HTMLInputElement
-          modalZplMarkTHold  : HTMLInputElement
-          modalZplMarkMedia  : HTMLInputElement
-          modalZplMarkGain    : HTMLInputElement
-
-          modalZplWithSensorGraph: HTMLInputElement
-
-          // Power up/head close actions
-          modalZplPowerUpAction  : HTMLSelectElement
-          modalZplHeadCloseAction: HTMLSelectElement
         }
+      )
+
+      // We'll wire up some basic event listeners to the printer manager.
+      // First, a button to prompt a user to add a printer.
+      const addPrinterBtn = document.getElementById('addprinter')!;
+      addPrinterBtn.addEventListener('click', async () => printerMgr.promptForNewDevice());
+
+      // Next a button to manually refresh all printers, just in case.
+      const refreshPrinterBtn = document.getElementById('refreshPrinters')!;
+      refreshPrinterBtn.addEventListener('click', async () => printerMgr.forceReconnect());
+
+      // Get some bookkeeping out of the way..
+      // First we create an interface to describe our settings form.
+      interface ConfigModalForm extends HTMLCollection {
+        modalCancel          : HTMLButtonElement
+        modalSubmit          : HTMLButtonElement
+        modalPrinterIndex    : HTMLInputElement
+
+        // Media
+        modalLabelWidth     : HTMLInputElement
+        modalLabelHeight    : HTMLInputElement
+        modalLabelOffsetLeft: HTMLInputElement
+        modalLabelOffsetTop : HTMLInputElement
+        modalMediaType      : HTMLSelectElement
+        modalWithAutosense  : HTMLInputElement
+
+        // Printer
+        modalDarkness       : HTMLSelectElement
+        modalSpeed          : HTMLSelectElement
+        modalBackfeedPercent: HTMLSelectElement
+
+        // These are ZPL-specific settings. Different languages can have additional
+        // commands or configs specific to their printers.
+        // Sensors
+        modalZplRibbonTHold: HTMLInputElement
+        modalZplRibbonGain : HTMLInputElement
+        modalZplWebTHold   : HTMLInputElement
+        modalZplWebMedia   : HTMLInputElement
+        modalZplTransGain  : HTMLInputElement
+        modalZplMarkTHold  : HTMLInputElement
+        modalZplMarkMedia  : HTMLInputElement
+        modalZplMarkGain   : HTMLInputElement
+
+        modalZplWithSensorGraph: HTMLInputElement
+
+        // Power up/head close actions
+        modalZplPowerUpAction  : HTMLSelectElement
+        modalZplHeadCloseAction: HTMLSelectElement
+      }
 
 
-        // A function to find and hide any alerts for a given alert ID.
-        function hideAlerts(alertId: string) {
-          const existingAlerts = document.getElementById('printerAlertSpace')?.querySelectorAll(`.${alertId}`) ?? [];
-          existingAlerts.forEach((a: Element) => { a.remove(); });
-        }
+      // A function to find and hide any alerts for a given alert ID.
+      function hideAlerts(alertId: string) {
+        const existingAlerts = document.getElementById('printerAlertSpace')?.querySelectorAll(`.${alertId}`) ?? [];
+        existingAlerts.forEach((a: Element) => { a.remove(); });
+      }
 
-        // A function to make it easier to show alerts
-        function showAlert(
-          level: 'warning' | 'danger',
-          alertId: string,
-          titleHtml: string,
-          bodyHtml: string,
-          closedCallback = () => {}
+      // A function to make it easier to show alerts
+      function showAlert(
+        level: 'warning' | 'danger',
+        alertId: string,
+        titleHtml: string,
+        bodyHtml: string,
+        closedCallback = () => {}
+      ) {
+        hideAlerts(alertId);
+
+        // Create the bootstrap alert div with the provided content
+        const alertWrapper = document.createElement('div');
+        alertWrapper.classList.add("alert", `alert-${level}`, "alert-dismissible", "fade", "show", alertId);
+        alertWrapper.id = alertId;
+        alertWrapper.role = "alert";
+        alertWrapper.innerHTML = `
+          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+          <h4>${titleHtml}</h4>
+          ${bodyHtml}`;
+
+        // Add it to the document and activate it
+        document.getElementById('printerAlertSpace')?.appendChild(alertWrapper);
+        new bootstrap.Alert(alertWrapper);
+
+        alertWrapper.addEventListener('closed.bs.alert', closedCallback);
+      }
+
+      // The app's logic is wrapped in a class just for ease of reading.
+      class BasicLabelDesignerApp {
+        constructor(
+          private manager: PrinterManager,
+          private btnContainer: HTMLElement,
+          private editor: Editor.ImageEditor,
+          private labelFormInstructions: HTMLElement,
+          private configModal: HTMLElement
         ) {
-          hideAlerts(alertId);
+          // Based on the containers, map the various listeners.
+          this.configModalHandle = new bootstrap.Modal(this.configModal);
+          this.configModal
+            .querySelector('form')!
+            .addEventListener('submit', this.updatePrinterConfig.bind(this));
 
-          // Create the bootstrap alert div with the provided content
-          const alertWrapper = document.createElement('div');
-          alertWrapper.classList.add("alert", `alert-${level}`, "alert-dismissible", "fade", "show", alertId);
-          alertWrapper.id = alertId;
-          alertWrapper.role = "alert";
-          alertWrapper.innerHTML = `
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-            <h4>${titleHtml}</h4>
-            ${bodyHtml}`;
+          // Add a second set of event listeners for printer connect and disconnect to redraw
+          // the printer list when it changes.
+          this.manager.addEventListener('connectedDevice', ({ detail }) => {
+            this.activePrinterIndex = -1;
+            this.redrawPrinterButtons();
 
-          // Add it to the document and activate it
-          document.getElementById('printerAlertSpace')?.appendChild(alertWrapper);
-          new bootstrap.Alert(alertWrapper);
+            // Printers themselves also have events, let's show an alert on errors.
+            const printer = detail.device;
+            printer.addEventListener('reportedError', ({ detail: msg }) => {
+              // Use the same ID so there's only one error message per printer.
+              const alertId = `alert-printererror-${printer.printerSerial}`;
+              hideAlerts(alertId);
 
-          alertWrapper.addEventListener('closed.bs.alert', closedCallback);
+              // Error messages are also status messages, such as indicating no problem.
+              if (msg.errors.size === 0 || msg.errors.has(WebLabel.ErrorState.NoError)) { return; }
+
+              showAlert(
+                // Show a warning for this printer
+                'warning',
+                alertId,
+                `Printer <strong>${printer.printerSerial}</strong> has an error`,
+                // There can be multiple errors, just show their raw values. A better
+                // application would use these for good messages!
+                `<p><ul>${Array.from(msg.errors).map(e => `<li>${e}`)}</ul></p>
+                <hr>
+                <p>Fix the issue, then dismiss this alert to check the status again.</p>`,
+                // And when the alert is dismissed, check the status again!
+                () => printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument)
+              );
+            });
+          });
+
+          this.manager.addEventListener('disconnectedDevice', () => {
+            this.activePrinterIndex = -1;
+            this.redrawPrinterButtons();
+          });
+
+          // Here's a nice font with a great set of emoji that work well for monochrome printing.
+          // The text font is fairly basic though, so we would like to use only the emoji out
+          // of this font and use a basic sans-serif font for regular text.
+          // https://fonts.google.com/noto/specimen/Noto+Emoji
+          const emojiFontName = 'noto-emoji';
+
+          // We can accomplish this with the unicodeRange property of our FontFace. We just
+          // need to list EVERY SINGLE EMOJI UNICODE RANGE to make it work. Fortunately someone
+          // has done this already: https://github.com/fraction/emoji-unicode-range
+          const emojiUnicodeRange = 'U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2604,U+260E,U+2611,U+2614-2615,U+2618,U+261D,U+2620,U+2622-2623,U+2626,U+262A,U+262E-262F,U+2638-263A,U+2640,U+2642,U+2648-2653,U+265F-2660,U+2663,U+2665-2666,U+2668,U+267B,U+267E-267F,U+2692-2697,U+2699,U+269B-269C,U+26A0-26A1,U+26AA-26AB,U+26B0-26B1,U+26BD-26BE,U+26C4-26C5,U+26C8,U+26CE,U+26CF,U+26D1,U+26D3-26D4,U+26E9-26EA,U+26F0-26F5,U+26F7-26FA,U+26FD,U+2702,U+2705,U+2708-2709,U+270A-270B,U+270C-270D,U+270F,U+2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2764,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F004,U+1F0CF,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201-1F202,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F321,U+1F324-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F396-1F397,U+1F399-1F39B,U+1F39E-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F3-1F3F5,U+1F3F7,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD,U+1F4FF,U+1F500-1F53D,U+1F549-1F54A,U+1F54B-1F54E,U+1F550-1F567,U+1F56F-1F570,U+1F573-1F579,U+1F57A,U+1F587,U+1F58A-1F58D,U+1F590,U+1F595-1F596,U+1F5A4,U+1F5A5,U+1F5A8,U+1F5B1-1F5B2,U+1F5BC,U+1F5C2-1F5C4,U+1F5D1-1F5D3,U+1F5DC-1F5DE,U+1F5E1,U+1F5E3,U+1F5E8,U+1F5EF,U+1F5F3,U+1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CB-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6E0-1F6E5,U+1F6E9,U+1F6EB-1F6EC,U+1F6F0,U+1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+231A-231B,U+23E9-23EC,U+23F0,U+23F3,U+25FD-25FE,U+2614-2615,U+2648-2653,U+267F,U+2693,U+26A1,U+26AA-26AB,U+26BD-26BE,U+26C4-26C5,U+26CE,U+26D4,U+26EA,U+26F2-26F3,U+26F5,U+26FA,U+26FD,U+2705,U+270A-270B,U+2728,U+274C,U+274E,U+2753-2755,U+2757,U+2795-2797,U+27B0,U+27BF,U+2B1B-2B1C,U+2B50,U+2B55,U+1F004,U+1F0CF,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201,U+1F21A,U+1F22F,U+1F232-1F236,U+1F238-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F32D-1F32F,U+1F330-1F335,U+1F337-1F37C,U+1F37E-1F37F,U+1F380-1F393,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CF-1F3D3,U+1F3E0-1F3F0,U+1F3F4,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F440,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FF,U+1F500-1F53D,U+1F54B-1F54E,U+1F550-1F567,U+1F57A,U+1F595-1F596,U+1F5A4,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CC,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6EB-1F6EC,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+1F3FB-1F3FF,U+261D,U+26F9,U+270A-270B,U+270C-270D,U+1F385,U+1F3C2-1F3C4,U+1F3C7,U+1F3CA,U+1F3CB-1F3CC,U+1F442-1F443,U+1F446-1F450,U+1F466-1F478,U+1F47C,U+1F481-1F483,U+1F485-1F487,U+1F48F,U+1F491,U+1F4AA,U+1F574-1F575,U+1F57A,U+1F590,U+1F595-1F596,U+1F645-1F647,U+1F64B-1F64F,U+1F6A3,U+1F6B4-1F6B6,U+1F6C0,U+1F6CC,U+1F90F,U+1F918,U+1F919-1F91E,U+1F91F,U+1F926,U+1F930,U+1F931-1F932,U+1F933-1F939,U+1F93C-1F93E,U+1F9B5-1F9B6,U+1F9B8-1F9B9,U+1F9BB,U+1F9CD-1F9CF,U+1F9D1-1F9DD,U+0023,U+002A,U+0030-0039,U+200D,U+20E3,U+FE0F,U+1F1E6-1F1FF,U+1F3FB-1F3FF,U+1F9B0-1F9B3,U+E0020-E007F,U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+2388,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2605,U+2607-2612,U+2614-2615,U+2616-2617,U+2618,U+2619,U+261A-266F,U+2670-2671,U+2672-267D,U+267E-267F,U+2680-2685,U+2690-2691,U+2692-269C,U+269D,U+269E-269F,U+26A0-26A1,U+26A2-26B1,U+26B2,U+26B3-26BC,U+26BD-26BF,U+26C0-26C3,U+26C4-26CD,U+26CE,U+26CF-26E1,U+26E2,U+26E3,U+26E4-26E7,U+26E8-26FF,U+2700,U+2701-2704,U+2705,U+2708-2709,U+270A-270B,U+270C-2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2767,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F000-1F02B,U+1F02C-1F02F,U+1F030-1F093,U+1F094-1F09F,U+1F0A0-1F0AE,U+1F0AF-1F0B0,U+1F0B1-1F0BE,U+1F0BF,U+1F0C0,U+1F0C1-1F0CF,U+1F0D0,U+1F0D1-1F0DF,U+1F0E0-1F0F5,U+1F0F6-1F0FF,U+1F10D-1F10F,U+1F12F,U+1F16C,U+1F16D-1F16F,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1AD-1F1E5,U+1F201-1F202,U+1F203-1F20F,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F23C-1F23F,U+1F249-1F24F,U+1F250-1F251,U+1F252-1F25F,U+1F260-1F265,U+1F266-1F2FF,U+1F300-1F320,U+1F321-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F394-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F1-1F3F7,U+1F3F8-1F3FA,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD-1F4FE,U+1F4FF,U+1F500-1F53D,U+1F546-1F54A,U+1F54B-1F54F,U+1F550-1F567,U+1F568-1F579,U+1F57A,U+1F57B-1F5A3,U+1F5A4,U+1F5A5-1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6C6-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D3-1F6D4,U+1F6D5,U+1F6D6-1F6DF,U+1F6E0-1F6EC,U+1F6ED-1F6EF,U+1F6F0-1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F6FB-1F6FF,U+1F774-1F77F,U+1F7D5-1F7D8,U+1F7D9-1F7DF,U+1F7E0-1F7EB,U+1F7EC-1F7FF,U+1F80C-1F80F,U+1F848-1F84F,U+1F85A-1F85F,U+1F888-1F88F,U+1F8AE-1F8FF,U+1F90C,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F972,U+1F973-1F976,U+1F977-1F979,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A3-1F9A4,U+1F9A5-1F9AA,U+1F9AB-1F9AD,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CB-1F9CC,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA00-1FA53,U+1FA54-1FA5F,U+1FA60-1FA6D,U+1FA6E-1FA6F,U+1FA70-1FA73,U+1FA74-1FA77,U+1FA78-1FA7A,U+1FA7B-1FA7F,U+1FA80-1FA82,U+1FA83-1FA8F,U+1FA90-1FA95,U+1FA96-1FFFD';
+
+          // And then we can use that range with our font when we load it.
+          const emojiOnlyFont = new FontFace(emojiFontName, 'url(fonts/NotoEmoji-Regular.ttf)', {
+            unicodeRange: emojiUnicodeRange,
+          });
+          emojiOnlyFont.load().then(() => {
+            document.fonts.add(emojiOnlyFont);
+          });
+          // We then set our fallback font as part of the font family we use in the canvas.
+          // This order matters, latter fonts will use the unicodeRange to override earlier fonts.
+          this.fontName = `Sans-serif, ${emojiFontName}`
         }
 
-        // The app's logic is wrapped in a class just for ease of reading.
-        class BasicLabelDesignerApp {
-          constructor(
-            private manager: PrinterManager,
-            private btnContainer: HTMLElement,
-            private labelForm: HTMLElement,
-            private labelFormInstructions: HTMLElement,
-            private configModal: HTMLElement
-          ) {
-            // Based on the containers, map the various listeners.
-            this.configModalHandle = new bootstrap.Modal(this.configModal);
-            this.configModal
-              .querySelector('form')!
-              .addEventListener('submit', this.updatePrinterConfig.bind(this));
-            this.labelForm.addEventListener('blur', this.renderTextForm.bind(this));
-            this.labelForm.addEventListener('keyup', this.renderTextForm.bind(this));
+        // Some storage fields and utility properties
+        private fontName: string;
+        private configModalHandle: bootstrap.Modal;
 
-            // Add a second set of event listeners for printer connect and disconnect to redraw
-            // the printer list when it changes.
-            this.manager.addEventListener('connectedDevice', ({ detail }) => {
-              this.activePrinterIndex = -1;
-              this.redrawPrinterButtons();
+        get printers(): readonly WebLabel.LabelPrinterUsb[] {
+          return this.manager.devices;
+        }
 
-              // Printers themselves also have events, let's show an alert on errors.
-              const printer = detail.device;
-              printer.addEventListener('reportedError', ({ detail: msg }) => {
-                // Use the same ID so there's only one error message per printer.
-                const alertId = `alert-printererror-${printer.printerSerial}`;
-                hideAlerts(alertId);
+        // Track which printer is currently selected for operations
+        private _activePrinter = 0;
+        get activePrinter(): WebLabel.LabelPrinterUsb | undefined {
+          return this._activePrinter < 0 || this._activePrinter > this.printers.length
+            ? undefined
+            : this.printers[this._activePrinter];
+        }
+        set activePrinterIndex(printerIdx: number) {
+          this._activePrinter = printerIdx;
+          this.redrawLabelCanvas();
+        }
 
-                // Error messages are also status messages, such as indicating no problem.
-                if (msg.errors.size === 0 || msg.errors.has(WebLabel.ErrorState.NoError)) { return; }
+        /** Initialize the app */
+        public async init() {
+          this.redrawPrinterButtons();
+          this.redrawLabelCanvas();
+        }
 
-                showAlert(
-                  // Show a warning for this printer
-                  'warning',
-                  alertId,
-                  `Printer <strong>${printer.printerSerial}</strong> has an error`,
-                  // There can be multiple errors, just show their raw values. A better
-                  // application would use these for good messages!
-                  `<p><ul>${Array.from(msg.errors).map(e => `<li>${e}`)}</ul></p>
-                  <hr>
-                  <p>Fix the issue, then dismiss this alert to check the status again.</p>`,
-                  // And when the alert is dismissed, check the status again!
-                  () => printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument)
-                );
-              });
-            });
-            this.manager.addEventListener('disconnectedDevice', () => {
-              this.activePrinterIndex = -1;
-              this.redrawPrinterButtons();
-            });
-
-            // Here's a nice font with a great set of emoji that work well for monochrome printing.
-            // The text font is fairly basic though, so we would like to use only the emoji out
-            // of this font and use a basic sans-serif font for regular text.
-            // https://fonts.google.com/noto/specimen/Noto+Emoji
-            const emojiFontName = 'noto-emoji';
-
-            // We can accomplish this with the unicodeRange property of our FontFace. We just
-            // need to list EVERY SINGLE EMOJI UNICODE RANGE to make it work. Fortunately someone
-            // has done this already: https://github.com/fraction/emoji-unicode-range
-            const emojiUnicodeRange = 'U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2604,U+260E,U+2611,U+2614-2615,U+2618,U+261D,U+2620,U+2622-2623,U+2626,U+262A,U+262E-262F,U+2638-263A,U+2640,U+2642,U+2648-2653,U+265F-2660,U+2663,U+2665-2666,U+2668,U+267B,U+267E-267F,U+2692-2697,U+2699,U+269B-269C,U+26A0-26A1,U+26AA-26AB,U+26B0-26B1,U+26BD-26BE,U+26C4-26C5,U+26C8,U+26CE,U+26CF,U+26D1,U+26D3-26D4,U+26E9-26EA,U+26F0-26F5,U+26F7-26FA,U+26FD,U+2702,U+2705,U+2708-2709,U+270A-270B,U+270C-270D,U+270F,U+2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2764,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F004,U+1F0CF,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201-1F202,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F321,U+1F324-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F396-1F397,U+1F399-1F39B,U+1F39E-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F3-1F3F5,U+1F3F7,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD,U+1F4FF,U+1F500-1F53D,U+1F549-1F54A,U+1F54B-1F54E,U+1F550-1F567,U+1F56F-1F570,U+1F573-1F579,U+1F57A,U+1F587,U+1F58A-1F58D,U+1F590,U+1F595-1F596,U+1F5A4,U+1F5A5,U+1F5A8,U+1F5B1-1F5B2,U+1F5BC,U+1F5C2-1F5C4,U+1F5D1-1F5D3,U+1F5DC-1F5DE,U+1F5E1,U+1F5E3,U+1F5E8,U+1F5EF,U+1F5F3,U+1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CB-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6E0-1F6E5,U+1F6E9,U+1F6EB-1F6EC,U+1F6F0,U+1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+231A-231B,U+23E9-23EC,U+23F0,U+23F3,U+25FD-25FE,U+2614-2615,U+2648-2653,U+267F,U+2693,U+26A1,U+26AA-26AB,U+26BD-26BE,U+26C4-26C5,U+26CE,U+26D4,U+26EA,U+26F2-26F3,U+26F5,U+26FA,U+26FD,U+2705,U+270A-270B,U+2728,U+274C,U+274E,U+2753-2755,U+2757,U+2795-2797,U+27B0,U+27BF,U+2B1B-2B1C,U+2B50,U+2B55,U+1F004,U+1F0CF,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201,U+1F21A,U+1F22F,U+1F232-1F236,U+1F238-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F32D-1F32F,U+1F330-1F335,U+1F337-1F37C,U+1F37E-1F37F,U+1F380-1F393,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CF-1F3D3,U+1F3E0-1F3F0,U+1F3F4,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F440,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FF,U+1F500-1F53D,U+1F54B-1F54E,U+1F550-1F567,U+1F57A,U+1F595-1F596,U+1F5A4,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CC,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6EB-1F6EC,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+1F3FB-1F3FF,U+261D,U+26F9,U+270A-270B,U+270C-270D,U+1F385,U+1F3C2-1F3C4,U+1F3C7,U+1F3CA,U+1F3CB-1F3CC,U+1F442-1F443,U+1F446-1F450,U+1F466-1F478,U+1F47C,U+1F481-1F483,U+1F485-1F487,U+1F48F,U+1F491,U+1F4AA,U+1F574-1F575,U+1F57A,U+1F590,U+1F595-1F596,U+1F645-1F647,U+1F64B-1F64F,U+1F6A3,U+1F6B4-1F6B6,U+1F6C0,U+1F6CC,U+1F90F,U+1F918,U+1F919-1F91E,U+1F91F,U+1F926,U+1F930,U+1F931-1F932,U+1F933-1F939,U+1F93C-1F93E,U+1F9B5-1F9B6,U+1F9B8-1F9B9,U+1F9BB,U+1F9CD-1F9CF,U+1F9D1-1F9DD,U+0023,U+002A,U+0030-0039,U+200D,U+20E3,U+FE0F,U+1F1E6-1F1FF,U+1F3FB-1F3FF,U+1F9B0-1F9B3,U+E0020-E007F,U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+2388,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2605,U+2607-2612,U+2614-2615,U+2616-2617,U+2618,U+2619,U+261A-266F,U+2670-2671,U+2672-267D,U+267E-267F,U+2680-2685,U+2690-2691,U+2692-269C,U+269D,U+269E-269F,U+26A0-26A1,U+26A2-26B1,U+26B2,U+26B3-26BC,U+26BD-26BF,U+26C0-26C3,U+26C4-26CD,U+26CE,U+26CF-26E1,U+26E2,U+26E3,U+26E4-26E7,U+26E8-26FF,U+2700,U+2701-2704,U+2705,U+2708-2709,U+270A-270B,U+270C-2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2767,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F000-1F02B,U+1F02C-1F02F,U+1F030-1F093,U+1F094-1F09F,U+1F0A0-1F0AE,U+1F0AF-1F0B0,U+1F0B1-1F0BE,U+1F0BF,U+1F0C0,U+1F0C1-1F0CF,U+1F0D0,U+1F0D1-1F0DF,U+1F0E0-1F0F5,U+1F0F6-1F0FF,U+1F10D-1F10F,U+1F12F,U+1F16C,U+1F16D-1F16F,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1AD-1F1E5,U+1F201-1F202,U+1F203-1F20F,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F23C-1F23F,U+1F249-1F24F,U+1F250-1F251,U+1F252-1F25F,U+1F260-1F265,U+1F266-1F2FF,U+1F300-1F320,U+1F321-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F394-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F1-1F3F7,U+1F3F8-1F3FA,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD-1F4FE,U+1F4FF,U+1F500-1F53D,U+1F546-1F54A,U+1F54B-1F54F,U+1F550-1F567,U+1F568-1F579,U+1F57A,U+1F57B-1F5A3,U+1F5A4,U+1F5A5-1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6C6-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D3-1F6D4,U+1F6D5,U+1F6D6-1F6DF,U+1F6E0-1F6EC,U+1F6ED-1F6EF,U+1F6F0-1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F6FB-1F6FF,U+1F774-1F77F,U+1F7D5-1F7D8,U+1F7D9-1F7DF,U+1F7E0-1F7EB,U+1F7EC-1F7FF,U+1F80C-1F80F,U+1F848-1F84F,U+1F85A-1F85F,U+1F888-1F88F,U+1F8AE-1F8FF,U+1F90C,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F972,U+1F973-1F976,U+1F977-1F979,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A3-1F9A4,U+1F9A5-1F9AA,U+1F9AB-1F9AD,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CB-1F9CC,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA00-1FA53,U+1FA54-1FA5F,U+1FA60-1FA6D,U+1FA6E-1FA6F,U+1FA70-1FA73,U+1FA74-1FA77,U+1FA78-1FA7A,U+1FA7B-1FA7F,U+1FA80-1FA82,U+1FA83-1FA8F,U+1FA90-1FA95,U+1FA96-1FFFD';
-
-            // And then we can use that range with our font when we load it.
-            const emojiOnlyFont = new FontFace(emojiFontName, 'url(fonts/NotoEmoji-Regular.ttf)', {
-              unicodeRange: emojiUnicodeRange,
-            });
-            emojiOnlyFont.load().then(() => {
-              document.fonts.add(emojiOnlyFont);
-            });
-            // We then set our fallback font as part of the font family we use in the canvas.
-            // This order matters, latter fonts will use the unicodeRange to override earlier fonts.
-            this.fontName = `Sans-serif, ${emojiFontName}`
+        /** Display the configuration for a printer. */
+        public showConfigModal(printer: WebLabel.LabelPrinterUsb, printerIdx: number) {
+          if (printer === undefined || printerIdx < 0) {
+            return;
           }
+          const config = printer.printerOptions;
+          // If the printer uses ZPL it will have a special config, show those!
+          const isZpl = config instanceof WebLabel.ZPL.ZplPrinterConfig;
 
-          // Some storage fields and utility properties
-          private fontName: string;
-          private configModalHandle: bootstrap.Modal;
+          const formElement = this.configModal.querySelector('form')!;
+          const form = formElement.elements as ConfigModalForm;
 
-          get printers(): readonly WebLabel.LabelPrinterUsb[] {
-            return this.manager.devices;
-          }
-
-          // Track which printer is currently selected for operations
-          private _activePrinter = 0;
-          get activePrinter(): WebLabel.LabelPrinterUsb | undefined {
-            return this._activePrinter < 0 || this._activePrinter > this.printers.length
-              ? undefined
-              : this.printers[this._activePrinter];
-          }
-          set activePrinterIndex(printerIdx: number) {
-            this._activePrinter = printerIdx;
-            this.redrawTextCanvas();
-          }
-
-          /** Initialize the app */
-          public async init() {
-            this.redrawPrinterButtons();
-            this.redrawTextCanvas();
-          }
-
-          /** Display the configuration for a printer. */
-          public showConfigModal(printer: WebLabel.LabelPrinterUsb, printerIdx: number) {
-            if (printer === undefined || printerIdx < 0) {
-              return;
-            }
-            const config = printer.printerOptions;
-            // If the printer uses ZPL it will have a special config, show those!
-            const isZpl = config instanceof WebLabel.ZPL.ZplPrinterConfig;
-
-            const formElement = this.configModal.querySelector('form')!;
-            const form = formElement.elements as ConfigModalForm;
-
-            // Only show ZPL settings if the printer language is ZPL.
-            for (const e of formElement.getElementsByTagName('modal-setting-zpl')) {
-              if (isZpl) {
-                e.classList.remove('d-hide');
-              } else {
-                e.classList.add('d-hide');
-              }
-            }
-
-            // Translate the available speeds to options to be selected
-            form.modalSpeed.innerHTML = '';
-            const speedTable = printer.printerOptions.speedTable.table;
-            for (const [key] of speedTable) {
-              // Skip utility values, so long as there's more than the defaults.
-              // Mobile printers *only* support auto, for example.
-              if ((speedTable.size > 3)
-                && (key === WebLabel.PrintSpeed.ipsAuto
-                  || key === WebLabel.PrintSpeed.ipsPrinterMax
-                  || key === WebLabel.PrintSpeed.ipsPrinterMin
-                )) {
-                continue;
-              }
-              const opt = document.createElement('option');
-              opt.value = key.toString();
-              opt.innerHTML = WebLabel.PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
-              form.modalSpeed.appendChild(opt);
-            }
-            form.modalSpeed.value = config.speed.printSpeed.toString();
-
-            switch (config.mediaGapDetectMode) {
-              case WebLabel.MediaMediaGapDetectionMode.continuous:
-                form.modalMediaType.value = "continuous";
-                break;
-              default:
-              case WebLabel.MediaMediaGapDetectionMode.webSensing:
-                form.modalMediaType.value = "gap";
-                break;
-              case WebLabel.MediaMediaGapDetectionMode.markSensing:
-                form.modalMediaType.value = "mark";
-                break;
-            }
-
-            // The other elements are just text.
-            (formElement.querySelector('#modalPrinterIndexText') as HTMLInputElement)!.textContent = printerIdx.toString();
-            form.modalPrinterIndex.value    = config.serialNumber;
-            form.modalLabelWidth.value      = config.mediaWidthInches.toString();
-            form.modalLabelHeight.value     = config.mediaLengthInches.toString();
-            form.modalDarkness.value        = config.darknessPercent.toString();
-            form.modalLabelOffsetLeft.value = config.mediaPrintOriginOffsetDots.left.toString();
-            form.modalLabelOffsetTop.value  = config.mediaPrintOriginOffsetDots.top.toString();
-            form.modalBackfeedPercent.value = config.backfeedAfterTaken.toString();
-
+          // Only show ZPL settings if the printer language is ZPL.
+          for (const e of formElement.getElementsByTagName('modal-setting-zpl')) {
             if (isZpl) {
-              form.modalZplRibbonTHold.value = config.ribbonThreshold.toString();
-              form.modalZplRibbonGain.value  = config.ribbonGain.toString();
-              form.modalZplWebTHold.value    = config.webThreshold.toString();
-              form.modalZplWebMedia.value    = config.mediaThreshold.toString();
-              form.modalZplTransGain.value   = config.transGain.toString();
-              form.modalZplMarkTHold.value   = config.markThreshold.toString();
-              form.modalZplMarkMedia.value   = config.markMediaThreshold.toString();
-              form.modalZplMarkGain.value    = config.markGain.toString();
-
-              form.modalZplPowerUpAction.value   = config.actionPowerUp.toString();
-              form.modalZplHeadCloseAction.value = config.actionHeadClose.toString();
-            }
-
-            this.configModalHandle.show();
-          }
-
-          /** Erase and re-draw the list of printer buttons in the UI. */
-          private redrawPrinterButtons() {
-            this.btnContainer.innerHTML = '';
-            this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
-          }
-
-          /** Highlight only the currently selected printer. */
-          private redrawPrinterButtonHighlights() {
-            this.printers.forEach((printer, idx) => {
-              const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
-              const element = document.getElementById(`printer_${idx}`)!;
-              element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
-            });
-          }
-
-          /** Add a printer's button UI to the list of printers. */
-          private drawPrinterButton(printer: WebLabel.LabelPrinterUsb, idx: number) {
-            const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
-
-            // Generate a new label printer button for the given printer.
-            const element = document.createElement("div");
-            element.innerHTML = `
-            <li id="printer_${idx}" data-printer-idx="${idx}"
-                class="list-group-item d-flex flex-row justify-content-between sligh-items-start"
-                style="background: linear-gradient(to right, ${highlight}, ${highlight}, grey, grey);">
-                <div class="col-sm-8">
-                    <div class="col-sm-12">
-                        <span data-serial="${printer.printerOptions.serialNumber}">${printer.printerOptions.serialNumber}</span>
-                    </div>
-                    <div class="col-sm-12">
-                        <span>${printer.printerOptions.mediaWidthInches}" x ${printer.printerOptions.mediaLengthInches}"</span>
-                    </div>
-                </div>
-                <div class="d-flex flex-row justify-content-end">
-                    <div class="btn-group" role="group" aria-label="Printer button group">
-                        <button id="printto_${idx}" class="btn btn-success btn-lg" data-label-width="${printer.printerOptions.mediaWidthInches}" data-label-height="${printer.printerOptions.mediaLengthInches}" data-printer-idx="${idx}">🖨</button>
-                            <button class="btn btn-success dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-                                <span class="visually-hidden">Settings</span>
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li><a id="printtest_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                                    Print test page
-                                </a></li>
-                                <li><a id="feedlabel_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                                    Feed blank label
-                                </a></li>
-                                <li><a id="configprinter_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                                    Set label config
-                                </a></li>
-                                <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                                    Print config on labels
-                                </a></li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </li>`;
-            // And slap it into the button container.
-            this.btnContainer.appendChild(element);
-
-            // Then wire up the button events so they work.
-            document.getElementById(`printto_${idx}`)!
-              .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                const doc = this.addCanvasImageToLabelDoc(printer.getLabelDocument());
-                await printer.sendDocument(doc);
-              });
-            document.getElementById(`printer_${idx}`)!
-              .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                if (this._activePrinter === printerIdx) {
-                  // Don't refresh anything if we already have this printer selected..
-                  return;
-                }
-                this.activePrinterIndex = printerIdx;
-                this.redrawPrinterButtonHighlights();
-                this.redrawTextCanvas();
-              });
-            document.getElementById(`printtest_${idx}`)!
-              .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                const doc = WebLabel.ReadyToPrintDocuments.printTestLabelDocument(
-                  printer.printerOptions.mediaWidthDots);
-                await printer.sendDocument(doc);
-              });
-            document.getElementById(`feedlabel_${idx}`)!
-              .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                const doc = WebLabel.ReadyToPrintDocuments.feedLabelDocument;
-                await printer.sendDocument(doc);
-              });
-            document.getElementById(`printconfig_${idx}`)!
-              .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                const doc = WebLabel.ReadyToPrintDocuments.printConfigDocument;
-                await printer.sendDocument(doc);
-              });
-            document.getElementById(`configprinter_${idx}`)!
-              .addEventListener('click', async (e) => {
-                e.preventDefault();
-                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
-                const printer = this.printers[printerIdx];
-                this.showConfigModal(printer, printerIdx);
-              });
-          }
-
-          /** Redraw the text canvas size according to the printer. */
-          private redrawTextCanvas() {
-            const printer = this.activePrinter;
-            if (printer === undefined) {
-              this.labelForm.classList.add('d-none');
-              this.labelFormInstructions.classList.remove('d-none');
-              return;
+              e.classList.remove('d-hide');
             } else {
-              this.labelForm.classList.remove('d-none');
-              this.labelFormInstructions.classList.add('d-none');
+              e.classList.add('d-hide');
             }
-
-            // Resize the canvas to match the label size.
-            const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-            // Add a small margin as printer alignment is not exact.
-            canvas.width = printer.printerOptions.mediaWidthDots - 2;
-            canvas.height = printer.printerOptions.mediaLengthDots - 2;
-
-            const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-            textarea.value = "Enter your label text here!";
-            this.renderTextForm();
           }
 
-          /** Render the text form to the canvas */
-          private renderTextForm() {
-            const printer = this.activePrinter;
-            if (printer === undefined) {
-              return;
+          // Translate the available speeds to options to be selected
+          form.modalSpeed.innerHTML = '';
+          const speedTable = printer.printerOptions.speedTable.table;
+          for (const [key] of speedTable) {
+            // Skip utility values, so long as there's more than the defaults.
+            // Mobile printers *only* support auto, for example.
+            if ((speedTable.size > 3)
+              && (key === WebLabel.PrintSpeed.ipsAuto
+                || key === WebLabel.PrintSpeed.ipsPrinterMax
+                || key === WebLabel.PrintSpeed.ipsPrinterMin
+              )) {
+              continue;
             }
+            const opt = document.createElement('option');
+            opt.value = key.toString();
+            opt.innerHTML = WebLabel.PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
+            form.modalSpeed.appendChild(opt);
+          }
+          form.modalSpeed.value = config.speed.printSpeed.toString();
 
-            const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-            const fontsizer = this.labelForm.querySelector('#previewFontSize') as HTMLInputElement;
-            const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-            const pageContext = canvas.getContext('2d')!;
-            pageContext.clearRect(0, 0, canvas.width, canvas.height);
-
-            const fontSize = Math.trunc(parseFloat(fontsizer.value));
-
-            // We'd like the preview image to be as close as possible to what the printer will
-            // actually print. To do this we don't draw text to the page's canvas directly,
-            // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
-            // then render *that* back to the page's canvas. This is a more accurate picture of
-            // what the label will end up looking like.
-
-            // A more complex app could do this more gracefully!
-            const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d')!;
-            offscreenContext.font = `${fontSize}pt ${this.fontName}`;
-            offscreenContext.fillStyle = "#000000";
-
-            // fillText doesn't do newlines, do that manually
-            textarea.value.split('\n').forEach((l, i) => {
-              offscreenContext.fillText(l, 5, (i * fontSize + 2) + fontSize);
-            })
-
-            // Now into the monochrome bitmap.
-            const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
-            const monoImg = WebLabel.BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
-            // And finally back onto the page.
-            pageContext.putImageData(monoImg.toImageData(), 0, 0);
+          switch (config.mediaGapDetectMode) {
+            case WebLabel.MediaMediaGapDetectionMode.continuous:
+              form.modalMediaType.value = "continuous";
+              break;
+            default:
+            case WebLabel.MediaMediaGapDetectionMode.webSensing:
+              form.modalMediaType.value = "gap";
+              break;
+            case WebLabel.MediaMediaGapDetectionMode.markSensing:
+              form.modalMediaType.value = "mark";
+              break;
           }
 
-          /** Render the canvas to a document for printing */
-          private addCanvasImageToLabelDoc(builder: WebLabel.ILabelDocumentBuilder): WebLabel.IDocument {
-            const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-            const imgData = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
+          // The other elements are just text.
+          (formElement.querySelector('#modalPrinterIndexText') as HTMLInputElement)!.textContent = printerIdx.toString();
+          form.modalPrinterIndex.value    = config.serialNumber;
+          form.modalLabelWidth.value      = config.mediaWidthInches.toString();
+          form.modalLabelHeight.value     = config.mediaLengthInches.toString();
+          form.modalDarkness.value        = config.darknessPercent.toString();
+          form.modalLabelOffsetLeft.value = config.mediaPrintOriginOffsetDots.left.toString();
+          form.modalLabelOffsetTop.value  = config.mediaPrintOriginOffsetDots.top.toString();
+          form.modalBackfeedPercent.value = config.backfeedAfterTaken.toString();
 
-            // One of the benefits of this library is being able to render images to a canvas element
-            // and sending that canvas directly to a label. This allows your webpage to generate complex
-            // images and fonts (like emoji!) that EPL/ZPL can't support.
-            return builder
-              .addImageFromImageData(imgData)
-              .addPrintCmd()
-              .finalize();
+          if (isZpl) {
+            form.modalZplRibbonTHold.value = config.ribbonThreshold.toString();
+            form.modalZplRibbonGain.value  = config.ribbonGain.toString();
+            form.modalZplWebTHold.value    = config.webThreshold.toString();
+            form.modalZplWebMedia.value    = config.mediaThreshold.toString();
+            form.modalZplTransGain.value   = config.transGain.toString();
+            form.modalZplMarkTHold.value   = config.markThreshold.toString();
+            form.modalZplMarkMedia.value   = config.markMediaThreshold.toString();
+            form.modalZplMarkGain.value    = config.markGain.toString();
+
+            form.modalZplPowerUpAction.value   = config.actionPowerUp.toString();
+            form.modalZplHeadCloseAction.value = config.actionHeadClose.toString();
           }
 
-          /** Send the contents of the config form as a config label to the printer. */
-          private async updatePrinterConfig(e: SubmitEvent) {
-            e.preventDefault();
+          this.configModalHandle.show();
+        }
 
-            // Figure out the right printer
-            const formElement = this.configModal.querySelector('form')!;
-            const form = formElement.elements as ConfigModalForm;
-            const printerIdx = parseInt((formElement.querySelector('#modalPrinterIndexText') as HTMLFormElement).innerText);
-            const printer = this.printers[printerIdx];
-            if (printer === undefined) {
-              return;
-            }
-            const isZpl = printer.printerOptions instanceof WebLabel.ZPL.ZplPrinterConfig;
+        /** Erase and re-draw the list of printer buttons in the UI. */
+        private redrawPrinterButtons() {
+          this.btnContainer.innerHTML = '';
+          this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
+        }
 
-            form.modalSubmit.setAttribute("disabled", "");
-            form.modalCancel.setAttribute("disabled", "");
+        /** Highlight only the currently selected printer. */
+        private redrawPrinterButtonHighlights() {
+          this.printers.forEach((printer, idx) => {
+            const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
+            const element = document.getElementById(`printer_${idx}`)!;
+            element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
+          });
+        }
 
-            // Pull the values out of the form.
-            const darkness = parseInt(form.modalDarkness.value) as WebLabel.DarknessPercent;
-            const rawSpeed = parseInt(form.modalSpeed.value) as WebLabel.PrintSpeed;
-            const mediaWidthInches = parseFloat(form.modalLabelWidth.value);
+        /** Add a printer's button UI to the list of printers. */
+        private drawPrinterButton(printer: WebLabel.LabelPrinterUsb, idx: number) {
+          const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
 
-            const mediaLengthInches = parseFloat(form.modalLabelHeight.value);
-            const offsetLeft = parseInt(form.modalLabelOffsetLeft.value);
-            const offsetTop = parseInt(form.modalLabelOffsetTop.value);
+          // Generate a new label printer button for the given printer.
+          const element = document.createElement("div");
+          element.innerHTML = `
+          <li id="printer_${idx}" data-printer-idx="${idx}"
+              class="list-group-item d-flex flex-row justify-content-between sligh-items-start"
+              style="background: linear-gradient(to right, ${highlight}, ${highlight}, grey, grey);">
+              <div class="col-sm-8">
+                  <div class="col-sm-12">
+                      <span data-serial="${printer.printerOptions.serialNumber}">${printer.printerOptions.serialNumber}</span>
+                  </div>
+                  <div class="col-sm-12">
+                      <span>${printer.printerOptions.mediaWidthInches}" x ${printer.printerOptions.mediaLengthInches}"</span>
+                  </div>
+              </div>
+              <div class="d-flex flex-row justify-content-end">
+                  <div class="btn-group" role="group" aria-label="Printer button group">
+                      <button id="printto_${idx}" class="btn btn-success btn-lg" data-label-width="${printer.printerOptions.mediaWidthInches}" data-label-height="${printer.printerOptions.mediaLengthInches}" data-printer-idx="${idx}">🖨</button>
+                          <button class="btn btn-success dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                              <span class="visually-hidden">Settings</span>
+                          </button>
+                          <ul class="dropdown-menu">
+                              <li><a id="printtest_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                  Print test page
+                              </a></li>
+                              <li><a id="feedlabel_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                  Feed blank label
+                              </a></li>
+                              <li><a id="configprinter_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                  Set label config
+                              </a></li>
+                              <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                  Print config on labels
+                              </a></li>
+                          </ul>
+                      </div>
+                  </div>
+              </div>
+          </li>`;
+          // And slap it into the button container.
+          this.btnContainer.appendChild(element);
 
-            const backfeedAfterTaken = form.modalBackfeedPercent.value as WebLabel.BackfeedAfterTaken;
+          // Then wire up the button events so they work.
+          document.getElementById(`printto_${idx}`)!
+            .addEventListener('click', async (e) => {
+              e.preventDefault();
+              const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+              const printer = this.printers[printerIdx];
+              const doc = this.addCanvasImageToLabelDoc(printer.getLabelDocument());
+              await printer.sendDocument(doc);
+            });
+          document.getElementById(`printer_${idx}`)!
+            .addEventListener('click', async (e) => {
+              e.preventDefault();
+              const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+              if (this._activePrinter === printerIdx) {
+                // Don't refresh anything if we already have this printer selected..
+                return;
+              }
+              this.activePrinterIndex = printerIdx;
+              this.redrawPrinterButtonHighlights();
+              this.redrawLabelCanvas();
+            });
+          document.getElementById(`printtest_${idx}`)!
+            .addEventListener('click', async (e) => {
+              e.preventDefault();
+              const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+              const printer = this.printers[printerIdx];
+              const doc = WebLabel.ReadyToPrintDocuments.printTestLabelDocument(
+                printer.printerOptions.mediaWidthDots);
+              await printer.sendDocument(doc);
+            });
+          document.getElementById(`feedlabel_${idx}`)!
+            .addEventListener('click', async (e) => {
+              e.preventDefault();
+              const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+              const printer = this.printers[printerIdx];
+              const doc = WebLabel.ReadyToPrintDocuments.feedLabelDocument;
+              await printer.sendDocument(doc);
+            });
+          document.getElementById(`printconfig_${idx}`)!
+            .addEventListener('click', async (e) => {
+              e.preventDefault();
+              const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+              const printer = this.printers[printerIdx];
+              const doc = WebLabel.ReadyToPrintDocuments.printConfigDocument;
+              await printer.sendDocument(doc);
+            });
+          document.getElementById(`configprinter_${idx}`)!
+            .addEventListener('click', async (e) => {
+              e.preventDefault();
+              const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+              const printer = this.printers[printerIdx];
+              this.showConfigModal(printer, printerIdx);
+            });
+        }
 
-            // Construct the config document with the values from the form
-            const configDoc = printer.getConfigDocument();
+        /** Redraw the canvas size according to the selected printer. */
+        private redrawLabelCanvas() {
+          const printer = this.activePrinter;
+          if (printer === undefined) {
+            this.editor.containerElement.classList.add('d-none');
+            this.labelFormInstructions.classList.remove('d-none');
+            return;
 
-            // Form mode should be set first for other elements to work right.
-            switch (form.modalMediaType.value) {
-              case "continuous":
-                configDoc.setLabelMediaToContinuous(mediaLengthInches);
-                break;
-              case "mark":
-                // TODO: Make a form for black line sensing.
-                configDoc.setLabelMediaToMarkSense(mediaLengthInches, 16, 0);
+          } else {
+            // Set the actual resolution of the canvas
+            this.editor.canvas.setDimensions({
+              height: printer.printerOptions.mediaLengthDots - 2,
+              width: printer.printerOptions.mediaWidthDots - 2,
+            });
+            // Scale the CSS size by half, keeping the same resolution.
+            this.editor.canvas.setDimensions({
+              height: printer.printerOptions.mediaLengthDots / 2,
+              width: printer.printerOptions.mediaWidthDots / 2,
+            }, { cssOnly: true });
+
+            this.editor.containerElement.classList.remove('d-none');
+            this.labelFormInstructions.classList.add('d-none');
+          }
+        }
+
+        /** Render the canvas to a document for printing */
+        private addCanvasImageToLabelDoc(builder: WebLabel.ILabelDocumentBuilder): WebLabel.IDocument {
+          const canvas = this.editor.canvas.toCanvasElement();
+          const imgData = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
+
+          // One of the benefits of this library is being able to render images to a canvas element
+          // and sending that canvas directly to a label. This allows your webpage to generate complex
+          // images and fonts (like emoji!) that EPL/ZPL can't support.
+          return builder
+            .addImageFromImageData(imgData)
+            .addPrintCmd()
+            .finalize();
+        }
+
+        /** Send the contents of the config form as a config label to the printer. */
+        private async updatePrinterConfig(e: SubmitEvent) {
+          e.preventDefault();
+
+          // Figure out the right printer
+          const formElement = this.configModal.querySelector('form')!;
+          const form = formElement.elements as ConfigModalForm;
+          const printerIdx = parseInt((formElement.querySelector('#modalPrinterIndexText') as HTMLFormElement).innerText);
+          const printer = this.printers[printerIdx];
+          if (printer === undefined) {
+            return;
+          }
+          const isZpl = printer.printerOptions instanceof WebLabel.ZPL.ZplPrinterConfig;
+
+          form.modalSubmit.setAttribute("disabled", "");
+          form.modalCancel.setAttribute("disabled", "");
+
+          // Pull the values out of the form.
+          const darkness = parseInt(form.modalDarkness.value) as WebLabel.DarknessPercent;
+          const rawSpeed = parseInt(form.modalSpeed.value) as WebLabel.PrintSpeed;
+          const mediaWidthInches = parseFloat(form.modalLabelWidth.value);
+
+          const mediaLengthInches = parseFloat(form.modalLabelHeight.value);
+          const offsetLeft = parseInt(form.modalLabelOffsetLeft.value);
+          const offsetTop = parseInt(form.modalLabelOffsetTop.value);
+
+          const backfeedAfterTaken = form.modalBackfeedPercent.value as WebLabel.BackfeedAfterTaken;
+
+          // Construct the config document with the values from the form
+          const configDoc = printer.getConfigDocument();
+
+          // Form mode should be set first for other elements to work right.
+          switch (form.modalMediaType.value) {
+            case "continuous":
+              configDoc.setLabelMediaToContinuous(mediaLengthInches);
+              break;
+            case "mark":
+              // TODO: Make a form for black line sensing.
+              configDoc.setLabelMediaToMarkSense(mediaLengthInches, 16, 0);
+              break;
+            default:
+            case "gap":
+              // TODO: Make a form for label gap size.
+              configDoc.setLabelMediaToWebGapSense(mediaLengthInches, 16);
+              break;
+          }
+
+          configDoc
+            .setPrintDirection()
+            .setLabelPrintOriginOffsetCommand(offsetLeft, offsetTop)
+            .setPrintSpeed(rawSpeed)
+            .setDarknessConfig(darkness)
+            .setLabelDimensions(mediaWidthInches)
+            .setBackfeedAfterTakenMode(backfeedAfterTaken);
+
+          if (isZpl) {
+            // Send the ZPL-specific settings too!
+            let actionPowerUp: WebLabel.ZPL.PowerUpAction;
+            switch (form.modalZplPowerUpAction.value) {
+              case "none":
+                actionPowerUp = "none";
                 break;
               default:
-              case "gap":
-                // TODO: Make a form for label gap size.
-                configDoc.setLabelMediaToWebGapSense(mediaLengthInches, 16);
+              case "feedBlank":
+                actionPowerUp = "feedBlank";
+                break;
+              case "calibrateWebSensor":
+                actionPowerUp = "calibrateWebLength";
+                break;
+            }
+
+            let actionHeadClose: WebLabel.ZPL.PowerUpAction;
+            switch (form.modalZplHeadCloseAction.value) {
+              case "none":
+                actionHeadClose = "none";
+                break;
+              default:
+              case "feedBlank":
+                actionHeadClose = "feedBlank";
+                break;
+              case "calibrateWebSensor":
+                actionHeadClose = "calibrateWebLength";
                 break;
             }
 
             configDoc
-              .setPrintDirection()
-              .setLabelPrintOriginOffsetCommand(offsetLeft, offsetTop)
-              .setPrintSpeed(rawSpeed)
-              .setDarknessConfig(darkness)
-              .setLabelDimensions(mediaWidthInches)
-              .setBackfeedAfterTakenMode(backfeedAfterTaken);
-
-            if (isZpl) {
-              // Send the ZPL-specific settings too!
-              let actionPowerUp: WebLabel.ZPL.PowerUpAction;
-              switch (form.modalZplPowerUpAction.value) {
-                case "none":
-                  actionPowerUp = "none";
-                  break;
-                default:
-                case "feedBlank":
-                  actionPowerUp = "feedBlank";
-                  break;
-                case "calibrateWebSensor":
-                  actionPowerUp = "calibrateWebLength";
-                  break;
-              }
-
-              let actionHeadClose: WebLabel.ZPL.PowerUpAction;
-              switch (form.modalZplHeadCloseAction.value) {
-                case "none":
-                  actionHeadClose = "none";
-                  break;
-                default:
-                case "feedBlank":
-                  actionHeadClose = "feedBlank";
-                  break;
-                case "calibrateWebSensor":
-                  actionHeadClose = "calibrateWebLength";
-                  break;
-              }
-
-              configDoc
-                .andThen(new WebLabel.ZPL.CmdSetPowerUpAndHeadCloseAction(
-                  actionPowerUp, actionHeadClose
-                ))
-                .andThen(new WebLabel.ZPL.CmdSetSensorCalibration({
-                  markGain          : Number(form.modalZplMarkGain.value),
-                  markMediaThreshold: Number(form.modalZplMarkMedia.value),
-                  markThreshold     : Number(form.modalZplMarkTHold.value),
-                  transGain         : Number(form.modalZplTransGain.value),
-                  mediaThreshold    : Number(form.modalZplWebMedia.value),
-                  ribbonGain        : Number(form.modalZplRibbonGain.value),
-                  ribbonThreshold   : Number(form.modalZplRibbonTHold.value),
-                  webThreshold      : Number(form.modalZplWebTHold.value),
-                }));
-            }
-
-            let doc: WebLabel.IDocument;
-            if (form.modalWithAutosense.checked) {
-              doc = configDoc.autosenseLabelLength();
-            } else if (isZpl && form.modalZplWithSensorGraph.checked) {
-              doc = configDoc.andThen(new WebLabel.ZPL.CmdGraphSensorCalibration()).finalize();
-            } else {
-              doc = configDoc.finalize();
-            }
-
-            // And send the whole shebang to the printer!
-            await printer.sendDocument(doc);
-
-            form.modalWithAutosense.checked = false;
-            form.modalZplWithSensorGraph.checked = false;
-            form.modalSubmit.removeAttribute("disabled");
-            form.modalCancel.removeAttribute("disabled");
-            this.activePrinterIndex = printerIdx;
-            this.configModalHandle.hide();
+              .andThen(new WebLabel.ZPL.CmdSetPowerUpAndHeadCloseAction(
+                actionPowerUp, actionHeadClose
+              ))
+              .andThen(new WebLabel.ZPL.CmdSetSensorCalibration({
+                markGain          : Number(form.modalZplMarkGain.value),
+                markMediaThreshold: Number(form.modalZplMarkMedia.value),
+                markThreshold     : Number(form.modalZplMarkTHold.value),
+                transGain         : Number(form.modalZplTransGain.value),
+                mediaThreshold    : Number(form.modalZplWebMedia.value),
+                ribbonGain        : Number(form.modalZplRibbonGain.value),
+                ribbonThreshold   : Number(form.modalZplRibbonTHold.value),
+                webThreshold      : Number(form.modalZplWebTHold.value),
+              }));
           }
-        }
 
-        // With the app class defined we can run it.
-        // First up collect the basic structure of the app
-        const btnContainer          = document.getElementById("printerlist")!;
-        const labelForm             = document.getElementById("labelForm")!;
-        const labelFormInstructions = document.getElementById("labelFormInstructions")!;
-        const configModal           = document.getElementById("printerOptionModal")!;
-
-        // And feed that into the app class to manage the elements
-        const app = new BasicLabelDesignerApp(printerMgr, btnContainer, labelForm, labelFormInstructions, configModal);
-        // and let it take over the UI.
-        await app.init();
-
-        // Make the TypeScript type system happy by adding a property to the Window object.
-        declare global {
-          interface Window { label_app: BasicLabelDesignerApp }
-        }
-        // Now we can access our printer in the dev console if we want to mess with it!
-        window.label_app = app;
-
-        // Now we'll fire the reconnect since our UI is wired up.
-        try {
-          await printerMgr.forceReconnect();
-        } catch (e) {
-          if (e instanceof WebDevices.DriverAccessDeniedError) {
-            // This happens when the operating system didn't let Chrome connect.
-            // Usually either another tab is open talking to the device, or the driver
-            // is already loaded by another application.
-            showAlert(
-              'danger',
-              'alert-printer-comm-error',
-              `Operating system refused device access`,
-              `<p>This usually happens for one of these reasons:
-              <ul>
-              <li>Another browser tab is already connected.
-              <li>Another application loaded a driver to talk to the device.
-              <li>You're on Windows and need to replace the driver.
-              </ul>
-              Fix the issue and re-connect to the device.</p>`
-            );
+          let doc: WebLabel.IDocument;
+          if (form.modalWithAutosense.checked) {
+            doc = configDoc.autosenseLabelLength();
+          } else if (isZpl && form.modalZplWithSensorGraph.checked) {
+            doc = configDoc.andThen(new WebLabel.ZPL.CmdGraphSensorCalibration()).finalize();
+          } else {
+            doc = configDoc.finalize();
           }
-        }
 
-        // We're done here. Bring in the dancing lobsters.
+          // And send the whole shebang to the printer!
+          await printer.sendDocument(doc);
+
+          form.modalWithAutosense.checked = false;
+          form.modalZplWithSensorGraph.checked = false;
+          form.modalSubmit.removeAttribute("disabled");
+          form.modalCancel.removeAttribute("disabled");
+          this.activePrinterIndex = printerIdx;
+          this.configModalHandle.hide();
+        }
+      }
+
+      // With the app class defined we can run it.
+      // First up collect the basic structure of the app
+      const btnContainer          = document.getElementById("printerlist")!;
+      const labelFormInstructions = document.getElementById("labelFormInstructions")!;
+      const configModal           = document.getElementById("printerOptionModal")!;
+
+      // And feed that into the app class to manage the elements
+      const app = new BasicLabelDesignerApp(printerMgr, btnContainer, editor, labelFormInstructions, configModal);
+      // and let it take over the UI.
+      await app.init();
+
+      // Now we can access our printer in the dev console if we want to mess with it!
+      (window as any).label_app = app;
+
+      // Now we'll fire the reconnect since our UI is wired up.
+      try {
+        await printerMgr.forceReconnect();
+      } catch (e) {
+        if (e instanceof WebDevices.DriverAccessDeniedError) {
+          // This happens when the operating system didn't let Chrome connect.
+          // Usually either another tab is open talking to the device, or the driver
+          // is already loaded by another application.
+          showAlert(
+            'danger',
+            'alert-printer-comm-error',
+            `Operating system refused device access`,
+            `<p>This usually happens for one of these reasons:
+            <ul>
+            <li>Another browser tab is already connected.
+            <li>Another application loaded a driver to talk to the device.
+            <li>You're on Windows and need to replace the driver.
+            </ul>
+            Fix the issue and re-connect to the device.</p>`
+          );
+        }
+      }
+
+      // We're done here. Bring in the dancing lobsters.
 
     </script>
     <div>
-      <div class="container-fluid">
-        <div class="row" style="padding-top: 16px;">
-          <div class="col-3" id="printer-list-sidebar">
+      <div class="container-fluid" style="height: 100%">
+        <div class="row" style="height: 100%">
+          <div class="col-3" id="printer-list-sidebar" style="padding-top: 16px;">
             <div class="d-grid gap-2 col-8 mx-auto mb-3">
               <div class="row">
                 <div class="col-9">
@@ -790,7 +707,7 @@
           </div>
           <div class="col-9">
             <div class="row">
-              <div class="col-12" id="printerAlertSpace">
+              <div class="col-12" id="printerAlertSpace" style="padding-top: 16px;">
                 <div class="alert alert-warning alert-dismissible d-none" role="alert" id="windowsDriverWarning">
                   <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                   <h4>Windows may need extra configuration</h4>
@@ -823,21 +740,8 @@
               <p>Connect a printer to your computer, then click Add Printer!</p>
               <p>Once a printer is connected select it by clicking on it on the left.</p>
             </div>
-            <div class="row">
-              <form id="labelForm" action="javascript:void(0);" class="d-none">
-                <div id="image-editor-container"></div>
-                <h5>Input</h5>
-                <label for="previewFontSize" class="form-label">Font Size</label>
-                <div class="input-group">
-                  <input id="previewFontSize" type="number" class="form-control" placeholder="16"
-                    aria-label="Font Size" value="16">
-                </div>
-                <textarea id="labelFormText" name="labelText" cols="40" rows="10" wrap="hard"
-                  style="font-family: monospace; resize: both;"
-                  placeholder="Enter your label text here!"></textarea>
-                <h5>Preview</h5>
-                <canvas id="labelCanvas" width="584" height="160" style="border: 2px solid blue; background-color: white; margin-bottom: 10px;"></canvas>
-              </form>
+            <div class="row" style="height: 100%; overflow-x: hidden">
+              <div id="image-editor-container"></div>
             </div>
           </div>
         </div>

--- a/demo/editor.html
+++ b/demo/editor.html
@@ -707,7 +707,7 @@
           </div>
           <div class="col-9">
             <div class="row">
-              <div class="col-12" id="printerAlertSpace" style="padding-top: 16px;">
+              <div class="col-12" id="printerAlertSpace">
                 <div class="alert alert-warning alert-dismissible d-none" role="alert" id="windowsDriverWarning">
                   <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                   <h4>Windows may need extra configuration</h4>

--- a/demo/editor.html
+++ b/demo/editor.html
@@ -1,0 +1,1138 @@
+<html>
+
+<head>
+    <title>Label Editor</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="light dark">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-dark-5@1.1.3/dist/css/bootstrap-dark-plugin.min.css"
+        rel="stylesheet">
+    <meta name="theme-color" content="#111111" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#eeeeee" media="(prefers-color-scheme: dark)">
+</head>
+<body>
+    <a href="https://github.com/cellivar/webzlp" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
+    <script type="importmap">
+        {
+          "imports": {
+            "fabricjs-label-editor": "https://cellivar.github.io/fabricjs-label-editor/lib/index.ts",
+            "fabric": "https://cdn.jsdelivr.net/npm/fabric@6.5.4/dist/index.mjs",
+            "webzlp": "../src/index.ts",
+            "web-device-mux": "https://cellivar.github.io/WebDeviceMux/src/index.ts"
+          }
+        }
+    </script>
+    <script type="module" src="./ts-browser.js"></script>
+    <script type="text/javascript" id="emergency_shenanigans_reboot_script">
+
+        window.addEventListener('DOMContentLoaded', async () => {
+            // Just in case our shenanigans explode, provide an easier way to clear state.
+            document.getElementById('emergencyRefreshBtn').addEventListener('click', () => {
+                navigator.serviceWorker.getRegistration('../demo-sw.js')
+                    .then(r => r.unregister())
+                    .finally(result => window.location.reload());
+            });
+        });
+
+    </script>
+    <script type="text/typescript" id="just_shenanigans_to_make_the_page_work">
+
+        // Since we got this far it's safe to hide the loading indicator.
+        document.getElementById('loadingIndicator').classList.add('d-none');
+
+        // This bit detects if the browser supports WebUSB, displaying a warning if not.
+        if (navigator.usb === undefined) {
+            document.getElementById('browserNoWebUsb').classList.remove('d-none');
+        }
+
+        // Display a warning if the OS is windows, which needs some configuration.
+        if (navigator.appVersion.indexOf('Win') != -1) {
+            document.getElementById('windowsDriverWarning').classList.remove('d-none');
+        }
+
+        // Display a warning if the OS is linux, which may need some configuration.
+        if (navigator.appVersion.indexOf('Linux') != -1) {
+            document.getElementById('linuxDriverWarning').classList.remove('d-none');
+        }
+
+        // ChromeOS works out of the box!
+
+        // WebUSB requires HTTPS, show an error if the page wasn't loaded securely.
+        if (location.protocol !== 'https:') {
+            document.getElementById('urlNotSecure').classList.remove('d-none');
+        }
+
+    </script>
+
+    <!-- Here's some actual demo code. Note that it is typescript, not javascript. -->
+    <script type="text/typescript" id="cool_demo_code_to_show_off_the_lib">
+
+        // Import the canvas editor lib and make it available
+        import * as Editor from 'fabricjs-label-editor'
+        (window as any).LabelEditor = Editor;
+        (window as any).EditorApp = new Editor.ImageEditor(document.getElementById('image-editor-container')!);
+
+        // First import the lib!
+        // This is our lib in this repo here
+        import * as WebLabel from 'webzlp';
+
+        // This is a utility lib we'll be using that makes it easier to use devices.
+        import * as WebDevices from 'web-device-mux';
+
+        // We'll drop these into the Window object so we can play with them in
+        // the DevTools console if we want to.
+        (window as any).WebLabel = WebLabel;
+        (window as any).WebDevices = WebDevices;
+
+        // For this demo we're going to make use of the USB printer manager
+        // so it can take care of concerns like the USB connect and disconnect events.
+
+        // We'll set a type alias so it's easier to read our code
+        type PrinterManager = WebDevices.UsbDeviceManager<WebLabel.LabelPrinterUsb>;
+        // Then we'll construct one to use
+        const printerMgr: PrinterManager = new WebDevices.UsbDeviceManager(
+          window.navigator.usb,
+          WebLabel.LabelPrinter.fromUSBDevice,
+          {
+            // Enable debugging, so the dev console can fill up with interesting messages!
+            debug: true,
+            requestOptions: {
+              // Limit the USB devices we try to connect to.
+              filters: [
+                {
+                  vendorId: 0x0A5F // Zebra
+                }
+              ]
+            }
+          }
+        )
+
+        // We'll wire up some basic event listeners to the printer manager.
+        // First, a button to prompt a user to add a printer.
+        const addPrinterBtn = document.getElementById('addprinter')!;
+        addPrinterBtn.addEventListener('click', async () => printerMgr.promptForNewDevice());
+
+        // Next a button to manually refresh all printers, just in case.
+        const refreshPrinterBtn = document.getElementById('refreshPrinters')!;
+        refreshPrinterBtn.addEventListener('click', async () => printerMgr.forceReconnect());
+
+        // Next we wire up some events on the UsbDeviceManager itself.
+        printerMgr.addEventListener('connectedDevice', ({ detail }) => {
+
+          // Let's print some details about the printer that was connected.
+          const printer = detail.device;
+          console.log('New printer is a', printer.printerModel);
+          const config = printer.printerOptions;
+          console.log('Printer darkness is', config.darknessPercent, 'percent');
+          console.log('Printer speed is', WebLabel.PrintSpeed[config.speed.printSpeed]);
+          console.log(
+            'Label is',
+            config.mediaWidthInches,
+            'in wide and',
+            config.mediaLengthInches,
+            'in long');
+          console.log('Printer media mode is', WebLabel.MediaMediaGapDetectionMode[config.mediaGapDetectMode]);
+
+          // You can do stuff with the printer that connected. It's a good idea
+          // to immediately query the printer for its status.
+          printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
+        });
+
+        // There's also an event that will tell you when a printer disconnects.
+        printerMgr.addEventListener('disconnectedDevice', ({ detail }) => {
+          const printer = detail.device;
+          console.log('Lost printer', printer.printerModel, 'serial', printer.printerOptions.serialNumber);
+        });
+
+        // When the browser first loaded the page any previously connected printers would have caused
+        // a connection event. Our listener wasn't listening yet so missed it.
+        // It's good practice to force a reconnect once your event handlers are ready.
+        // We're going to skip this for now though, because we want it to happen after the app is ready.
+        //await printerMgr.reconnectAllPrinters();
+
+        // And that's all there is to setup! The page can now talk to printers.
+        // If you're using a chromebook this should just work. If you're on Windows
+        // you might need to do some driver setup, see the repo README for more details.
+
+        // The rest of this demo is an example of a basic label generator app.
+
+        // Get some bookkeeping out of the way..
+        // First we create an interface to describe our settings form.
+        interface ConfigModalForm extends HTMLCollection {
+          modalCancel          : HTMLButtonElement
+          modalSubmit          : HTMLButtonElement
+          modalPrinterIndex    : HTMLInputElement
+
+          // Media
+          modalLabelWidth     : HTMLInputElement
+          modalLabelHeight    : HTMLInputElement
+          modalLabelOffsetLeft: HTMLInputElement
+          modalLabelOffsetTop : HTMLInputElement
+          modalMediaType      : HTMLSelectElement
+          modalWithAutosense  : HTMLInputElement
+
+          // Printer
+          modalDarkness       : HTMLSelectElement
+          modalSpeed          : HTMLSelectElement
+          modalBackfeedPercent: HTMLSelectElement
+
+          // These are ZPL-specific settings. Different languages can have additional
+          // commands or configs specific to their printers.
+          // Sensors
+          modalZplRibbonTHold: HTMLInputElement
+          modalZplRibbonGain  : HTMLInputElement
+          modalZplWebTHold   : HTMLInputElement
+          modalZplWebMedia   : HTMLInputElement
+          modalZplTransGain     : HTMLInputElement
+          modalZplMarkTHold  : HTMLInputElement
+          modalZplMarkMedia  : HTMLInputElement
+          modalZplMarkGain    : HTMLInputElement
+
+          modalZplWithSensorGraph: HTMLInputElement
+
+          // Power up/head close actions
+          modalZplPowerUpAction  : HTMLSelectElement
+          modalZplHeadCloseAction: HTMLSelectElement
+        }
+
+
+        // A function to find and hide any alerts for a given alert ID.
+        function hideAlerts(alertId: string) {
+          const existingAlerts = document.getElementById('printerAlertSpace')?.querySelectorAll(`.${alertId}`) ?? [];
+          existingAlerts.forEach((a: Element) => { a.remove(); });
+        }
+
+        // A function to make it easier to show alerts
+        function showAlert(
+          level: 'warning' | 'danger',
+          alertId: string,
+          titleHtml: string,
+          bodyHtml: string,
+          closedCallback = () => {}
+        ) {
+          hideAlerts(alertId);
+
+          // Create the bootstrap alert div with the provided content
+          const alertWrapper = document.createElement('div');
+          alertWrapper.classList.add("alert", `alert-${level}`, "alert-dismissible", "fade", "show", alertId);
+          alertWrapper.id = alertId;
+          alertWrapper.role = "alert";
+          alertWrapper.innerHTML = `
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            <h4>${titleHtml}</h4>
+            ${bodyHtml}`;
+
+          // Add it to the document and activate it
+          document.getElementById('printerAlertSpace')?.appendChild(alertWrapper);
+          new bootstrap.Alert(alertWrapper);
+
+          alertWrapper.addEventListener('closed.bs.alert', closedCallback);
+        }
+
+        // The app's logic is wrapped in a class just for ease of reading.
+        class BasicLabelDesignerApp {
+          constructor(
+            private manager: PrinterManager,
+            private btnContainer: HTMLElement,
+            private labelForm: HTMLElement,
+            private labelFormInstructions: HTMLElement,
+            private configModal: HTMLElement
+          ) {
+            // Based on the containers, map the various listeners.
+            this.configModalHandle = new bootstrap.Modal(this.configModal);
+            this.configModal
+              .querySelector('form')!
+              .addEventListener('submit', this.updatePrinterConfig.bind(this));
+            this.labelForm.addEventListener('blur', this.renderTextForm.bind(this));
+            this.labelForm.addEventListener('keyup', this.renderTextForm.bind(this));
+
+            // Add a second set of event listeners for printer connect and disconnect to redraw
+            // the printer list when it changes.
+            this.manager.addEventListener('connectedDevice', ({ detail }) => {
+              this.activePrinterIndex = -1;
+              this.redrawPrinterButtons();
+
+              // Printers themselves also have events, let's show an alert on errors.
+              const printer = detail.device;
+              printer.addEventListener('reportedError', ({ detail: msg }) => {
+                // Use the same ID so there's only one error message per printer.
+                const alertId = `alert-printererror-${printer.printerSerial}`;
+                hideAlerts(alertId);
+
+                // Error messages are also status messages, such as indicating no problem.
+                if (msg.errors.size === 0 || msg.errors.has(WebLabel.ErrorState.NoError)) { return; }
+
+                showAlert(
+                  // Show a warning for this printer
+                  'warning',
+                  alertId,
+                  `Printer <strong>${printer.printerSerial}</strong> has an error`,
+                  // There can be multiple errors, just show their raw values. A better
+                  // application would use these for good messages!
+                  `<p><ul>${Array.from(msg.errors).map(e => `<li>${e}`)}</ul></p>
+                  <hr>
+                  <p>Fix the issue, then dismiss this alert to check the status again.</p>`,
+                  // And when the alert is dismissed, check the status again!
+                  () => printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument)
+                );
+              });
+            });
+            this.manager.addEventListener('disconnectedDevice', () => {
+              this.activePrinterIndex = -1;
+              this.redrawPrinterButtons();
+            });
+
+            // Here's a nice font with a great set of emoji that work well for monochrome printing.
+            // The text font is fairly basic though, so we would like to use only the emoji out
+            // of this font and use a basic sans-serif font for regular text.
+            // https://fonts.google.com/noto/specimen/Noto+Emoji
+            const emojiFontName = 'noto-emoji';
+
+            // We can accomplish this with the unicodeRange property of our FontFace. We just
+            // need to list EVERY SINGLE EMOJI UNICODE RANGE to make it work. Fortunately someone
+            // has done this already: https://github.com/fraction/emoji-unicode-range
+            const emojiUnicodeRange = 'U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2604,U+260E,U+2611,U+2614-2615,U+2618,U+261D,U+2620,U+2622-2623,U+2626,U+262A,U+262E-262F,U+2638-263A,U+2640,U+2642,U+2648-2653,U+265F-2660,U+2663,U+2665-2666,U+2668,U+267B,U+267E-267F,U+2692-2697,U+2699,U+269B-269C,U+26A0-26A1,U+26AA-26AB,U+26B0-26B1,U+26BD-26BE,U+26C4-26C5,U+26C8,U+26CE,U+26CF,U+26D1,U+26D3-26D4,U+26E9-26EA,U+26F0-26F5,U+26F7-26FA,U+26FD,U+2702,U+2705,U+2708-2709,U+270A-270B,U+270C-270D,U+270F,U+2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2764,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F004,U+1F0CF,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201-1F202,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F321,U+1F324-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F396-1F397,U+1F399-1F39B,U+1F39E-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F3-1F3F5,U+1F3F7,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD,U+1F4FF,U+1F500-1F53D,U+1F549-1F54A,U+1F54B-1F54E,U+1F550-1F567,U+1F56F-1F570,U+1F573-1F579,U+1F57A,U+1F587,U+1F58A-1F58D,U+1F590,U+1F595-1F596,U+1F5A4,U+1F5A5,U+1F5A8,U+1F5B1-1F5B2,U+1F5BC,U+1F5C2-1F5C4,U+1F5D1-1F5D3,U+1F5DC-1F5DE,U+1F5E1,U+1F5E3,U+1F5E8,U+1F5EF,U+1F5F3,U+1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CB-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6E0-1F6E5,U+1F6E9,U+1F6EB-1F6EC,U+1F6F0,U+1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+231A-231B,U+23E9-23EC,U+23F0,U+23F3,U+25FD-25FE,U+2614-2615,U+2648-2653,U+267F,U+2693,U+26A1,U+26AA-26AB,U+26BD-26BE,U+26C4-26C5,U+26CE,U+26D4,U+26EA,U+26F2-26F3,U+26F5,U+26FA,U+26FD,U+2705,U+270A-270B,U+2728,U+274C,U+274E,U+2753-2755,U+2757,U+2795-2797,U+27B0,U+27BF,U+2B1B-2B1C,U+2B50,U+2B55,U+1F004,U+1F0CF,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201,U+1F21A,U+1F22F,U+1F232-1F236,U+1F238-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F32D-1F32F,U+1F330-1F335,U+1F337-1F37C,U+1F37E-1F37F,U+1F380-1F393,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CF-1F3D3,U+1F3E0-1F3F0,U+1F3F4,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F440,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FF,U+1F500-1F53D,U+1F54B-1F54E,U+1F550-1F567,U+1F57A,U+1F595-1F596,U+1F5A4,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CC,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6EB-1F6EC,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+1F3FB-1F3FF,U+261D,U+26F9,U+270A-270B,U+270C-270D,U+1F385,U+1F3C2-1F3C4,U+1F3C7,U+1F3CA,U+1F3CB-1F3CC,U+1F442-1F443,U+1F446-1F450,U+1F466-1F478,U+1F47C,U+1F481-1F483,U+1F485-1F487,U+1F48F,U+1F491,U+1F4AA,U+1F574-1F575,U+1F57A,U+1F590,U+1F595-1F596,U+1F645-1F647,U+1F64B-1F64F,U+1F6A3,U+1F6B4-1F6B6,U+1F6C0,U+1F6CC,U+1F90F,U+1F918,U+1F919-1F91E,U+1F91F,U+1F926,U+1F930,U+1F931-1F932,U+1F933-1F939,U+1F93C-1F93E,U+1F9B5-1F9B6,U+1F9B8-1F9B9,U+1F9BB,U+1F9CD-1F9CF,U+1F9D1-1F9DD,U+0023,U+002A,U+0030-0039,U+200D,U+20E3,U+FE0F,U+1F1E6-1F1FF,U+1F3FB-1F3FF,U+1F9B0-1F9B3,U+E0020-E007F,U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+2388,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2605,U+2607-2612,U+2614-2615,U+2616-2617,U+2618,U+2619,U+261A-266F,U+2670-2671,U+2672-267D,U+267E-267F,U+2680-2685,U+2690-2691,U+2692-269C,U+269D,U+269E-269F,U+26A0-26A1,U+26A2-26B1,U+26B2,U+26B3-26BC,U+26BD-26BF,U+26C0-26C3,U+26C4-26CD,U+26CE,U+26CF-26E1,U+26E2,U+26E3,U+26E4-26E7,U+26E8-26FF,U+2700,U+2701-2704,U+2705,U+2708-2709,U+270A-270B,U+270C-2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2767,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F000-1F02B,U+1F02C-1F02F,U+1F030-1F093,U+1F094-1F09F,U+1F0A0-1F0AE,U+1F0AF-1F0B0,U+1F0B1-1F0BE,U+1F0BF,U+1F0C0,U+1F0C1-1F0CF,U+1F0D0,U+1F0D1-1F0DF,U+1F0E0-1F0F5,U+1F0F6-1F0FF,U+1F10D-1F10F,U+1F12F,U+1F16C,U+1F16D-1F16F,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1AD-1F1E5,U+1F201-1F202,U+1F203-1F20F,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F23C-1F23F,U+1F249-1F24F,U+1F250-1F251,U+1F252-1F25F,U+1F260-1F265,U+1F266-1F2FF,U+1F300-1F320,U+1F321-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F394-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F1-1F3F7,U+1F3F8-1F3FA,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD-1F4FE,U+1F4FF,U+1F500-1F53D,U+1F546-1F54A,U+1F54B-1F54F,U+1F550-1F567,U+1F568-1F579,U+1F57A,U+1F57B-1F5A3,U+1F5A4,U+1F5A5-1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6C6-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D3-1F6D4,U+1F6D5,U+1F6D6-1F6DF,U+1F6E0-1F6EC,U+1F6ED-1F6EF,U+1F6F0-1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F6FB-1F6FF,U+1F774-1F77F,U+1F7D5-1F7D8,U+1F7D9-1F7DF,U+1F7E0-1F7EB,U+1F7EC-1F7FF,U+1F80C-1F80F,U+1F848-1F84F,U+1F85A-1F85F,U+1F888-1F88F,U+1F8AE-1F8FF,U+1F90C,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F972,U+1F973-1F976,U+1F977-1F979,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A3-1F9A4,U+1F9A5-1F9AA,U+1F9AB-1F9AD,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CB-1F9CC,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA00-1FA53,U+1FA54-1FA5F,U+1FA60-1FA6D,U+1FA6E-1FA6F,U+1FA70-1FA73,U+1FA74-1FA77,U+1FA78-1FA7A,U+1FA7B-1FA7F,U+1FA80-1FA82,U+1FA83-1FA8F,U+1FA90-1FA95,U+1FA96-1FFFD';
+
+            // And then we can use that range with our font when we load it.
+            const emojiOnlyFont = new FontFace(emojiFontName, 'url(fonts/NotoEmoji-Regular.ttf)', {
+              unicodeRange: emojiUnicodeRange,
+            });
+            emojiOnlyFont.load().then(() => {
+              document.fonts.add(emojiOnlyFont);
+            });
+            // We then set our fallback font as part of the font family we use in the canvas.
+            // This order matters, latter fonts will use the unicodeRange to override earlier fonts.
+            this.fontName = `Sans-serif, ${emojiFontName}`
+          }
+
+          // Some storage fields and utility properties
+          private fontName: string;
+          private configModalHandle: bootstrap.Modal;
+
+          get printers(): readonly WebLabel.LabelPrinterUsb[] {
+            return this.manager.devices;
+          }
+
+          // Track which printer is currently selected for operations
+          private _activePrinter = 0;
+          get activePrinter(): WebLabel.LabelPrinterUsb | undefined {
+            return this._activePrinter < 0 || this._activePrinter > this.printers.length
+              ? undefined
+              : this.printers[this._activePrinter];
+          }
+          set activePrinterIndex(printerIdx: number) {
+            this._activePrinter = printerIdx;
+            this.redrawTextCanvas();
+          }
+
+          /** Initialize the app */
+          public async init() {
+            this.redrawPrinterButtons();
+            this.redrawTextCanvas();
+          }
+
+          /** Display the configuration for a printer. */
+          public showConfigModal(printer: WebLabel.LabelPrinterUsb, printerIdx: number) {
+            if (printer === undefined || printerIdx < 0) {
+              return;
+            }
+            const config = printer.printerOptions;
+            // If the printer uses ZPL it will have a special config, show those!
+            const isZpl = config instanceof WebLabel.ZPL.ZplPrinterConfig;
+
+            const formElement = this.configModal.querySelector('form')!;
+            const form = formElement.elements as ConfigModalForm;
+
+            // Only show ZPL settings if the printer language is ZPL.
+            for (const e of formElement.getElementsByTagName('modal-setting-zpl')) {
+              if (isZpl) {
+                e.classList.remove('d-hide');
+              } else {
+                e.classList.add('d-hide');
+              }
+            }
+
+            // Translate the available speeds to options to be selected
+            form.modalSpeed.innerHTML = '';
+            const speedTable = printer.printerOptions.speedTable.table;
+            for (const [key] of speedTable) {
+              // Skip utility values, so long as there's more than the defaults.
+              // Mobile printers *only* support auto, for example.
+              if ((speedTable.size > 3)
+                && (key === WebLabel.PrintSpeed.ipsAuto
+                  || key === WebLabel.PrintSpeed.ipsPrinterMax
+                  || key === WebLabel.PrintSpeed.ipsPrinterMin
+                )) {
+                continue;
+              }
+              const opt = document.createElement('option');
+              opt.value = key.toString();
+              opt.innerHTML = WebLabel.PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
+              form.modalSpeed.appendChild(opt);
+            }
+            form.modalSpeed.value = config.speed.printSpeed.toString();
+
+            switch (config.mediaGapDetectMode) {
+              case WebLabel.MediaMediaGapDetectionMode.continuous:
+                form.modalMediaType.value = "continuous";
+                break;
+              default:
+              case WebLabel.MediaMediaGapDetectionMode.webSensing:
+                form.modalMediaType.value = "gap";
+                break;
+              case WebLabel.MediaMediaGapDetectionMode.markSensing:
+                form.modalMediaType.value = "mark";
+                break;
+            }
+
+            // The other elements are just text.
+            (formElement.querySelector('#modalPrinterIndexText') as HTMLInputElement)!.textContent = printerIdx.toString();
+            form.modalPrinterIndex.value    = config.serialNumber;
+            form.modalLabelWidth.value      = config.mediaWidthInches.toString();
+            form.modalLabelHeight.value     = config.mediaLengthInches.toString();
+            form.modalDarkness.value        = config.darknessPercent.toString();
+            form.modalLabelOffsetLeft.value = config.mediaPrintOriginOffsetDots.left.toString();
+            form.modalLabelOffsetTop.value  = config.mediaPrintOriginOffsetDots.top.toString();
+            form.modalBackfeedPercent.value = config.backfeedAfterTaken.toString();
+
+            if (isZpl) {
+              form.modalZplRibbonTHold.value = config.ribbonThreshold.toString();
+              form.modalZplRibbonGain.value  = config.ribbonGain.toString();
+              form.modalZplWebTHold.value    = config.webThreshold.toString();
+              form.modalZplWebMedia.value    = config.mediaThreshold.toString();
+              form.modalZplTransGain.value   = config.transGain.toString();
+              form.modalZplMarkTHold.value   = config.markThreshold.toString();
+              form.modalZplMarkMedia.value   = config.markMediaThreshold.toString();
+              form.modalZplMarkGain.value    = config.markGain.toString();
+
+              form.modalZplPowerUpAction.value   = config.actionPowerUp.toString();
+              form.modalZplHeadCloseAction.value = config.actionHeadClose.toString();
+            }
+
+            this.configModalHandle.show();
+          }
+
+          /** Erase and re-draw the list of printer buttons in the UI. */
+          private redrawPrinterButtons() {
+            this.btnContainer.innerHTML = '';
+            this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
+          }
+
+          /** Highlight only the currently selected printer. */
+          private redrawPrinterButtonHighlights() {
+            this.printers.forEach((printer, idx) => {
+              const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
+              const element = document.getElementById(`printer_${idx}`)!;
+              element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
+            });
+          }
+
+          /** Add a printer's button UI to the list of printers. */
+          private drawPrinterButton(printer: WebLabel.LabelPrinterUsb, idx: number) {
+            const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
+
+            // Generate a new label printer button for the given printer.
+            const element = document.createElement("div");
+            element.innerHTML = `
+            <li id="printer_${idx}" data-printer-idx="${idx}"
+                class="list-group-item d-flex flex-row justify-content-between sligh-items-start"
+                style="background: linear-gradient(to right, ${highlight}, ${highlight}, grey, grey);">
+                <div class="col-sm-8">
+                    <div class="col-sm-12">
+                        <span data-serial="${printer.printerOptions.serialNumber}">${printer.printerOptions.serialNumber}</span>
+                    </div>
+                    <div class="col-sm-12">
+                        <span>${printer.printerOptions.mediaWidthInches}" x ${printer.printerOptions.mediaLengthInches}"</span>
+                    </div>
+                </div>
+                <div class="d-flex flex-row justify-content-end">
+                    <div class="btn-group" role="group" aria-label="Printer button group">
+                        <button id="printto_${idx}" class="btn btn-success btn-lg" data-label-width="${printer.printerOptions.mediaWidthInches}" data-label-height="${printer.printerOptions.mediaLengthInches}" data-printer-idx="${idx}">🖨</button>
+                            <button class="btn btn-success dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                                <span class="visually-hidden">Settings</span>
+                            </button>
+                            <ul class="dropdown-menu">
+                                <li><a id="printtest_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                    Print test page
+                                </a></li>
+                                <li><a id="feedlabel_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                    Feed blank label
+                                </a></li>
+                                <li><a id="configprinter_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                    Set label config
+                                </a></li>
+                                <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                    Print config on labels
+                                </a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </li>`;
+            // And slap it into the button container.
+            this.btnContainer.appendChild(element);
+
+            // Then wire up the button events so they work.
+            document.getElementById(`printto_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                const doc = this.addCanvasImageToLabelDoc(printer.getLabelDocument());
+                await printer.sendDocument(doc);
+              });
+            document.getElementById(`printer_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                if (this._activePrinter === printerIdx) {
+                  // Don't refresh anything if we already have this printer selected..
+                  return;
+                }
+                this.activePrinterIndex = printerIdx;
+                this.redrawPrinterButtonHighlights();
+                this.redrawTextCanvas();
+              });
+            document.getElementById(`printtest_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                const doc = WebLabel.ReadyToPrintDocuments.printTestLabelDocument(
+                  printer.printerOptions.mediaWidthDots);
+                await printer.sendDocument(doc);
+              });
+            document.getElementById(`feedlabel_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                const doc = WebLabel.ReadyToPrintDocuments.feedLabelDocument;
+                await printer.sendDocument(doc);
+              });
+            document.getElementById(`printconfig_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                const doc = WebLabel.ReadyToPrintDocuments.printConfigDocument;
+                await printer.sendDocument(doc);
+              });
+            document.getElementById(`configprinter_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                this.showConfigModal(printer, printerIdx);
+              });
+          }
+
+          /** Redraw the text canvas size according to the printer. */
+          private redrawTextCanvas() {
+            const printer = this.activePrinter;
+            if (printer === undefined) {
+              this.labelForm.classList.add('d-none');
+              this.labelFormInstructions.classList.remove('d-none');
+              return;
+            } else {
+              this.labelForm.classList.remove('d-none');
+              this.labelFormInstructions.classList.add('d-none');
+            }
+
+            // Resize the canvas to match the label size.
+            const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+            // Add a small margin as printer alignment is not exact.
+            canvas.width = printer.printerOptions.mediaWidthDots - 2;
+            canvas.height = printer.printerOptions.mediaLengthDots - 2;
+
+            const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+            textarea.value = "Enter your label text here!";
+            this.renderTextForm();
+          }
+
+          /** Render the text form to the canvas */
+          private renderTextForm() {
+            const printer = this.activePrinter;
+            if (printer === undefined) {
+              return;
+            }
+
+            const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+            const fontsizer = this.labelForm.querySelector('#previewFontSize') as HTMLInputElement;
+            const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+            const pageContext = canvas.getContext('2d')!;
+            pageContext.clearRect(0, 0, canvas.width, canvas.height);
+
+            const fontSize = Math.trunc(parseFloat(fontsizer.value));
+
+            // We'd like the preview image to be as close as possible to what the printer will
+            // actually print. To do this we don't draw text to the page's canvas directly,
+            // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
+            // then render *that* back to the page's canvas. This is a more accurate picture of
+            // what the label will end up looking like.
+
+            // A more complex app could do this more gracefully!
+            const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d')!;
+            offscreenContext.font = `${fontSize}pt ${this.fontName}`;
+            offscreenContext.fillStyle = "#000000";
+
+            // fillText doesn't do newlines, do that manually
+            textarea.value.split('\n').forEach((l, i) => {
+              offscreenContext.fillText(l, 5, (i * fontSize + 2) + fontSize);
+            })
+
+            // Now into the monochrome bitmap.
+            const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
+            const monoImg = WebLabel.BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
+            // And finally back onto the page.
+            pageContext.putImageData(monoImg.toImageData(), 0, 0);
+          }
+
+          /** Render the canvas to a document for printing */
+          private addCanvasImageToLabelDoc(builder: WebLabel.ILabelDocumentBuilder): WebLabel.IDocument {
+            const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+            const imgData = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
+
+            // One of the benefits of this library is being able to render images to a canvas element
+            // and sending that canvas directly to a label. This allows your webpage to generate complex
+            // images and fonts (like emoji!) that EPL/ZPL can't support.
+            return builder
+              .addImageFromImageData(imgData)
+              .addPrintCmd()
+              .finalize();
+          }
+
+          /** Send the contents of the config form as a config label to the printer. */
+          private async updatePrinterConfig(e: SubmitEvent) {
+            e.preventDefault();
+
+            // Figure out the right printer
+            const formElement = this.configModal.querySelector('form')!;
+            const form = formElement.elements as ConfigModalForm;
+            const printerIdx = parseInt((formElement.querySelector('#modalPrinterIndexText') as HTMLFormElement).innerText);
+            const printer = this.printers[printerIdx];
+            if (printer === undefined) {
+              return;
+            }
+            const isZpl = printer.printerOptions instanceof WebLabel.ZPL.ZplPrinterConfig;
+
+            form.modalSubmit.setAttribute("disabled", "");
+            form.modalCancel.setAttribute("disabled", "");
+
+            // Pull the values out of the form.
+            const darkness = parseInt(form.modalDarkness.value) as WebLabel.DarknessPercent;
+            const rawSpeed = parseInt(form.modalSpeed.value) as WebLabel.PrintSpeed;
+            const mediaWidthInches = parseFloat(form.modalLabelWidth.value);
+
+            const mediaLengthInches = parseFloat(form.modalLabelHeight.value);
+            const offsetLeft = parseInt(form.modalLabelOffsetLeft.value);
+            const offsetTop = parseInt(form.modalLabelOffsetTop.value);
+
+            const backfeedAfterTaken = form.modalBackfeedPercent.value as WebLabel.BackfeedAfterTaken;
+
+            // Construct the config document with the values from the form
+            const configDoc = printer.getConfigDocument();
+
+            // Form mode should be set first for other elements to work right.
+            switch (form.modalMediaType.value) {
+              case "continuous":
+                configDoc.setLabelMediaToContinuous(mediaLengthInches);
+                break;
+              case "mark":
+                // TODO: Make a form for black line sensing.
+                configDoc.setLabelMediaToMarkSense(mediaLengthInches, 16, 0);
+                break;
+              default:
+              case "gap":
+                // TODO: Make a form for label gap size.
+                configDoc.setLabelMediaToWebGapSense(mediaLengthInches, 16);
+                break;
+            }
+
+            configDoc
+              .setPrintDirection()
+              .setLabelPrintOriginOffsetCommand(offsetLeft, offsetTop)
+              .setPrintSpeed(rawSpeed)
+              .setDarknessConfig(darkness)
+              .setLabelDimensions(mediaWidthInches)
+              .setBackfeedAfterTakenMode(backfeedAfterTaken);
+
+            if (isZpl) {
+              // Send the ZPL-specific settings too!
+              let actionPowerUp: WebLabel.ZPL.PowerUpAction;
+              switch (form.modalZplPowerUpAction.value) {
+                case "none":
+                  actionPowerUp = "none";
+                  break;
+                default:
+                case "feedBlank":
+                  actionPowerUp = "feedBlank";
+                  break;
+                case "calibrateWebSensor":
+                  actionPowerUp = "calibrateWebLength";
+                  break;
+              }
+
+              let actionHeadClose: WebLabel.ZPL.PowerUpAction;
+              switch (form.modalZplHeadCloseAction.value) {
+                case "none":
+                  actionHeadClose = "none";
+                  break;
+                default:
+                case "feedBlank":
+                  actionHeadClose = "feedBlank";
+                  break;
+                case "calibrateWebSensor":
+                  actionHeadClose = "calibrateWebLength";
+                  break;
+              }
+
+              configDoc
+                .andThen(new WebLabel.ZPL.CmdSetPowerUpAndHeadCloseAction(
+                  actionPowerUp, actionHeadClose
+                ))
+                .andThen(new WebLabel.ZPL.CmdSetSensorCalibration({
+                  markGain          : Number(form.modalZplMarkGain.value),
+                  markMediaThreshold: Number(form.modalZplMarkMedia.value),
+                  markThreshold     : Number(form.modalZplMarkTHold.value),
+                  transGain         : Number(form.modalZplTransGain.value),
+                  mediaThreshold    : Number(form.modalZplWebMedia.value),
+                  ribbonGain        : Number(form.modalZplRibbonGain.value),
+                  ribbonThreshold   : Number(form.modalZplRibbonTHold.value),
+                  webThreshold      : Number(form.modalZplWebTHold.value),
+                }));
+            }
+
+            let doc: WebLabel.IDocument;
+            if (form.modalWithAutosense.checked) {
+              doc = configDoc.autosenseLabelLength();
+            } else if (isZpl && form.modalZplWithSensorGraph.checked) {
+              doc = configDoc.andThen(new WebLabel.ZPL.CmdGraphSensorCalibration()).finalize();
+            } else {
+              doc = configDoc.finalize();
+            }
+
+            // And send the whole shebang to the printer!
+            await printer.sendDocument(doc);
+
+            form.modalWithAutosense.checked = false;
+            form.modalZplWithSensorGraph.checked = false;
+            form.modalSubmit.removeAttribute("disabled");
+            form.modalCancel.removeAttribute("disabled");
+            this.activePrinterIndex = printerIdx;
+            this.configModalHandle.hide();
+          }
+        }
+
+        // With the app class defined we can run it.
+        // First up collect the basic structure of the app
+        const btnContainer          = document.getElementById("printerlist")!;
+        const labelForm             = document.getElementById("labelForm")!;
+        const labelFormInstructions = document.getElementById("labelFormInstructions")!;
+        const configModal           = document.getElementById("printerOptionModal")!;
+
+        // And feed that into the app class to manage the elements
+        const app = new BasicLabelDesignerApp(printerMgr, btnContainer, labelForm, labelFormInstructions, configModal);
+        // and let it take over the UI.
+        await app.init();
+
+        // Make the TypeScript type system happy by adding a property to the Window object.
+        declare global {
+          interface Window { label_app: BasicLabelDesignerApp }
+        }
+        // Now we can access our printer in the dev console if we want to mess with it!
+        window.label_app = app;
+
+        // Now we'll fire the reconnect since our UI is wired up.
+        try {
+          await printerMgr.forceReconnect();
+        } catch (e) {
+          if (e instanceof WebDevices.DriverAccessDeniedError) {
+            // This happens when the operating system didn't let Chrome connect.
+            // Usually either another tab is open talking to the device, or the driver
+            // is already loaded by another application.
+            showAlert(
+              'danger',
+              'alert-printer-comm-error',
+              `Operating system refused device access`,
+              `<p>This usually happens for one of these reasons:
+              <ul>
+              <li>Another browser tab is already connected.
+              <li>Another application loaded a driver to talk to the device.
+              <li>You're on Windows and need to replace the driver.
+              </ul>
+              Fix the issue and re-connect to the device.</p>`
+            );
+          }
+        }
+
+        // We're done here. Bring in the dancing lobsters.
+
+    </script>
+    <div>
+      <div class="container-fluid">
+        <div class="row" style="padding-top: 16px;">
+          <div class="col-3" id="printer-list-sidebar">
+            <div class="d-grid gap-2 col-8 mx-auto mb-3">
+              <div class="row">
+                <div class="col-9">
+                  <button class="btn btn-primary" id="addprinter">➕ Add Printer</button>
+                </div>
+                <div class="col-3">
+                  <button class="btn btn-success" id="refreshPrinters">🔃</button>
+                </div>
+              </div>
+            </div>
+            <ol id="printerlist" class="list-group list-group-numbered">
+            </ol>
+          </div>
+          <div class="col-9">
+            <div class="row">
+              <div class="col-12" id="printerAlertSpace">
+                <div class="alert alert-warning alert-dismissible d-none" role="alert" id="windowsDriverWarning">
+                  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                  <h4>Windows may need extra configuration</h4>
+                  <p>It looks like your operating system is Windows. The <a href="https://web.dev/build-for-webusb/#windows">windows driver model conflicts with WebUSB</a> and might prevent this page from working with a printer.</p>
+                  <p>To make this demo work you'll need to <a href="https://cellivar.github.io/WebZLP/docs/windows_driver">set up your driver correctly</a>. You'll see errors in the developer console if it isn't configured correctly.</p>
+                </div>
+                <div class="alert alert-warning alert-dismissible d-none" role="alert" id="linuxDriverWarning">
+                  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                  <h4>Linux may need extra configuration</h4>
+                  <p>It looks like your operating system is Linux. The <a href="https://web.dev/build-for-webusb/#linux">linux default driver conflicts with WebUSB</a> and might prevent this page from working with a printer.</p>
+                  <p>If a printer doesn't connect successfully you'll need to <a href="https://github.com/anthroarts/artshow-jockey/tree/73a794bcaa0f0a10625c94d4b2876eba5b638287/udev">set up udev rules</a> to load a different driver. You'll see errors in the developer console if it isn't configured correctly.</p>
+                  <p>You may be able to find the correct USB IDs for your device by visiting either opening <pre>chrome://usb-internals</pre> in a new tab and clicking on the 'Devices' tab, or visiting the <a href="http://www.linux-usb.org/usb-ids.html">the USB ID Repository</a>.</p>
+                </div>
+                <div class="alert alert-warning d-none" role="alert" id="browserNoWebUsb">
+                  <h4>Your browser doesn't support WebUSB</h4>
+                  <p>This demo uses WebUSB to function and your browser doesn't seem to have that available.</p>
+                </div>
+                <div class="alert alert-warning d-none" role="alert" id="urlNotSecure">
+                  <h4>WebUSB requires HTTPS</h4>
+                  <p>It looks like this URL is not using HTTPS, and WebUSB <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebUSB_API">only works in a secure context.</a> You'll need to load this page over HTTPS instead.</p>
+                </div>
+                <div class="alert alert-info" role="alert" id="loadingIndicator">
+                  <h4>Loading....</h4>
+                  <p>If you see this for a long time check the dev console for errors and try the <button id="emergencyRefreshBtn">emergency reset button.</button></p>
+                  <p>Chrome has a bug that prevents this page working in incognito, private browsing, or a Guest profile on ChomeOS.</p>
+                </div>
+              </div>
+            </div>
+            <div id="labelFormInstructions" class="row">
+              <p>Connect a printer to your computer, then click Add Printer!</p>
+              <p>Once a printer is connected select it by clicking on it on the left.</p>
+            </div>
+            <div class="row">
+              <form id="labelForm" action="javascript:void(0);" class="d-none">
+                <div id="image-editor-container"></div>
+                <h5>Input</h5>
+                <label for="previewFontSize" class="form-label">Font Size</label>
+                <div class="input-group">
+                  <input id="previewFontSize" type="number" class="form-control" placeholder="16"
+                    aria-label="Font Size" value="16">
+                </div>
+                <textarea id="labelFormText" name="labelText" cols="40" rows="10" wrap="hard"
+                  style="font-family: monospace; resize: both;"
+                  placeholder="Enter your label text here!"></textarea>
+                <h5>Preview</h5>
+                <canvas id="labelCanvas" width="584" height="160" style="border: 2px solid blue; background-color: white; margin-bottom: 10px;"></canvas>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div id="printerOptionModal" class="modal" tabindex="-1">
+      <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+          <form id="printerSettingsForm">
+            <div class="modal-header">
+              <h4 class="modal-title">Settings</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <div class="mb-3">
+                <div class="row">
+                  <label for="modalPrinterIndex" class="form-label">Printer ID</label>
+                  <div class="input-group mb-3">
+                    <span id="modalPrinterIndexText" class="input-group-text">42Q424242424</span>
+                    <input id="modalPrinterIndex" class="form-control" type="text" value="-1"
+                      aria-label="Printer ID" aria-describedby="modalPrinterIndexText" disabled readonly>
+                  </div>
+                </div>
+              </div>
+              <div class="mb-3">
+                <div class="row">
+                  <h5>Media Settings</h5>
+                </div>
+                <div class="row">
+                  <div class="col-md-4">
+                    <label for="modalLabelWidth" class="form-label">Media Width</label>
+                    <div class="input-group mb-3">
+                      <input id="modalLabelWidth" type="text" class="form-control" placeholder="1.23"
+                        aria-label="Width" required pattern="\d+\.*\d*"
+                        data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="top" title="">
+                      <span id="modalLabelWidthText" class="input-group-text">in</span>
+                    </div>
+                  </div>
+                  <div class="col-md-4">
+                    <label for="modalLabelHeight" class="form-label">Media Length</label>
+                    <div class="input-group mb-3">
+                      <input id="modalLabelHeight" type="text" class="form-control" placeholder="1.23"
+                        aria-label="Height" required pattern="\d+\.*\d*"
+                        data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="top" title="Auto-Calibrate will override this.">
+                      <span id="modalLabelHeightText" class="input-group-text">in</span>
+                    </div>
+                  </div>
+                  <div class="col-md-4">
+                    <label class="form-label">Auto-Calibrate</label>
+                    <div class="input-group mb-3">
+                      <input id="modalWithAutosense" type="checkbox" class="btn-check"
+                        aria-label="RunAutosense" autocomplete="off">
+                      <label for="modalWithAutosense" class="btn btn-outline-primary"
+                        data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right" title="Will feed several labels to calibrate sensor.<br/><b>Make sure to unspool peeler first!</b>"
+                        >Run on save</label>
+                    </div>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-md-3">
+                    <label for="modalLabelOffsetLeft" class="form-label">Left Offset</label>
+                    <div class="input-group mb-3">
+                      <input id="modalLabelOffsetLeft" type="text" class="form-control" placeholder="0"
+                        aria-label="Width" required pattern="-?\d+"
+                        data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right" title="Default is correct for configured width.">
+                      <span class="input-group-text">dots</span>
+                    </div>
+                  </div>
+                  <div class="col-md-3">
+                    <label for="modalLabelOffsetTop" class="form-label">Top Offset</label>
+                    <div class="input-group mb-3">
+                      <input id="modalLabelOffsetTop" type="text" class="form-control" placeholder="0"
+                        aria-label="Height" required pattern="-?\d+">
+                      <span class="input-group-text">dots</span>
+                    </div>
+                  </div>
+                  <div class="col-md-6">
+                    <label for="modalMediaType" class="form-label">Media Type</label>
+                    <div class="mb-3">
+                      <select id="modalMediaType" class="form-select" aria-label="Media Type">
+                        <option value="continuous">Continuous</option>
+                        <option value="gap">Web/gap sense</option>
+                        <option value="mark">Line mark sense</option>
+                      </select>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="mb-3">
+                <hr/>
+                <div class="row">
+                  <h5>Printer Settings</h5>
+                </div>
+                <div class="row">
+                  <div class="col row mb-3">
+                    <label for="modalDarkness" class="col-sm-5 col-form-label">Darkness</label>
+                    <div class="col-sm-7">
+                      <div class="input-group col-sm-7">
+                        <input type="number" min="1" max="99" id="modalDarkness" class="form-control" aria-label="Darkness"
+                        data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right" title="Use the lowest setting with consistent results.<br>Higher values wear the head faster."
+                        />
+                        <span class="input-group-text">%</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="col row mb-3">
+                    <label for="modalSpeed" class="col-sm-5 col-form-label">Speed</label>
+                    <div class="col-sm-7">
+                      <select id="modalSpeed" class="form-select" aria-label="Speed"
+                      data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right" title="Printing faster needs darker printing.<br>Lower darkness if you get sticking.<br>Test the combinations for best results."
+                      >
+                        <option value="3">1.5 ips</option>
+                        <option value="4">2 ips</option>
+                        <option value="5">2.5 ips</option>
+                        <option value="7">3.5 ips</option>
+                      </select>
+                    </div>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col">
+                    <label for="modalBackfeedPercent" class="form-label">Backfeed sequence</label>
+                    <div class="mb-3">
+                      <select id="modalBackfeedPercent" class="form-select" aria-label="Media Type"
+                      data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right" title="Percent of backfeed after cut/take, then rest is at next print.<br>Disabled prevents any backfeed."
+                      >
+                        <option value="disabled">Disabled</option>
+                        <option value="0">0%</option>
+                        <option value="10">10%</option>
+                        <option value="20">20%</option>
+                        <option value="30">30%</option>
+                        <option value="40">40%</option>
+                        <option value="50">50%</option>
+                        <option value="60">60%</option>
+                        <option value="70">70%</option>
+                        <option value="80">80%</option>
+                        <option value="90">90%</option>
+                        <option value="100">100%</option>
+                      </select>
+                    </div>
+                  </div>
+                </div>
+                <div class="row modal-setting-zpl">
+                  <div class="col-md-6">
+                    <div class="form-floating">
+                      <select id="modalZplPowerUpAction" class="form-select">
+                        <option value="feedBlank">Feed to next label</option>
+                        <option value="none">Do Nothing</option>
+                        <option value="calibrateWebSensor">Media Auto-Calibrate</option>
+                      </select>
+                      <label for="modalZplPowerUpAction">Action on power-up</label>
+                    </div>
+                  </div>
+                  <div class="col-md-6">
+                    <div class="form-floating">
+                      <select id="modalZplHeadCloseAction" class="form-select">
+                        <option value="feedBlank">Feed to next label</option>
+                        <option value="none">Do Nothing</option>
+                        <option value="calibrateWebSensor">Media Auto-Calibrate</option>
+                      </select>
+                      <label for="modalZplHeadCloseAction">Action on head close</label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="mb-3 modal-settings-zpl">
+                <hr/>
+                <div class="row">
+                  <div class="col-md-7">
+                    <h5>Sensor Settings</h5>
+                  </div>
+                  <div class="col-md-5">
+                    <div class="input-group mb-3">
+                      <input id="modalZplWithSensorGraph" type="checkbox" class="btn-check"
+                        aria-label="Run sensor graph" autocomplete="off">
+                      <label for="modalZplWithSensorGraph" class="btn btn-outline-primary"
+                        data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right"
+                        title="SET LABEL LENGTH FIRST. Will graph sensor values on labels.<br/><b>Make sure to unspool peeler first!</b>"
+                        >Print graph on save</label>
+                    </div>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-md-4">
+                    <p class="h5">Ribbon</p>
+                  </div>
+                  <div class="col-md-4">
+                    <p class="h5">Web sense</p>
+                  </div>
+                  <div class="col-md-4">
+                    <p class="h5">Mark sense</p>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplRibbonTHold" value="50"
+                      data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="left"
+                      title="Below this the ribbon is 'out'. OUT line on newer printer graphs, RIBBON line on older.<br>Should be at least 10 lower than the graphed value when loaded.<br>Ignored on direct-only printers."
+                      />
+                      <label for="modalZplRibbonTHold">Threshold</label>
+                    </div>
+                  </div>
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplWebTHold" value="50"
+                      data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="left"
+                      title="The WEB line on the graph. The sensor value should reliably cross this at every web.<br>Only used in gap sense."
+                      />
+                      <label for="modalZplWebTHold">Threshold</label>
+                    </div>
+                  </div>
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplMarkTHold" value="50"
+                      data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right"
+                      title="The WEB line on the graph. The sensor value should reliably cross this at every mark.<br>Only used in mark sense."
+                      />
+                      <label for="modalZplMarkTHold">Threshold</label>
+                    </div>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-md-4"></div>
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplWebMedia" value="50"
+                      data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right"
+                      title="Above this the media is 'out'. OUT line on newer printer graphs, MEDIA line on older.<br>Should be 15 above the higest sensor spike.<br>Only used in web sense."
+                      />
+                      <label for="modalZplWebMedia">Media</label>
+                    </div>
+                  </div>
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplMarkMedia" value="50"
+                      data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right"
+                      title="Below this line hte media is 'out'. OUT line on newer printer graphs, MEDIA line on older.<br>Should be 15 below the lowest sensor spike.<br>Only used in mark sense."
+                      />
+                      <label for="modalZplMarkMedia">Media</label>
+                    </div>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplRibbonGain" value="50"
+                      data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="left"
+                      title="Adjust lower or higher to increase or decrease the range of the ribbon sensor graph. Aim for a large difference between ribbon loaded and unloaded. Ignored on direct-only printers."
+                       />
+                      <label for="modalZplRibbonGain">Gain</label>
+                    </div>
+                  </div>
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplTransGain" value="50"
+                      data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right"
+                      title="Adjust lower or higher to increase or decrease the range of the media sensor graph.<br>Aim for a large clear spike in the web, with low noise over the label.<br>Only used in web sense."
+                      />
+                      <label for="modalZplTransGain">Gain</label>
+                    </div>
+                  </div>
+                  <div class="col-md-4">
+                    <div class="form-floating">
+                      <input class="form-control" id="modalZplMarkGain" value="50"
+                      data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="right"
+                      title="Adjust lower or higher to increase or decrease the range of the media sensor graph.<br>Aim for a large clear spike in the mark, with low noise over the label.<br>Only used in mark sense."
+                      />
+                      <label for="modalZplMarkGain">Gain</label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button id="modalCancel" type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+              <input id="modalSubmit" type="submit" class="btn btn-primary" value="Save">
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.10.2/dist/umd/popper.min.js"
+        integrity="sha384-7+zCNj/IqJ95wo16oMtfsKbZ9ccEh31eOz1HGyDuCQ6wgnyJNSYdrPa03rtR1zdB"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.min.js"
+        integrity="sha384-QJHtvGhmr9XOIpI6YVutG+2QOK9T+ZnN4kzFN1RtK3zEFEIsxhlmWl5/YESvpZ13"
+        crossorigin="anonymous"></script>
+    <script type="text/javascript">
+      // Enable tooltips for bootstrap
+      var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+      var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl)
+      })
+    </script>
+</body>
+
+</html>

--- a/demo/test_advanced.ts
+++ b/demo/test_advanced.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as WebLabel from '../src/index.js';
 import * as WebDevices from 'web-device-mux';
 import bootstrap from 'bootstrap';
@@ -104,13 +105,13 @@ interface ConfigModalForm extends HTMLCollection {
   // commands or configs specific to their printers.
   // Sensors
   modalZplRibbonTHold: HTMLInputElement
-  modalZplRibbonLed  : HTMLInputElement
+  modalZplRibbonGain : HTMLInputElement
   modalZplWebTHold   : HTMLInputElement
   modalZplWebMedia   : HTMLInputElement
-  modalZplWebLed     : HTMLInputElement
+  modalZplTransGain  : HTMLInputElement
   modalZplMarkTHold  : HTMLInputElement
   modalZplMarkMedia  : HTMLInputElement
-  modalZplMarkLed    : HTMLInputElement
+  modalZplMarkGain   : HTMLInputElement
 
   modalZplWithSensorGraph: HTMLInputElement
 
@@ -321,13 +322,13 @@ class BasicLabelDesignerApp {
 
     if (isZpl) {
       form.modalZplRibbonTHold.value = config.ribbonThreshold.toString();
-      form.modalZplRibbonLed.value   = config.ribbonGain.toString();
+      form.modalZplRibbonGain.value  = config.ribbonGain.toString();
       form.modalZplWebTHold.value    = config.webThreshold.toString();
       form.modalZplWebMedia.value    = config.mediaThreshold.toString();
-      form.modalZplWebLed.value      = config.transGain.toString();
+      form.modalZplTransGain.value   = config.transGain.toString();
       form.modalZplMarkTHold.value   = config.markThreshold.toString();
       form.modalZplMarkMedia.value   = config.markMediaThreshold.toString();
-      form.modalZplMarkLed.value     = config.markGain.toString();
+      form.modalZplMarkGain.value    = config.markGain.toString();
 
       form.modalZplPowerUpAction.value   = config.actionPowerUp.toString();
       form.modalZplHeadCloseAction.value = config.actionHeadClose.toString();
@@ -616,12 +617,12 @@ class BasicLabelDesignerApp {
           actionPowerUp, actionHeadClose
         ))
         .andThen(new WebLabel.ZPL.CmdSetSensorCalibration({
-          markGain          : Number(form.modalZplMarkLed.value),
+          markGain          : Number(form.modalZplMarkGain.value),
           markMediaThreshold: Number(form.modalZplMarkMedia.value),
           markThreshold     : Number(form.modalZplMarkTHold.value),
-          transGain         : Number(form.modalZplWebLed.value),
+          transGain         : Number(form.modalZplTransGain.value),
           mediaThreshold    : Number(form.modalZplWebMedia.value),
-          ribbonGain        : Number(form.modalZplRibbonLed.value),
+          ribbonGain        : Number(form.modalZplRibbonGain.value),
           ribbonThreshold   : Number(form.modalZplRibbonTHold.value),
           webThreshold      : Number(form.modalZplWebTHold.value),
         }));
@@ -660,12 +661,9 @@ const app = new BasicLabelDesignerApp(printerMgr, btnContainer, labelForm, label
 // and let it take over the UI.
 await app.init();
 
-// Make the TypeScript type system happy by adding a property to the Window object.
-declare global {
-  interface Window { label_app: BasicLabelDesignerApp }
-}
+
 // Now we can access our printer in the dev console if we want to mess with it!
-window.label_app = app;
+(window as any).label_app = app;
 
 // Now we'll fire the reconnect since our UI is wired up.
 try {

--- a/demo/test_editor.ts
+++ b/demo/test_editor.ts
@@ -7,13 +7,19 @@ import bootstrap from 'bootstrap';
 // a good way to configure Visual Studio Code to, well, treat it as typescript.
 ////////////////////////////////////////////////////////////////////////////////
 
-// Import the canvas editor lib and make it available
+// This demo uses a more complex label designer using the Fabric.JS library.
+// Internally it makes use of an HTML canvas, and thus it's easy to plug into
+// WebZLP for label designing!
+// Import the canvas editor lib and create a canvas to use for printing.
 // import * as Editor from 'fabricjs-label-editor'
-// window.LabelEditor = Editor;
-(window as any).EditorApp = new Editor.ImageEditor(document.getElementById('image-editor-container')!);
+// import * as WebLabel from 'webzlp';
+// import * as WebDevices from 'web-device-mux';
+(window as any).FabricEditor = Editor;
+(window as any).WebLabel = WebLabel;
+(window as any).WebDevices = WebDevices;
 
-// First import the lib!
-//import * as WebLabel from 'web-receiptline-printer';
+const editor = new Editor.ImageEditor(document.getElementById('image-editor-container')!);
+(window as any).LabelEditor = editor;
 
 // For this demo we're going to make use of the USB printer manager
 // so it can take care of concerns like the USB connect and disconnect events.
@@ -47,46 +53,6 @@ addPrinterBtn.addEventListener('click', async () => printerMgr.promptForNewDevic
 const refreshPrinterBtn = document.getElementById('refreshPrinters')!;
 refreshPrinterBtn.addEventListener('click', async () => printerMgr.forceReconnect());
 
-// Next we wire up some events on the UsbDeviceManager itself.
-printerMgr.addEventListener('connectedDevice', ({ detail }) => {
-
-  // Let's print some details about the printer that was connected.
-  const printer = detail.device;
-  console.log('New printer is a', printer.printerModel);
-  const config = printer.printerOptions;
-  console.log('Printer darkness is', config.darknessPercent, 'percent');
-  console.log('Printer speed is', WebLabel.PrintSpeed[config.speed.printSpeed]);
-  console.log(
-    'Label is',
-    config.mediaWidthInches,
-    'in wide and',
-    config.mediaLengthInches,
-    'in long');
-  console.log('Printer media mode is', WebLabel.MediaMediaGapDetectionMode[config.mediaGapDetectMode]);
-
-  // You can do stuff with the printer that connected. It's a good idea
-  // to immediately query the printer for its status.
-  printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
-});
-
-// There's also an event that will tell you when a printer disconnects.
-printerMgr.addEventListener('disconnectedDevice', ({ detail }) => {
-  const printer = detail.device;
-  console.log('Lost printer', printer.printerModel, 'serial', printer.printerOptions.serialNumber);
-});
-
-// When the browser first loaded the page any previously connected printers would have caused
-// a connection event. Our listener wasn't listening yet so missed it.
-// It's good practice to force a reconnect once your event handlers are ready.
-// We're going to skip this for now though, because we want it to happen after the app is ready.
-//await printerMgr.reconnectAllPrinters();
-
-// And that's all there is to setup! The page can now talk to printers.
-// If you're using a chromebook this should just work. If you're on Windows
-// you might need to do some driver setup, see the repo README for more details.
-
-// The rest of this demo is an example of a basic label generator app.
-
 // Get some bookkeeping out of the way..
 // First we create an interface to describe our settings form.
 interface ConfigModalForm extends HTMLCollection {
@@ -111,13 +77,13 @@ interface ConfigModalForm extends HTMLCollection {
   // commands or configs specific to their printers.
   // Sensors
   modalZplRibbonTHold: HTMLInputElement
-  modalZplRibbonLed  : HTMLInputElement
+  modalZplRibbonGain : HTMLInputElement
   modalZplWebTHold   : HTMLInputElement
   modalZplWebMedia   : HTMLInputElement
-  modalZplWebLed     : HTMLInputElement
+  modalZplTransGain  : HTMLInputElement
   modalZplMarkTHold  : HTMLInputElement
   modalZplMarkMedia  : HTMLInputElement
-  modalZplMarkLed    : HTMLInputElement
+  modalZplMarkGain   : HTMLInputElement
 
   modalZplWithSensorGraph: HTMLInputElement
 
@@ -165,7 +131,7 @@ class BasicLabelDesignerApp {
   constructor(
     private manager: PrinterManager,
     private btnContainer: HTMLElement,
-    private labelForm: HTMLElement,
+    private editor: Editor.ImageEditor,
     private labelFormInstructions: HTMLElement,
     private configModal: HTMLElement
   ) {
@@ -174,8 +140,6 @@ class BasicLabelDesignerApp {
     this.configModal
       .querySelector('form')!
       .addEventListener('submit', this.updatePrinterConfig.bind(this));
-    this.labelForm.addEventListener('blur', this.renderTextForm.bind(this));
-    this.labelForm.addEventListener('keyup', this.renderTextForm.bind(this));
 
     // Add a second set of event listeners for printer connect and disconnect to redraw
     // the printer list when it changes.
@@ -208,6 +172,7 @@ class BasicLabelDesignerApp {
         );
       });
     });
+
     this.manager.addEventListener('disconnectedDevice', () => {
       this.activePrinterIndex = -1;
       this.redrawPrinterButtons();
@@ -253,13 +218,13 @@ class BasicLabelDesignerApp {
   }
   set activePrinterIndex(printerIdx: number) {
     this._activePrinter = printerIdx;
-    this.redrawTextCanvas();
+    this.redrawLabelCanvas();
   }
 
   /** Initialize the app */
   public async init() {
     this.redrawPrinterButtons();
-    this.redrawTextCanvas();
+    this.redrawLabelCanvas();
   }
 
   /** Display the configuration for a printer. */
@@ -328,13 +293,13 @@ class BasicLabelDesignerApp {
 
     if (isZpl) {
       form.modalZplRibbonTHold.value = config.ribbonThreshold.toString();
-      form.modalZplRibbonLed.value   = config.ribbonGain.toString();
+      form.modalZplRibbonGain.value  = config.ribbonGain.toString();
       form.modalZplWebTHold.value    = config.webThreshold.toString();
       form.modalZplWebMedia.value    = config.mediaThreshold.toString();
-      form.modalZplWebLed.value      = config.transGain.toString();
+      form.modalZplTransGain.value   = config.transGain.toString();
       form.modalZplMarkTHold.value   = config.markThreshold.toString();
       form.modalZplMarkMedia.value   = config.markMediaThreshold.toString();
-      form.modalZplMarkLed.value     = config.markGain.toString();
+      form.modalZplMarkGain.value    = config.markGain.toString();
 
       form.modalZplPowerUpAction.value   = config.actionPowerUp.toString();
       form.modalZplHeadCloseAction.value = config.actionHeadClose.toString();
@@ -422,7 +387,7 @@ class BasicLabelDesignerApp {
         }
         this.activePrinterIndex = printerIdx;
         this.redrawPrinterButtonHighlights();
-        this.redrawTextCanvas();
+        this.redrawLabelCanvas();
       });
     document.getElementById(`printtest_${idx}`)!
       .addEventListener('click', async (e) => {
@@ -458,70 +423,34 @@ class BasicLabelDesignerApp {
       });
   }
 
-  /** Redraw the text canvas size according to the printer. */
-  private redrawTextCanvas() {
+  /** Redraw the canvas size according to the selected printer. */
+  private redrawLabelCanvas() {
     const printer = this.activePrinter;
     if (printer === undefined) {
-      this.labelForm.classList.add('d-none');
+      this.editor.containerElement.classList.add('d-none');
       this.labelFormInstructions.classList.remove('d-none');
       return;
+
     } else {
-      this.labelForm.classList.remove('d-none');
+      // Set the actual resolution of the canvas
+      this.editor.canvas.setDimensions({
+        height: printer.printerOptions.mediaLengthDots - 2,
+        width: printer.printerOptions.mediaWidthDots - 2,
+      });
+      // Scale the CSS size by half, keeping the same resolution.
+      this.editor.canvas.setDimensions({
+        height: printer.printerOptions.mediaLengthDots / 2,
+        width: printer.printerOptions.mediaWidthDots / 2,
+      }, { cssOnly: true });
+
+      this.editor.containerElement.classList.remove('d-none');
       this.labelFormInstructions.classList.add('d-none');
     }
-
-    // Resize the canvas to match the label size.
-    const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-    // Add a small margin as printer alignment is not exact.
-    canvas.width = printer.printerOptions.mediaWidthDots - 2;
-    canvas.height = printer.printerOptions.mediaLengthDots - 2;
-
-    const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-    textarea.value = "Enter your label text here!";
-    this.renderTextForm();
-  }
-
-  /** Render the text form to the canvas */
-  private renderTextForm() {
-    const printer = this.activePrinter;
-    if (printer === undefined) {
-      return;
-    }
-
-    const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
-    const fontsizer = this.labelForm.querySelector('#previewFontSize') as HTMLInputElement;
-    const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
-    const pageContext = canvas.getContext('2d')!;
-    pageContext.clearRect(0, 0, canvas.width, canvas.height);
-
-    const fontSize = Math.trunc(parseFloat(fontsizer.value));
-
-    // We'd like the preview image to be as close as possible to what the printer will
-    // actually print. To do this we don't draw text to the page's canvas directly,
-    // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
-    // then render *that* back to the page's canvas. This is a more accurate picture of
-    // what the label will end up looking like.
-
-    // A more complex app could do this more gracefully!
-    const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d')!;
-    offscreenContext.font = `${fontSize}pt ${this.fontName}`;
-    offscreenContext.fillStyle = "#000000";
-
-    // fillText doesn't do newlines, do that manually
-    textarea.value.split('\n').forEach((l, i) => {
-      offscreenContext.fillText(l, 5, (i * fontSize + 2) + fontSize);
-    })
-
-    // Now into the monochrome bitmap.
-    const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
-    const monoImg = WebLabel.BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
-    // And finally back onto the page.
-    pageContext.putImageData(monoImg.toImageData(), 0, 0);
   }
 
   /** Render the canvas to a document for printing */
   private addCanvasImageToLabelDoc(builder: WebLabel.ILabelDocumentBuilder): WebLabel.IDocument {
-    const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+    const canvas = this.editor.canvas.toCanvasElement();
     const imgData = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
 
     // One of the benefits of this library is being able to render images to a canvas element
@@ -623,12 +552,12 @@ class BasicLabelDesignerApp {
           actionPowerUp, actionHeadClose
         ))
         .andThen(new WebLabel.ZPL.CmdSetSensorCalibration({
-          markGain          : Number(form.modalZplMarkLed.value),
+          markGain          : Number(form.modalZplMarkGain.value),
           markMediaThreshold: Number(form.modalZplMarkMedia.value),
           markThreshold     : Number(form.modalZplMarkTHold.value),
-          transGain         : Number(form.modalZplWebLed.value),
+          transGain         : Number(form.modalZplTransGain.value),
           mediaThreshold    : Number(form.modalZplWebMedia.value),
-          ribbonGain        : Number(form.modalZplRibbonLed.value),
+          ribbonGain        : Number(form.modalZplRibbonGain.value),
           ribbonThreshold   : Number(form.modalZplRibbonTHold.value),
           webThreshold      : Number(form.modalZplWebTHold.value),
         }));
@@ -658,21 +587,16 @@ class BasicLabelDesignerApp {
 // With the app class defined we can run it.
 // First up collect the basic structure of the app
 const btnContainer          = document.getElementById("printerlist")!;
-const labelForm             = document.getElementById("labelForm")!;
 const labelFormInstructions = document.getElementById("labelFormInstructions")!;
 const configModal           = document.getElementById("printerOptionModal")!;
 
 // And feed that into the app class to manage the elements
-const app = new BasicLabelDesignerApp(printerMgr, btnContainer, labelForm, labelFormInstructions, configModal);
+const app = new BasicLabelDesignerApp(printerMgr, btnContainer, editor, labelFormInstructions, configModal);
 // and let it take over the UI.
 await app.init();
 
-// Make the TypeScript type system happy by adding a property to the Window object.
-declare global {
-  interface Window { label_app: BasicLabelDesignerApp }
-}
 // Now we can access our printer in the dev console if we want to mess with it!
-window.label_app = app;
+(window as any).label_app = app;
 
 // Now we'll fire the reconnect since our UI is wired up.
 try {

--- a/demo/test_editor.ts
+++ b/demo/test_editor.ts
@@ -1,0 +1,700 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as WebLabel from '../src/index.js';
+import * as WebDevices from 'web-device-mux';
+import * as Editor from '../../fabricjs-label-editor/lib/index.js'
+import bootstrap from 'bootstrap';
+// This file exists to test the index.html's typescript. Unfortunately there isn't
+// a good way to configure Visual Studio Code to, well, treat it as typescript.
+////////////////////////////////////////////////////////////////////////////////
+
+// Import the canvas editor lib and make it available
+// import * as Editor from 'fabricjs-label-editor'
+// window.LabelEditor = Editor;
+(window as any).EditorApp = new Editor.ImageEditor(document.getElementById('image-editor-container')!);
+
+// First import the lib!
+//import * as WebLabel from 'web-receiptline-printer';
+
+// For this demo we're going to make use of the USB printer manager
+// so it can take care of concerns like the USB connect and disconnect events.
+
+// We'll set a type alias so it's easier to read our code
+type PrinterManager = WebDevices.UsbDeviceManager<WebLabel.LabelPrinterUsb>;
+// Then we'll construct one to use
+const printerMgr: PrinterManager = new WebDevices.UsbDeviceManager(
+  window.navigator.usb,
+  WebLabel.LabelPrinter.fromUSBDevice,
+  {
+    // Enable debugging, so the dev console can fill up with interesting messages!
+    debug: true,
+    requestOptions: {
+      // Limit the USB devices we try to connect to.
+      filters: [
+        {
+          vendorId: 0x0A5F // Zebra
+        }
+      ]
+    }
+  }
+)
+
+// We'll wire up some basic event listeners to the printer manager.
+// First, a button to prompt a user to add a printer.
+const addPrinterBtn = document.getElementById('addprinter')!;
+addPrinterBtn.addEventListener('click', async () => printerMgr.promptForNewDevice());
+
+// Next a button to manually refresh all printers, just in case.
+const refreshPrinterBtn = document.getElementById('refreshPrinters')!;
+refreshPrinterBtn.addEventListener('click', async () => printerMgr.forceReconnect());
+
+// Next we wire up some events on the UsbDeviceManager itself.
+printerMgr.addEventListener('connectedDevice', ({ detail }) => {
+
+  // Let's print some details about the printer that was connected.
+  const printer = detail.device;
+  console.log('New printer is a', printer.printerModel);
+  const config = printer.printerOptions;
+  console.log('Printer darkness is', config.darknessPercent, 'percent');
+  console.log('Printer speed is', WebLabel.PrintSpeed[config.speed.printSpeed]);
+  console.log(
+    'Label is',
+    config.mediaWidthInches,
+    'in wide and',
+    config.mediaLengthInches,
+    'in long');
+  console.log('Printer media mode is', WebLabel.MediaMediaGapDetectionMode[config.mediaGapDetectMode]);
+
+  // You can do stuff with the printer that connected. It's a good idea
+  // to immediately query the printer for its status.
+  printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument);
+});
+
+// There's also an event that will tell you when a printer disconnects.
+printerMgr.addEventListener('disconnectedDevice', ({ detail }) => {
+  const printer = detail.device;
+  console.log('Lost printer', printer.printerModel, 'serial', printer.printerOptions.serialNumber);
+});
+
+// When the browser first loaded the page any previously connected printers would have caused
+// a connection event. Our listener wasn't listening yet so missed it.
+// It's good practice to force a reconnect once your event handlers are ready.
+// We're going to skip this for now though, because we want it to happen after the app is ready.
+//await printerMgr.reconnectAllPrinters();
+
+// And that's all there is to setup! The page can now talk to printers.
+// If you're using a chromebook this should just work. If you're on Windows
+// you might need to do some driver setup, see the repo README for more details.
+
+// The rest of this demo is an example of a basic label generator app.
+
+// Get some bookkeeping out of the way..
+// First we create an interface to describe our settings form.
+interface ConfigModalForm extends HTMLCollection {
+  modalCancel          : HTMLButtonElement
+  modalSubmit          : HTMLButtonElement
+  modalPrinterIndex    : HTMLInputElement
+
+  // Media
+  modalLabelWidth     : HTMLInputElement
+  modalLabelHeight    : HTMLInputElement
+  modalLabelOffsetLeft: HTMLInputElement
+  modalLabelOffsetTop : HTMLInputElement
+  modalMediaType      : HTMLSelectElement
+  modalWithAutosense  : HTMLInputElement
+
+  // Printer
+  modalDarkness       : HTMLSelectElement
+  modalSpeed          : HTMLSelectElement
+  modalBackfeedPercent: HTMLSelectElement
+
+  // These are ZPL-specific settings. Different languages can have additional
+  // commands or configs specific to their printers.
+  // Sensors
+  modalZplRibbonTHold: HTMLInputElement
+  modalZplRibbonLed  : HTMLInputElement
+  modalZplWebTHold   : HTMLInputElement
+  modalZplWebMedia   : HTMLInputElement
+  modalZplWebLed     : HTMLInputElement
+  modalZplMarkTHold  : HTMLInputElement
+  modalZplMarkMedia  : HTMLInputElement
+  modalZplMarkLed    : HTMLInputElement
+
+  modalZplWithSensorGraph: HTMLInputElement
+
+  // Power up/head close actions
+  modalZplPowerUpAction  : HTMLSelectElement
+  modalZplHeadCloseAction: HTMLSelectElement
+}
+
+
+// A function to find and hide any alerts for a given alert ID.
+function hideAlerts(alertId: string) {
+  const existingAlerts = document.getElementById('printerAlertSpace')?.querySelectorAll(`.${alertId}`) ?? [];
+  existingAlerts.forEach((a: Element) => { a.remove(); });
+}
+
+// A function to make it easier to show alerts
+function showAlert(
+  level: 'warning' | 'danger',
+  alertId: string,
+  titleHtml: string,
+  bodyHtml: string,
+  closedCallback = () => {}
+) {
+  hideAlerts(alertId);
+
+  // Create the bootstrap alert div with the provided content
+  const alertWrapper = document.createElement('div');
+  alertWrapper.classList.add("alert", `alert-${level}`, "alert-dismissible", "fade", "show", alertId);
+  alertWrapper.id = alertId;
+  alertWrapper.role = "alert";
+  alertWrapper.innerHTML = `
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    <h4>${titleHtml}</h4>
+    ${bodyHtml}`;
+
+  // Add it to the document and activate it
+  document.getElementById('printerAlertSpace')?.appendChild(alertWrapper);
+  new bootstrap.Alert(alertWrapper);
+
+  alertWrapper.addEventListener('closed.bs.alert', closedCallback);
+}
+
+// The app's logic is wrapped in a class just for ease of reading.
+class BasicLabelDesignerApp {
+  constructor(
+    private manager: PrinterManager,
+    private btnContainer: HTMLElement,
+    private labelForm: HTMLElement,
+    private labelFormInstructions: HTMLElement,
+    private configModal: HTMLElement
+  ) {
+    // Based on the containers, map the various listeners.
+    this.configModalHandle = new bootstrap.Modal(this.configModal);
+    this.configModal
+      .querySelector('form')!
+      .addEventListener('submit', this.updatePrinterConfig.bind(this));
+    this.labelForm.addEventListener('blur', this.renderTextForm.bind(this));
+    this.labelForm.addEventListener('keyup', this.renderTextForm.bind(this));
+
+    // Add a second set of event listeners for printer connect and disconnect to redraw
+    // the printer list when it changes.
+    this.manager.addEventListener('connectedDevice', ({ detail }) => {
+      this.activePrinterIndex = -1;
+      this.redrawPrinterButtons();
+
+      // Printers themselves also have events, let's show an alert on errors.
+      const printer = detail.device;
+      printer.addEventListener('reportedError', ({ detail: msg }) => {
+        // Use the same ID so there's only one error message per printer.
+        const alertId = `alert-printererror-${printer.printerSerial}`;
+        hideAlerts(alertId);
+
+        // Error messages are also status messages, such as indicating no problem.
+        if (msg.errors.size === 0 || msg.errors.has(WebLabel.ErrorState.NoError)) { return; }
+
+        showAlert(
+          // Show a warning for this printer
+          'warning',
+          alertId,
+          `Printer <strong>${printer.printerSerial}</strong> has an error`,
+          // There can be multiple errors, just show their raw values. A better
+          // application would use these for good messages!
+          `<p><ul>${Array.from(msg.errors).map(e => `<li>${e}`)}</ul></p>
+          <hr>
+          <p>Fix the issue, then dismiss this alert to check the status again.</p>`,
+          // And when the alert is dismissed, check the status again!
+          () => printer.sendDocument(WebLabel.ReadyToPrintDocuments.printerStatusDocument)
+        );
+      });
+    });
+    this.manager.addEventListener('disconnectedDevice', () => {
+      this.activePrinterIndex = -1;
+      this.redrawPrinterButtons();
+    });
+
+    // Here's a nice font with a great set of emoji that work well for monochrome printing.
+    // The text font is fairly basic though, so we would like to use only the emoji out
+    // of this font and use a basic sans-serif font for regular text.
+    // https://fonts.google.com/noto/specimen/Noto+Emoji
+    const emojiFontName = 'noto-emoji';
+
+    // We can accomplish this with the unicodeRange property of our FontFace. We just
+    // need to list EVERY SINGLE EMOJI UNICODE RANGE to make it work. Fortunately someone
+    // has done this already: https://github.com/fraction/emoji-unicode-range
+    const emojiUnicodeRange = 'U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2604,U+260E,U+2611,U+2614-2615,U+2618,U+261D,U+2620,U+2622-2623,U+2626,U+262A,U+262E-262F,U+2638-263A,U+2640,U+2642,U+2648-2653,U+265F-2660,U+2663,U+2665-2666,U+2668,U+267B,U+267E-267F,U+2692-2697,U+2699,U+269B-269C,U+26A0-26A1,U+26AA-26AB,U+26B0-26B1,U+26BD-26BE,U+26C4-26C5,U+26C8,U+26CE,U+26CF,U+26D1,U+26D3-26D4,U+26E9-26EA,U+26F0-26F5,U+26F7-26FA,U+26FD,U+2702,U+2705,U+2708-2709,U+270A-270B,U+270C-270D,U+270F,U+2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2764,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F004,U+1F0CF,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201-1F202,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F321,U+1F324-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F396-1F397,U+1F399-1F39B,U+1F39E-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F3-1F3F5,U+1F3F7,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD,U+1F4FF,U+1F500-1F53D,U+1F549-1F54A,U+1F54B-1F54E,U+1F550-1F567,U+1F56F-1F570,U+1F573-1F579,U+1F57A,U+1F587,U+1F58A-1F58D,U+1F590,U+1F595-1F596,U+1F5A4,U+1F5A5,U+1F5A8,U+1F5B1-1F5B2,U+1F5BC,U+1F5C2-1F5C4,U+1F5D1-1F5D3,U+1F5DC-1F5DE,U+1F5E1,U+1F5E3,U+1F5E8,U+1F5EF,U+1F5F3,U+1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CB-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6E0-1F6E5,U+1F6E9,U+1F6EB-1F6EC,U+1F6F0,U+1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+231A-231B,U+23E9-23EC,U+23F0,U+23F3,U+25FD-25FE,U+2614-2615,U+2648-2653,U+267F,U+2693,U+26A1,U+26AA-26AB,U+26BD-26BE,U+26C4-26C5,U+26CE,U+26D4,U+26EA,U+26F2-26F3,U+26F5,U+26FA,U+26FD,U+2705,U+270A-270B,U+2728,U+274C,U+274E,U+2753-2755,U+2757,U+2795-2797,U+27B0,U+27BF,U+2B1B-2B1C,U+2B50,U+2B55,U+1F004,U+1F0CF,U+1F18E,U+1F191-1F19A,U+1F1E6-1F1FF,U+1F201,U+1F21A,U+1F22F,U+1F232-1F236,U+1F238-1F23A,U+1F250-1F251,U+1F300-1F320,U+1F32D-1F32F,U+1F330-1F335,U+1F337-1F37C,U+1F37E-1F37F,U+1F380-1F393,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CF-1F3D3,U+1F3E0-1F3F0,U+1F3F4,U+1F3F8-1F3FF,U+1F400-1F43E,U+1F440,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FF,U+1F500-1F53D,U+1F54B-1F54E,U+1F550-1F567,U+1F57A,U+1F595-1F596,U+1F5A4,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6CC,U+1F6D0,U+1F6D1-1F6D2,U+1F6D5,U+1F6EB-1F6EC,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F7E0-1F7EB,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F973-1F976,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A5-1F9AA,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA70-1FA73,U+1FA78-1FA7A,U+1FA80-1FA82,U+1FA90-1FA95,U+1F3FB-1F3FF,U+261D,U+26F9,U+270A-270B,U+270C-270D,U+1F385,U+1F3C2-1F3C4,U+1F3C7,U+1F3CA,U+1F3CB-1F3CC,U+1F442-1F443,U+1F446-1F450,U+1F466-1F478,U+1F47C,U+1F481-1F483,U+1F485-1F487,U+1F48F,U+1F491,U+1F4AA,U+1F574-1F575,U+1F57A,U+1F590,U+1F595-1F596,U+1F645-1F647,U+1F64B-1F64F,U+1F6A3,U+1F6B4-1F6B6,U+1F6C0,U+1F6CC,U+1F90F,U+1F918,U+1F919-1F91E,U+1F91F,U+1F926,U+1F930,U+1F931-1F932,U+1F933-1F939,U+1F93C-1F93E,U+1F9B5-1F9B6,U+1F9B8-1F9B9,U+1F9BB,U+1F9CD-1F9CF,U+1F9D1-1F9DD,U+0023,U+002A,U+0030-0039,U+200D,U+20E3,U+FE0F,U+1F1E6-1F1FF,U+1F3FB-1F3FF,U+1F9B0-1F9B3,U+E0020-E007F,U+00A9,U+00AE,U+203C,U+2049,U+2122,U+2139,U+2194-2199,U+21A9-21AA,U+231A-231B,U+2328,U+2388,U+23CF,U+23E9-23F3,U+23F8-23FA,U+24C2,U+25AA-25AB,U+25B6,U+25C0,U+25FB-25FE,U+2600-2605,U+2607-2612,U+2614-2615,U+2616-2617,U+2618,U+2619,U+261A-266F,U+2670-2671,U+2672-267D,U+267E-267F,U+2680-2685,U+2690-2691,U+2692-269C,U+269D,U+269E-269F,U+26A0-26A1,U+26A2-26B1,U+26B2,U+26B3-26BC,U+26BD-26BF,U+26C0-26C3,U+26C4-26CD,U+26CE,U+26CF-26E1,U+26E2,U+26E3,U+26E4-26E7,U+26E8-26FF,U+2700,U+2701-2704,U+2705,U+2708-2709,U+270A-270B,U+270C-2712,U+2714,U+2716,U+271D,U+2721,U+2728,U+2733-2734,U+2744,U+2747,U+274C,U+274E,U+2753-2755,U+2757,U+2763-2767,U+2795-2797,U+27A1,U+27B0,U+27BF,U+2934-2935,U+2B05-2B07,U+2B1B-2B1C,U+2B50,U+2B55,U+3030,U+303D,U+3297,U+3299,U+1F000-1F02B,U+1F02C-1F02F,U+1F030-1F093,U+1F094-1F09F,U+1F0A0-1F0AE,U+1F0AF-1F0B0,U+1F0B1-1F0BE,U+1F0BF,U+1F0C0,U+1F0C1-1F0CF,U+1F0D0,U+1F0D1-1F0DF,U+1F0E0-1F0F5,U+1F0F6-1F0FF,U+1F10D-1F10F,U+1F12F,U+1F16C,U+1F16D-1F16F,U+1F170-1F171,U+1F17E,U+1F17F,U+1F18E,U+1F191-1F19A,U+1F1AD-1F1E5,U+1F201-1F202,U+1F203-1F20F,U+1F21A,U+1F22F,U+1F232-1F23A,U+1F23C-1F23F,U+1F249-1F24F,U+1F250-1F251,U+1F252-1F25F,U+1F260-1F265,U+1F266-1F2FF,U+1F300-1F320,U+1F321-1F32C,U+1F32D-1F32F,U+1F330-1F335,U+1F336,U+1F337-1F37C,U+1F37D,U+1F37E-1F37F,U+1F380-1F393,U+1F394-1F39F,U+1F3A0-1F3C4,U+1F3C5,U+1F3C6-1F3CA,U+1F3CB-1F3CE,U+1F3CF-1F3D3,U+1F3D4-1F3DF,U+1F3E0-1F3F0,U+1F3F1-1F3F7,U+1F3F8-1F3FA,U+1F400-1F43E,U+1F43F,U+1F440,U+1F441,U+1F442-1F4F7,U+1F4F8,U+1F4F9-1F4FC,U+1F4FD-1F4FE,U+1F4FF,U+1F500-1F53D,U+1F546-1F54A,U+1F54B-1F54F,U+1F550-1F567,U+1F568-1F579,U+1F57A,U+1F57B-1F5A3,U+1F5A4,U+1F5A5-1F5FA,U+1F5FB-1F5FF,U+1F600,U+1F601-1F610,U+1F611,U+1F612-1F614,U+1F615,U+1F616,U+1F617,U+1F618,U+1F619,U+1F61A,U+1F61B,U+1F61C-1F61E,U+1F61F,U+1F620-1F625,U+1F626-1F627,U+1F628-1F62B,U+1F62C,U+1F62D,U+1F62E-1F62F,U+1F630-1F633,U+1F634,U+1F635-1F640,U+1F641-1F642,U+1F643-1F644,U+1F645-1F64F,U+1F680-1F6C5,U+1F6C6-1F6CF,U+1F6D0,U+1F6D1-1F6D2,U+1F6D3-1F6D4,U+1F6D5,U+1F6D6-1F6DF,U+1F6E0-1F6EC,U+1F6ED-1F6EF,U+1F6F0-1F6F3,U+1F6F4-1F6F6,U+1F6F7-1F6F8,U+1F6F9,U+1F6FA,U+1F6FB-1F6FF,U+1F774-1F77F,U+1F7D5-1F7D8,U+1F7D9-1F7DF,U+1F7E0-1F7EB,U+1F7EC-1F7FF,U+1F80C-1F80F,U+1F848-1F84F,U+1F85A-1F85F,U+1F888-1F88F,U+1F8AE-1F8FF,U+1F90C,U+1F90D-1F90F,U+1F910-1F918,U+1F919-1F91E,U+1F91F,U+1F920-1F927,U+1F928-1F92F,U+1F930,U+1F931-1F932,U+1F933-1F93A,U+1F93C-1F93E,U+1F93F,U+1F940-1F945,U+1F947-1F94B,U+1F94C,U+1F94D-1F94F,U+1F950-1F95E,U+1F95F-1F96B,U+1F96C-1F970,U+1F971,U+1F972,U+1F973-1F976,U+1F977-1F979,U+1F97A,U+1F97B,U+1F97C-1F97F,U+1F980-1F984,U+1F985-1F991,U+1F992-1F997,U+1F998-1F9A2,U+1F9A3-1F9A4,U+1F9A5-1F9AA,U+1F9AB-1F9AD,U+1F9AE-1F9AF,U+1F9B0-1F9B9,U+1F9BA-1F9BF,U+1F9C0,U+1F9C1-1F9C2,U+1F9C3-1F9CA,U+1F9CB-1F9CC,U+1F9CD-1F9CF,U+1F9D0-1F9E6,U+1F9E7-1F9FF,U+1FA00-1FA53,U+1FA54-1FA5F,U+1FA60-1FA6D,U+1FA6E-1FA6F,U+1FA70-1FA73,U+1FA74-1FA77,U+1FA78-1FA7A,U+1FA7B-1FA7F,U+1FA80-1FA82,U+1FA83-1FA8F,U+1FA90-1FA95,U+1FA96-1FFFD';
+
+    // And then we can use that range with our font when we load it.
+    const emojiOnlyFont = new FontFace(emojiFontName, 'url(fonts/NotoEmoji-Regular.ttf)', {
+      unicodeRange: emojiUnicodeRange,
+    });
+    emojiOnlyFont.load().then(() => {
+      document.fonts.add(emojiOnlyFont);
+    });
+    // We then set our fallback font as part of the font family we use in the canvas.
+    // This order matters, latter fonts will use the unicodeRange to override earlier fonts.
+    this.fontName = `Sans-serif, ${emojiFontName}`
+  }
+
+  // Some storage fields and utility properties
+  private fontName: string;
+  private configModalHandle: bootstrap.Modal;
+
+  get printers(): readonly WebLabel.LabelPrinterUsb[] {
+    return this.manager.devices;
+  }
+
+  // Track which printer is currently selected for operations
+  private _activePrinter = 0;
+  get activePrinter(): WebLabel.LabelPrinterUsb | undefined {
+    return this._activePrinter < 0 || this._activePrinter > this.printers.length
+      ? undefined
+      : this.printers[this._activePrinter];
+  }
+  set activePrinterIndex(printerIdx: number) {
+    this._activePrinter = printerIdx;
+    this.redrawTextCanvas();
+  }
+
+  /** Initialize the app */
+  public async init() {
+    this.redrawPrinterButtons();
+    this.redrawTextCanvas();
+  }
+
+  /** Display the configuration for a printer. */
+  public showConfigModal(printer: WebLabel.LabelPrinterUsb, printerIdx: number) {
+    if (printer === undefined || printerIdx < 0) {
+      return;
+    }
+    const config = printer.printerOptions;
+    // If the printer uses ZPL it will have a special config, show those!
+    const isZpl = config instanceof WebLabel.ZPL.ZplPrinterConfig;
+
+    const formElement = this.configModal.querySelector('form')!;
+    const form = formElement.elements as ConfigModalForm;
+
+    // Only show ZPL settings if the printer language is ZPL.
+    for (const e of formElement.getElementsByTagName('modal-setting-zpl')) {
+      if (isZpl) {
+        e.classList.remove('d-hide');
+      } else {
+        e.classList.add('d-hide');
+      }
+    }
+
+    // Translate the available speeds to options to be selected
+    form.modalSpeed.innerHTML = '';
+    const speedTable = printer.printerOptions.speedTable.table;
+    for (const [key] of speedTable) {
+      // Skip utility values, so long as there's more than the defaults.
+      // Mobile printers *only* support auto, for example.
+      if ((speedTable.size > 3)
+        && (key === WebLabel.PrintSpeed.ipsAuto
+          || key === WebLabel.PrintSpeed.ipsPrinterMax
+          || key === WebLabel.PrintSpeed.ipsPrinterMin
+        )) {
+        continue;
+      }
+      const opt = document.createElement('option');
+      opt.value = key.toString();
+      opt.innerHTML = WebLabel.PrintSpeed[key].substring(3).replaceAll('_', '.') + ' ips';
+      form.modalSpeed.appendChild(opt);
+    }
+    form.modalSpeed.value = config.speed.printSpeed.toString();
+
+    switch (config.mediaGapDetectMode) {
+      case WebLabel.MediaMediaGapDetectionMode.continuous:
+        form.modalMediaType.value = "continuous";
+        break;
+      default:
+      case WebLabel.MediaMediaGapDetectionMode.webSensing:
+        form.modalMediaType.value = "gap";
+        break;
+      case WebLabel.MediaMediaGapDetectionMode.markSensing:
+        form.modalMediaType.value = "mark";
+        break;
+    }
+
+    // The other elements are just text.
+    (formElement.querySelector('#modalPrinterIndexText') as HTMLInputElement)!.textContent = printerIdx.toString();
+    form.modalPrinterIndex.value    = config.serialNumber;
+    form.modalLabelWidth.value      = config.mediaWidthInches.toString();
+    form.modalLabelHeight.value     = config.mediaLengthInches.toString();
+    form.modalDarkness.value        = config.darknessPercent.toString();
+    form.modalLabelOffsetLeft.value = config.mediaPrintOriginOffsetDots.left.toString();
+    form.modalLabelOffsetTop.value  = config.mediaPrintOriginOffsetDots.top.toString();
+    form.modalBackfeedPercent.value = config.backfeedAfterTaken.toString();
+
+    if (isZpl) {
+      form.modalZplRibbonTHold.value = config.ribbonThreshold.toString();
+      form.modalZplRibbonLed.value   = config.ribbonGain.toString();
+      form.modalZplWebTHold.value    = config.webThreshold.toString();
+      form.modalZplWebMedia.value    = config.mediaThreshold.toString();
+      form.modalZplWebLed.value      = config.transGain.toString();
+      form.modalZplMarkTHold.value   = config.markThreshold.toString();
+      form.modalZplMarkMedia.value   = config.markMediaThreshold.toString();
+      form.modalZplMarkLed.value     = config.markGain.toString();
+
+      form.modalZplPowerUpAction.value   = config.actionPowerUp.toString();
+      form.modalZplHeadCloseAction.value = config.actionHeadClose.toString();
+    }
+
+    this.configModalHandle.show();
+  }
+
+  /** Erase and re-draw the list of printer buttons in the UI. */
+  private redrawPrinterButtons() {
+    this.btnContainer.innerHTML = '';
+    this.printers.forEach((printer, idx) => this.drawPrinterButton(printer, idx));
+  }
+
+  /** Highlight only the currently selected printer. */
+  private redrawPrinterButtonHighlights() {
+    this.printers.forEach((printer, idx) => {
+      const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
+      const element = document.getElementById(`printer_${idx}`)!;
+      element.style.background = `linear-gradient(to right, ${highlight}, ${highlight}, grey, grey)`;
+    });
+  }
+
+  /** Add a printer's button UI to the list of printers. */
+  private drawPrinterButton(printer: WebLabel.LabelPrinterUsb, idx: number) {
+    const highlight = this._activePrinter === idx ? "var(--bs-blue)" : "transparent";
+
+    // Generate a new label printer button for the given printer.
+    const element = document.createElement("div");
+    element.innerHTML = `
+    <li id="printer_${idx}" data-printer-idx="${idx}"
+        class="list-group-item d-flex flex-row justify-content-between sligh-items-start"
+        style="background: linear-gradient(to right, ${highlight}, ${highlight}, grey, grey);">
+        <div class="col-sm-8">
+            <div class="col-sm-12">
+                <span data-serial="${printer.printerOptions.serialNumber}">${printer.printerOptions.serialNumber}</span>
+            </div>
+            <div class="col-sm-12">
+                <span>${printer.printerOptions.mediaWidthInches}" x ${printer.printerOptions.mediaLengthInches}"</span>
+            </div>
+        </div>
+        <div class="d-flex flex-row justify-content-end">
+            <div class="btn-group" role="group" aria-label="Printer button group">
+                <button id="printto_${idx}" class="btn btn-success btn-lg" data-label-width="${printer.printerOptions.mediaWidthInches}" data-label-height="${printer.printerOptions.mediaLengthInches}" data-printer-idx="${idx}">🖨</button>
+                    <button class="btn btn-success dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                        <span class="visually-hidden">Settings</span>
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li><a id="printtest_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                            Print test page
+                        </a></li>
+                        <li><a id="feedlabel_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                            Feed blank label
+                        </a></li>
+                        <li><a id="configprinter_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                            Set label config
+                        </a></li>
+                        <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                            Print config on labels
+                        </a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </li>`;
+    // And slap it into the button container.
+    this.btnContainer.appendChild(element);
+
+    // Then wire up the button events so they work.
+    document.getElementById(`printto_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = this.addCanvasImageToLabelDoc(printer.getLabelDocument());
+        await printer.sendDocument(doc);
+      });
+    document.getElementById(`printer_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        if (this._activePrinter === printerIdx) {
+          // Don't refresh anything if we already have this printer selected..
+          return;
+        }
+        this.activePrinterIndex = printerIdx;
+        this.redrawPrinterButtonHighlights();
+        this.redrawTextCanvas();
+      });
+    document.getElementById(`printtest_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = WebLabel.ReadyToPrintDocuments.printTestLabelDocument(
+          printer.printerOptions.mediaWidthDots);
+        await printer.sendDocument(doc);
+      });
+    document.getElementById(`feedlabel_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = WebLabel.ReadyToPrintDocuments.feedLabelDocument;
+        await printer.sendDocument(doc);
+      });
+    document.getElementById(`printconfig_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = WebLabel.ReadyToPrintDocuments.printConfigDocument;
+        await printer.sendDocument(doc);
+      });
+    document.getElementById(`configprinter_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        this.showConfigModal(printer, printerIdx);
+      });
+  }
+
+  /** Redraw the text canvas size according to the printer. */
+  private redrawTextCanvas() {
+    const printer = this.activePrinter;
+    if (printer === undefined) {
+      this.labelForm.classList.add('d-none');
+      this.labelFormInstructions.classList.remove('d-none');
+      return;
+    } else {
+      this.labelForm.classList.remove('d-none');
+      this.labelFormInstructions.classList.add('d-none');
+    }
+
+    // Resize the canvas to match the label size.
+    const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+    // Add a small margin as printer alignment is not exact.
+    canvas.width = printer.printerOptions.mediaWidthDots - 2;
+    canvas.height = printer.printerOptions.mediaLengthDots - 2;
+
+    const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+    textarea.value = "Enter your label text here!";
+    this.renderTextForm();
+  }
+
+  /** Render the text form to the canvas */
+  private renderTextForm() {
+    const printer = this.activePrinter;
+    if (printer === undefined) {
+      return;
+    }
+
+    const textarea = this.labelForm.querySelector('#labelFormText') as HTMLTextAreaElement;
+    const fontsizer = this.labelForm.querySelector('#previewFontSize') as HTMLInputElement;
+    const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+    const pageContext = canvas.getContext('2d')!;
+    pageContext.clearRect(0, 0, canvas.width, canvas.height);
+
+    const fontSize = Math.trunc(parseFloat(fontsizer.value));
+
+    // We'd like the preview image to be as close as possible to what the printer will
+    // actually print. To do this we don't draw text to the page's canvas directly,
+    // instead we draw to an offscreen canvas, render that canvas to a monochrome bitmap,
+    // then render *that* back to the page's canvas. This is a more accurate picture of
+    // what the label will end up looking like.
+
+    // A more complex app could do this more gracefully!
+    const offscreenContext = new OffscreenCanvas(canvas.width, canvas.height).getContext('2d')!;
+    offscreenContext.font = `${fontSize}pt ${this.fontName}`;
+    offscreenContext.fillStyle = "#000000";
+
+    // fillText doesn't do newlines, do that manually
+    textarea.value.split('\n').forEach((l, i) => {
+      offscreenContext.fillText(l, 5, (i * fontSize + 2) + fontSize);
+    })
+
+    // Now into the monochrome bitmap.
+    const offscreenImg = offscreenContext.getImageData(0, 0, canvas.width, canvas.height);
+    const monoImg = WebLabel.BitmapGRF.fromCanvasImageData(offscreenImg, { trimWhitespace: false });
+    // And finally back onto the page.
+    pageContext.putImageData(monoImg.toImageData(), 0, 0);
+  }
+
+  /** Render the canvas to a document for printing */
+  private addCanvasImageToLabelDoc(builder: WebLabel.ILabelDocumentBuilder): WebLabel.IDocument {
+    const canvas = this.labelForm.querySelector("#labelCanvas") as HTMLCanvasElement;
+    const imgData = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
+
+    // One of the benefits of this library is being able to render images to a canvas element
+    // and sending that canvas directly to a label. This allows your webpage to generate complex
+    // images and fonts (like emoji!) that EPL/ZPL can't support.
+    return builder
+      .addImageFromImageData(imgData)
+      .addPrintCmd()
+      .finalize();
+  }
+
+  /** Send the contents of the config form as a config label to the printer. */
+  private async updatePrinterConfig(e: SubmitEvent) {
+    e.preventDefault();
+
+    // Figure out the right printer
+    const formElement = this.configModal.querySelector('form')!;
+    const form = formElement.elements as ConfigModalForm;
+    const printerIdx = parseInt((formElement.querySelector('#modalPrinterIndexText') as HTMLFormElement).innerText);
+    const printer = this.printers[printerIdx];
+    if (printer === undefined) {
+      return;
+    }
+    const isZpl = printer.printerOptions instanceof WebLabel.ZPL.ZplPrinterConfig;
+
+    form.modalSubmit.setAttribute("disabled", "");
+    form.modalCancel.setAttribute("disabled", "");
+
+    // Pull the values out of the form.
+    const darkness = parseInt(form.modalDarkness.value) as WebLabel.DarknessPercent;
+    const rawSpeed = parseInt(form.modalSpeed.value) as WebLabel.PrintSpeed;
+    const mediaWidthInches = parseFloat(form.modalLabelWidth.value);
+
+    const mediaLengthInches = parseFloat(form.modalLabelHeight.value);
+    const offsetLeft = parseInt(form.modalLabelOffsetLeft.value);
+    const offsetTop = parseInt(form.modalLabelOffsetTop.value);
+
+    const backfeedAfterTaken = form.modalBackfeedPercent.value as WebLabel.BackfeedAfterTaken;
+
+    // Construct the config document with the values from the form
+    const configDoc = printer.getConfigDocument();
+
+    // Form mode should be set first for other elements to work right.
+    switch (form.modalMediaType.value) {
+      case "continuous":
+        configDoc.setLabelMediaToContinuous(mediaLengthInches);
+        break;
+      case "mark":
+        // TODO: Make a form for black line sensing.
+        configDoc.setLabelMediaToMarkSense(mediaLengthInches, 16, 0);
+        break;
+      default:
+      case "gap":
+        // TODO: Make a form for label gap size.
+        configDoc.setLabelMediaToWebGapSense(mediaLengthInches, 16);
+        break;
+    }
+
+    configDoc
+      .setPrintDirection()
+      .setLabelPrintOriginOffsetCommand(offsetLeft, offsetTop)
+      .setPrintSpeed(rawSpeed)
+      .setDarknessConfig(darkness)
+      .setLabelDimensions(mediaWidthInches)
+      .setBackfeedAfterTakenMode(backfeedAfterTaken);
+
+    if (isZpl) {
+      // Send the ZPL-specific settings too!
+      let actionPowerUp: WebLabel.ZPL.PowerUpAction;
+      switch (form.modalZplPowerUpAction.value) {
+        case "none":
+          actionPowerUp = "none";
+          break;
+        default:
+        case "feedBlank":
+          actionPowerUp = "feedBlank";
+          break;
+        case "calibrateWebSensor":
+          actionPowerUp = "calibrateWebLength";
+          break;
+      }
+
+      let actionHeadClose: WebLabel.ZPL.PowerUpAction;
+      switch (form.modalZplHeadCloseAction.value) {
+        case "none":
+          actionHeadClose = "none";
+          break;
+        default:
+        case "feedBlank":
+          actionHeadClose = "feedBlank";
+          break;
+        case "calibrateWebSensor":
+          actionHeadClose = "calibrateWebLength";
+          break;
+      }
+
+      configDoc
+        .andThen(new WebLabel.ZPL.CmdSetPowerUpAndHeadCloseAction(
+          actionPowerUp, actionHeadClose
+        ))
+        .andThen(new WebLabel.ZPL.CmdSetSensorCalibration({
+          markGain          : Number(form.modalZplMarkLed.value),
+          markMediaThreshold: Number(form.modalZplMarkMedia.value),
+          markThreshold     : Number(form.modalZplMarkTHold.value),
+          transGain         : Number(form.modalZplWebLed.value),
+          mediaThreshold    : Number(form.modalZplWebMedia.value),
+          ribbonGain        : Number(form.modalZplRibbonLed.value),
+          ribbonThreshold   : Number(form.modalZplRibbonTHold.value),
+          webThreshold      : Number(form.modalZplWebTHold.value),
+        }));
+    }
+
+    let doc: WebLabel.IDocument;
+    if (form.modalWithAutosense.checked) {
+      doc = configDoc.autosenseLabelLength();
+    } else if (isZpl && form.modalZplWithSensorGraph.checked) {
+      doc = configDoc.andThen(new WebLabel.ZPL.CmdGraphSensorCalibration()).finalize();
+    } else {
+      doc = configDoc.finalize();
+    }
+
+    // And send the whole shebang to the printer!
+    await printer.sendDocument(doc);
+
+    form.modalWithAutosense.checked = false;
+    form.modalZplWithSensorGraph.checked = false;
+    form.modalSubmit.removeAttribute("disabled");
+    form.modalCancel.removeAttribute("disabled");
+    this.activePrinterIndex = printerIdx;
+    this.configModalHandle.hide();
+  }
+}
+
+// With the app class defined we can run it.
+// First up collect the basic structure of the app
+const btnContainer          = document.getElementById("printerlist")!;
+const labelForm             = document.getElementById("labelForm")!;
+const labelFormInstructions = document.getElementById("labelFormInstructions")!;
+const configModal           = document.getElementById("printerOptionModal")!;
+
+// And feed that into the app class to manage the elements
+const app = new BasicLabelDesignerApp(printerMgr, btnContainer, labelForm, labelFormInstructions, configModal);
+// and let it take over the UI.
+await app.init();
+
+// Make the TypeScript type system happy by adding a property to the Window object.
+declare global {
+  interface Window { label_app: BasicLabelDesignerApp }
+}
+// Now we can access our printer in the dev console if we want to mess with it!
+window.label_app = app;
+
+// Now we'll fire the reconnect since our UI is wired up.
+try {
+  await printerMgr.forceReconnect();
+} catch (e) {
+  if (e instanceof WebDevices.DriverAccessDeniedError) {
+    // This happens when the operating system didn't let Chrome connect.
+    // Usually either another tab is open talking to the device, or the driver
+    // is already loaded by another application.
+    showAlert(
+      'danger',
+      'alert-printer-comm-error',
+      `Operating system refused device access`,
+      `<p>This usually happens for one of these reasons:
+      <ul>
+      <li>Another browser tab is already connected.
+      <li>Another application loaded a driver to talk to the device.
+      <li>You're on Windows and need to replace the driver.
+      </ul>
+      Fix the issue and re-connect to the device.</p>`
+    );
+  }
+}
+
+// We're done here. Bring in the dancing lobsters.


### PR DESCRIPTION
Closes #51

I can't believe this pile of shenanigans actually works as well as it does hahaha.

I forked a [simple FabricJS canvas editor](https://github.com/Cellivar/fabricjs-label-editor) project and rewrote it to work with my live typescript transpiler system. The editor demo page here lets you create labels with custom textboxes, uploaded images with transparency, and honestly is slowly morphing into a lightweight browser editor for impromptu label printing.

My refusal to use things like Webpack is more fun than hampering me at this point.

There's a few bugs to fix both with the canvas editor and the way it's loaded here, but this is good enough for now.