### PR TITLE
Improve ZPL mark sense

### DIFF
--- a/demo/advanced.html
+++ b/demo/advanced.html
@@ -446,18 +446,21 @@
                                 <span class="visually-hidden">Settings</span>
                             </button>
                             <ul class="dropdown-menu">
-                                <li><a id="printtest_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                                    Print test page
-                                </a></li>
-                                <li><a id="feedlabel_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                                    Feed blank label
-                                </a></li>
-                                <li><a id="configprinter_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                                    Set label config
-                                </a></li>
-                                <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                                    Print config on labels
-                                </a></li>
+                              <li><a id="printerStatus_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                Query printer status
+                              </a></li>
+                              <li><a id="printtest_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                Print test page
+                              </a></li>
+                              <li><a id="feedlabel_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                Feed blank label
+                              </a></li>
+                              <li><a id="configprinter_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                Set label config
+                              </a></li>
+                              <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                                Print config on labels
+                              </a></li>
                             </ul>
                         </div>
                     </div>
@@ -486,6 +489,14 @@
                 this.activePrinterIndex = printerIdx;
                 this.redrawPrinterButtonHighlights();
                 this.redrawTextCanvas();
+              });
+            document.getElementById(`printerStatus_${idx}`)!
+              .addEventListener('click', async (e) => {
+                e.preventDefault();
+                const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+                const printer = this.printers[printerIdx];
+                const doc = printer.getConfigDocument().queryStatus().finalize();
+                await printer.sendDocument(doc);
               });
             document.getElementById(`printtest_${idx}`)!
               .addEventListener('click', async (e) => {
@@ -709,12 +720,19 @@
             // And send the whole shebang to the printer!
             await printer.sendDocument(doc);
 
+            // Then get the updated printer info..
+            await printer.sendDocument(WebLabel.ReadyToPrintDocuments.configDocument);
+
+            // Hide the config modal
             form.modalWithAutosense.checked = false;
             form.modalZplWithSensorGraph.checked = false;
             form.modalSubmit.removeAttribute("disabled");
             form.modalCancel.removeAttribute("disabled");
             this.activePrinterIndex = printerIdx;
             this.configModalHandle.hide();
+
+            // Redraw the buttons with the updated config
+            this.redrawPrinterButtons();
           }
         }
 

--- a/demo/editor.html
+++ b/demo/editor.html
@@ -412,18 +412,21 @@
                               <span class="visually-hidden">Settings</span>
                           </button>
                           <ul class="dropdown-menu">
-                              <li><a id="printtest_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                                  Print test page
-                              </a></li>
-                              <li><a id="feedlabel_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                                  Feed blank label
-                              </a></li>
-                              <li><a id="configprinter_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                                  Set label config
-                              </a></li>
-                              <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                                  Print config on labels
-                              </a></li>
+                            <li><a id="printerStatus_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                              Query printer status
+                            </a></li>
+                            <li><a id="printtest_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                              Print test page
+                            </a></li>
+                            <li><a id="feedlabel_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                              Feed blank label
+                            </a></li>
+                            <li><a id="configprinter_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                              Set label config
+                            </a></li>
+                            <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                              Print config on labels
+                            </a></li>
                           </ul>
                       </div>
                   </div>
@@ -452,6 +455,14 @@
               this.activePrinterIndex = printerIdx;
               this.redrawPrinterButtonHighlights();
               this.redrawLabelCanvas();
+            });
+          document.getElementById(`printerStatus_${idx}`)!
+            .addEventListener('click', async (e) => {
+              e.preventDefault();
+              const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+              const printer = this.printers[printerIdx];
+              const doc = printer.getConfigDocument().queryStatus().finalize();
+              await printer.sendDocument(doc);
             });
           document.getElementById(`printtest_${idx}`)!
             .addEventListener('click', async (e) => {
@@ -639,12 +650,19 @@
           // And send the whole shebang to the printer!
           await printer.sendDocument(doc);
 
+          // Then get the updated printer info..
+          await printer.sendDocument(WebLabel.ReadyToPrintDocuments.configDocument);
+
+          // Hide the config modal
           form.modalWithAutosense.checked = false;
           form.modalZplWithSensorGraph.checked = false;
           form.modalSubmit.removeAttribute("disabled");
           form.modalCancel.removeAttribute("disabled");
           this.activePrinterIndex = printerIdx;
           this.configModalHandle.hide();
+
+          // Redraw the buttons with the updated config
+          this.redrawPrinterButtons();
         }
       }
 

--- a/demo/test_advanced.ts
+++ b/demo/test_advanced.ts
@@ -377,18 +377,21 @@ class BasicLabelDesignerApp {
                         <span class="visually-hidden">Settings</span>
                     </button>
                     <ul class="dropdown-menu">
-                        <li><a id="printtest_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                            Print test page
-                        </a></li>
-                        <li><a id="feedlabel_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                            Feed blank label
-                        </a></li>
-                        <li><a id="configprinter_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                            Set label config
-                        </a></li>
-                        <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                            Print config on labels
-                        </a></li>
+                      <li><a id="printerStatus_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                        Query printer status
+                      </a></li>
+                      <li><a id="printtest_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                        Print test page
+                      </a></li>
+                      <li><a id="feedlabel_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                        Feed blank label
+                      </a></li>
+                      <li><a id="configprinter_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                        Set label config
+                      </a></li>
+                      <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                        Print config on labels
+                      </a></li>
                     </ul>
                 </div>
             </div>
@@ -417,6 +420,14 @@ class BasicLabelDesignerApp {
         this.activePrinterIndex = printerIdx;
         this.redrawPrinterButtonHighlights();
         this.redrawTextCanvas();
+      });
+    document.getElementById(`printerStatus_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = printer.getConfigDocument().queryStatus().finalize();
+        await printer.sendDocument(doc);
       });
     document.getElementById(`printtest_${idx}`)!
       .addEventListener('click', async (e) => {
@@ -640,12 +651,19 @@ class BasicLabelDesignerApp {
     // And send the whole shebang to the printer!
     await printer.sendDocument(doc);
 
+    // Then get the updated printer info..
+    await printer.sendDocument(WebLabel.ReadyToPrintDocuments.configDocument);
+
+    // Hide the config modal
     form.modalWithAutosense.checked = false;
     form.modalZplWithSensorGraph.checked = false;
     form.modalSubmit.removeAttribute("disabled");
     form.modalCancel.removeAttribute("disabled");
     this.activePrinterIndex = printerIdx;
     this.configModalHandle.hide();
+
+    // Redraw the buttons with the updated config
+    this.redrawPrinterButtons();
   }
 }
 

--- a/demo/test_editor.ts
+++ b/demo/test_editor.ts
@@ -348,18 +348,21 @@ class BasicLabelDesignerApp {
                         <span class="visually-hidden">Settings</span>
                     </button>
                     <ul class="dropdown-menu">
-                        <li><a id="printtest_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                            Print test page
-                        </a></li>
-                        <li><a id="feedlabel_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                            Feed blank label
-                        </a></li>
-                        <li><a id="configprinter_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                            Set label config
-                        </a></li>
-                        <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
-                            Print config on labels
-                        </a></li>
+                      <li><a id="printerStatus_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                        Query printer status
+                      </a></li>
+                      <li><a id="printtest_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                        Print test page
+                      </a></li>
+                      <li><a id="feedlabel_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                        Feed blank label
+                      </a></li>
+                      <li><a id="configprinter_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                        Set label config
+                      </a></li>
+                      <li><a id="printconfig_${idx}" data-printer-idx="${idx}" class="dropdown-item" href="#">
+                        Print config on labels
+                      </a></li>
                     </ul>
                 </div>
             </div>
@@ -388,6 +391,14 @@ class BasicLabelDesignerApp {
         this.activePrinterIndex = printerIdx;
         this.redrawPrinterButtonHighlights();
         this.redrawLabelCanvas();
+      });
+    document.getElementById(`printerStatus_${idx}`)!
+      .addEventListener('click', async (e) => {
+        e.preventDefault();
+        const printerIdx = (e.currentTarget as HTMLAnchorElement).dataset.printerIdx as unknown as number;
+        const printer = this.printers[printerIdx];
+        const doc = printer.getConfigDocument().queryStatus().finalize();
+        await printer.sendDocument(doc);
       });
     document.getElementById(`printtest_${idx}`)!
       .addEventListener('click', async (e) => {
@@ -575,12 +586,19 @@ class BasicLabelDesignerApp {
     // And send the whole shebang to the printer!
     await printer.sendDocument(doc);
 
+    // Then get the updated printer info..
+    await printer.sendDocument(WebLabel.ReadyToPrintDocuments.configDocument);
+
+    // Hide the config modal
     form.modalWithAutosense.checked = false;
     form.modalZplWithSensorGraph.checked = false;
     form.modalSubmit.removeAttribute("disabled");
     form.modalCancel.removeAttribute("disabled");
     this.activePrinterIndex = printerIdx;
     this.configModalHandle.hide();
+
+    // Redraw the buttons with the updated config
+    this.redrawPrinterButtons();
   }
 }
 

--- a/src/Documents/ConfigDocument.ts
+++ b/src/Documents/ConfigDocument.ts
@@ -26,10 +26,12 @@ export class ConfigDocumentBuilder
   // to commit the changes to stored memory. EPL does this automatically, ZPL does not
   // so to bring them closer to parity this is automatically implied.
   private _doSave = false;
-  // TODO: Consider whether this should move to a ZPL extended command.
   override finalize() {
     if (this._doSave) {
-      this.andThen(new Cmds.SaveCurrentConfigurationCommand());
+      this.andThen(new Cmds.SaveCurrentConfigurationCommand())
+        .andThen(new Cmds.EndLabel())
+        .andThen(new Cmds.StartLabel())
+        .andThen(new Cmds.QueryConfigurationCommand());
     }
     return super.finalize();
   }

--- a/src/Languages/Zpl/test_files/LP2844_Z_CONF.ts.snap
+++ b/src/Languages/Zpl/test_files/LP2844_Z_CONF.ts.snap
@@ -6,7 +6,7 @@
       "messageType": "SettingUpdateMessage",
       "printerHardware": {},
       "printerMedia": {
-        "mediaGapDetectMode": 1,
+        "mediaGapDetectMode": 2,
         "mediaLengthDots": 235,
       },
       "printerSettings": {},


### PR DESCRIPTION
Older ZPL printers have a more awkward way to detect the print mode apparently. 

This also adds a "query printer status" button to the advanced and editor demos so you can see why your printer is blinking at you.