### PR TITLE
Remove double-offset from prints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webzlp",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A small library using WebUSB to print labels on label printers.",
   "type": "module",
   "repository": {

--- a/src/Commands/TranspileCommand.ts
+++ b/src/Commands/TranspileCommand.ts
@@ -44,8 +44,8 @@ export function getNewTranspileState(config: PrinterConfig): TranspiledDocumentS
       left: -1,
       top: -1
     },
-    horizontalOffset: config.mediaPrintOriginOffsetDots.left,
-    verticalOffset: config.mediaPrintOriginOffsetDots.top,
+    horizontalOffset: 0,
+    verticalOffset: 0,
     lineSpacingDots: 1,
     printWidth: config.mediaWidthDots,
     margin: {


### PR DESCRIPTION
Somewhere in the V2 rewrite I started setting the initial label offsets to the printer's configured offsets, which was causing double offsets for images. I'll need to expand my printed test pattern suite apparently.